### PR TITLE
Ignoring binaries in cmd/ and hack/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,14 @@ MNIST/
 NYTimes/
 SIFT/
 *.hdf5
+
+# exclude binaries
+cmd/**/*
+!cmd/**/*.*
+!cmd/**/*/
+hack/**/*
+!hack/**/*.*
+!hack/**/*/
+
+!Makefile
+!LICENSE


### PR DESCRIPTION
I added .gitignore settings for ignoring binary files in `cmd/` and `hack/`.