### PR TITLE
add sequential operation benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,6 +395,8 @@ $(BENCH_DATASETS): $(BENCH_DATASET_MD5S)
 	    md5sum -c $(patsubst $(BENCH_DATASET_HDF5_DIR)/%.hdf5,$(BENCH_DATASET_MD5_DIR_NAME)/%.md5,$@) || \
 	    (rm -f $(patsubst $(BENCH_DATASET_HDF5_DIR)/%.hdf5,$(BENCH_DATASET_HDF5_DIR_NAME)/%.hdf5,$@) && exit 1))
 
+bench-agent: bench-agent-stream bench-agent-sequential
+
 bench-agent-stream: \
 	ngt \
 	$(BENCH_DATASET_HDF5_DIR)/fashion-mnist-784-euclidean.hdf5 \
@@ -406,6 +408,32 @@ bench-agent-stream: \
 	go test -count=1 \
 		-timeout=1h \
 		-bench=gRPCStream \
+		-benchmem \
+		-o pprof/agent/ngt/agent.bin \
+		-cpuprofile pprof/agent/ngt/cpu-stream.out \
+		-memprofile pprof/agent/ngt/mem-stream.out \
+		./hack/e2e/benchmark/agent/ngt/ngt_bench_test.go
+	go tool pprof --svg \
+		pprof/agent/ngt/agent.bin \
+		pprof/agent/ngt/cpu-stream.out \
+		> pprof/agent/ngt/cpu-stream.svg
+	go tool pprof --svg \
+		pprof/agent/ngt/agent.bin \
+		pprof/agent/ngt/mem-stream.out \
+		> pprof/agent/ngt/mem-stream.svg
+	rm -rf /tmp/ngt/
+
+bench-agent-sequential: \
+	ngt \
+	$(BENCH_DATASET_HDF5_DIR)/fashion-mnist-784-euclidean.hdf5 \
+	$(BENCH_DATASET_HDF5_DIR)/mnist-784-euclidean.hdf5
+	rm -rf /tmp/ngt/
+	rm -rf pprof/agent/ngt
+	mkdir -p /tmp/ngt
+	mkdir -p pprof/agent/ngt
+	go test -count=1 \
+		-timeout=1h \
+		-bench=gRPCSequential \
 		-benchmem \
 		-o pprof/agent/ngt/agent.bin \
 		-cpuprofile pprof/agent/ngt/cpu-stream.out \


### PR DESCRIPTION
implement e2e sequential operation benchmark test
```
% make bench-agent       
rm -rf /tmp/ngt/
rm -rf pprof/agent/ngt
mkdir -p /tmp/ngt
mkdir -p pprof/agent/ngt
go test -count=1 \
                -timeout=1h \
                -bench=gRPCStream \
                -benchmem \
                -o pprof/agent/ngt/agent.bin \
                -cpuprofile pprof/agent/ngt/cpu-stream.out \
                -memprofile pprof/agent/ngt/mem-stream.out \
                ./hack/e2e/benchmark/agent/ngt/ngt_bench_test.go
2019-10-23 14:39:51     [INFO]: server agent-grpc executing preStartFunc
2019-10-23 14:39:51     [INFO]: gRPC server agent-grpc starting on 127.0.0.1:8082
2019-10-23 14:39:51     [INFO]: REST server agent-rest starting on 127.0.0.1:8081
goos: darwin
goarch: amd64
BenchmarkAgentNGTgRPCStream/fashion-mnist-784-euclidean/StreamInsert_60000_objects-4                   1        9618903559 ns/op        1663295448 B/op  3329242 allocs/op
BenchmarkAgentNGTgRPCStream/fashion-mnist-784-euclidean/CreateIndex-4                                  1        17834999516 ns/op        1952864 B/op      60062 allocs/op
BenchmarkAgentNGTgRPCStream/fashion-mnist-784-euclidean/StreamSearch_10000_objects-4                   1        3143898738 ns/op        316037448 B/op   1119419 allocs/op
BenchmarkAgentNGTgRPCStream/fashion-mnist-784-euclidean/StreamRemove_30000_objects-4                   1        28754476422 ns/op       41189280 B/op    1422019 allocs/op
2019-10-23 14:40:56     [WARN]: gRPC server agent-grpc shutdown process starting
2019-10-23 14:40:56     [INFO]: server agent-grpc executing preStopFunc
2019-10-23 14:40:56     [WARN]: gRPC server agent-grpc is now shutting down
2019-10-23 14:40:56     [INFO]: gRPC server agent-grpc stopped
2019-10-23 14:40:56     [WARN]: REST server agent-rest shutdown process starting
2019-10-23 14:40:56     [WARN]: REST server agent-rest is now shutting down
2019-10-23 14:40:56     [INFO]: REST server agent-rest stopped
2019-10-23 14:40:56     [WARN]: daemon stopped
2019-10-23 14:40:56     [INFO]: server agent-grpc executing preStartFunc
2019-10-23 14:40:56     [INFO]: gRPC server agent-grpc starting on 127.0.0.1:8082
2019-10-23 14:40:56     [INFO]: REST server agent-rest starting on 127.0.0.1:8081
BenchmarkAgentNGTgRPCStream/mnist-784-euclidean/StreamInsert_60000_objects-4                           1        9539109563 ns/op        1663140456 B/op  3328997 allocs/op
BenchmarkAgentNGTgRPCStream/mnist-784-euclidean/CreateIndex-4                                          1        16472280600 ns/op        1826096 B/op      56937 allocs/op
BenchmarkAgentNGTgRPCStream/mnist-784-euclidean/StreamSearch_10000_objects-4                           1        3362887115 ns/op        316070912 B/op   1119747 allocs/op
BenchmarkAgentNGTgRPCStream/mnist-784-euclidean/StreamRemove_30000_objects-4                           1        20851473430 ns/op       40245272 B/op    1393611 allocs/op
PASS
2019-10-23 14:41:52     [WARN]: gRPC server agent-grpc shutdown process starting
2019-10-23 14:41:52     [INFO]: server agent-grpc executing preStopFunc
2019-10-23 14:41:52     [WARN]: gRPC server agent-grpc is now shutting down
2019-10-23 14:41:52     [INFO]: gRPC server agent-grpc stopped
2019-10-23 14:41:52     [WARN]: REST server agent-rest shutdown process starting
2019-10-23 14:41:52     [WARN]: REST server agent-rest is now shutting down
2019-10-23 14:41:52     [INFO]: REST server agent-rest stopped
2019-10-23 14:41:52     [WARN]: daemon stopped
ok      command-line-arguments  122.280s
go tool pprof --svg \
                pprof/agent/ngt/agent.bin \
                pprof/agent/ngt/cpu-stream.out \
                > pprof/agent/ngt/cpu-stream.svg
go tool pprof --svg \
                pprof/agent/ngt/agent.bin \
                pprof/agent/ngt/mem-stream.out \
                > pprof/agent/ngt/mem-stream.svg
rm -rf /tmp/ngt/
rm -rf /tmp/ngt/
rm -rf pprof/agent/ngt
mkdir -p /tmp/ngt
mkdir -p pprof/agent/ngt
go test -count=1 \
                -timeout=1h \
                -bench=gRPCSequential \
                -benchmem \
                -o pprof/agent/ngt/agent.bin \
                -cpuprofile pprof/agent/ngt/cpu-stream.out \
                -memprofile pprof/agent/ngt/mem-stream.out \
                ./hack/e2e/benchmark/agent/ngt/ngt_bench_test.go
2019-10-23 14:41:59     [INFO]: server agent-grpc executing preStartFunc
2019-10-23 14:41:59     [INFO]: gRPC server agent-grpc starting on 127.0.0.1:8082
2019-10-23 14:41:59     [INFO]: REST server agent-rest starting on 127.0.0.1:8081
goos: darwin
goarch: amd64
BenchmarkAgentNGTgRPCSequential/fashion-mnist-784-euclidean/Insert_60000_objects-4                     1        16635627999 ns/op       2091799536 B/op 10499971 allocs/op
BenchmarkAgentNGTgRPCSequential/fashion-mnist-784-euclidean/CreateIndex-4                              1        17052839153 ns/op        1884600 B/op      57828 allocs/op
BenchmarkAgentNGTgRPCSequential/fashion-mnist-784-euclidean/StreamSearch_10000_objects-4               1        3228531768 ns/op        387363544 B/op   2311096 allocs/op
BenchmarkAgentNGTgRPCSequential/fashion-mnist-784-euclidean/StreamRemove_30000_objects-4               1        28656535338 ns/op       256126616 B/op   5047274 allocs/op
2019-10-23 14:46:40     [WARN]: gRPC server agent-grpc shutdown process starting
2019-10-23 14:46:40     [INFO]: server agent-grpc executing preStopFunc
2019-10-23 14:46:40     [WARN]: gRPC server agent-grpc is now shutting down
2019-10-23 14:46:40     [INFO]: gRPC server agent-grpc stopped
2019-10-23 14:46:40     [WARN]: REST server agent-rest shutdown process starting
2019-10-23 14:46:40     [WARN]: REST server agent-rest is now shutting down
2019-10-23 14:46:40     [INFO]: REST server agent-rest stopped
2019-10-23 14:46:40     [WARN]: daemon stopped
2019-10-23 14:46:40     [INFO]: server agent-grpc executing preStartFunc
2019-10-23 14:46:40     [INFO]: gRPC server agent-grpc starting on 127.0.0.1:8082
2019-10-23 14:46:40     [INFO]: REST server agent-rest starting on 127.0.0.1:8081
BenchmarkAgentNGTgRPCSequential/mnist-784-euclidean/Insert_60000_objects-4                             1        11671792446 ns/op       2091355384 B/op 10487534 allocs/op
BenchmarkAgentNGTgRPCSequential/mnist-784-euclidean/CreateIndex-4                                      1        16092159798 ns/op        1705672 B/op      53158 allocs/op
BenchmarkAgentNGTgRPCSequential/mnist-784-euclidean/StreamSearch_10000_objects-4                       1        3675417455 ns/op        387402408 B/op   2312291 allocs/op
BenchmarkAgentNGTgRPCSequential/mnist-784-euclidean/StreamRemove_30000_objects-4                       1        25854088470 ns/op       255829632 B/op   5038228 allocs/op
PASS
2019-10-23 14:47:43     [WARN]: gRPC server agent-grpc shutdown process starting
2019-10-23 14:47:43     [INFO]: server agent-grpc executing preStopFunc
2019-10-23 14:47:43     [WARN]: gRPC server agent-grpc is now shutting down
2019-10-23 14:47:43     [INFO]: gRPC server agent-grpc stopped
2019-10-23 14:47:43     [WARN]: REST server agent-rest shutdown process starting
2019-10-23 14:47:43     [WARN]: REST server agent-rest is now shutting down
2019-10-23 14:47:43     [INFO]: REST server agent-rest stopped
2019-10-23 14:47:43     [WARN]: daemon stopped
ok      command-line-arguments  134.742s
go tool pprof --svg \
                pprof/agent/ngt/agent.bin \
                pprof/agent/ngt/cpu-stream.out \
                > pprof/agent/ngt/cpu-stream.svg
go tool pprof --svg \
                pprof/agent/ngt/agent.bin \
                pprof/agent/ngt/mem-stream.out \
                > pprof/agent/ngt/mem-stream.svg
rm -rf /tmp/ngt/
```