### PR TITLE
:bug: Fix response structure of GetMetas(Inverse) #105

### DIFF
--- a/internal/db/nosql/cassandra/cassandra.go
+++ b/internal/db/nosql/cassandra/cassandra.go
@@ -305,6 +305,7 @@ func (c *client) MultiGetValue(keys ...string) ([]string, error) {
 			} else {
 				errs = errors.ErrCassandraNotFound(key)
 			}
+			values = append(values, "")
 			continue
 		}
 		values = append(values, kvs[key])
@@ -340,6 +341,7 @@ func (c *client) MultiGetKey(values ...string) ([]string, error) {
 			} else {
 				errs = errors.ErrCassandraNotFound(value)
 			}
+			keys = append(keys, "")
 			continue
 		}
 		keys = append(keys, kvs[value])

--- a/pkg/meta/cassandra/handler/grpc/handler.go
+++ b/pkg/meta/cassandra/handler/grpc/handler.go
@@ -63,18 +63,17 @@ func (s *server) GetMeta(ctx context.Context, key *payload.Meta_Key) (*payload.M
 	}, nil
 }
 
-func (s *server) GetMetas(ctx context.Context, keys *payload.Meta_Keys) (*payload.Meta_Vals, error) {
-	vals, err := s.cassandra.GetMultiple(keys.GetKeys()...)
+func (s *server) GetMetas(ctx context.Context, keys *payload.Meta_Keys) (mv *payload.Meta_Vals, err error) {
+	mv = new(payload.Meta_Vals)
+	mv.Vals, err = s.cassandra.GetMultiple(keys.GetKeys()...)
 	if err != nil {
 		detail := errDetail{method: "GetMetas", keys: keys.GetKeys()}
 		if errors.IsErrCassandraNotFound(errors.UnWrapAll(err)) {
-			return nil, status.WrapWithNotFound("Cassandra entry not found", &detail, err)
+			return mv, status.WrapWithNotFound("Cassandra entry not found", &detail, err)
 		}
-		return nil, status.WrapWithUnknown("Unknown error occurred", &detail, err)
+		return mv, status.WrapWithUnknown("Unknown error occurred", &detail, err)
 	}
-	return &payload.Meta_Vals{
-		Vals: vals,
-	}, nil
+	return mv, nil
 }
 
 func (s *server) GetMetaInverse(ctx context.Context, val *payload.Meta_Val) (*payload.Meta_Key, error) {
@@ -91,18 +90,17 @@ func (s *server) GetMetaInverse(ctx context.Context, val *payload.Meta_Val) (*pa
 	}, nil
 }
 
-func (s *server) GetMetasInverse(ctx context.Context, vals *payload.Meta_Vals) (*payload.Meta_Keys, error) {
-	keys, err := s.cassandra.GetInverseMultiple(vals.GetVals()...)
+func (s *server) GetMetasInverse(ctx context.Context, vals *payload.Meta_Vals) (mk *payload.Meta_Keys, err error) {
+	mk = new(payload.Meta_Keys)
+	mk.Keys, err = s.cassandra.GetInverseMultiple(vals.GetVals()...)
 	if err != nil {
 		detail := errDetail{method: "GetMetasInverse", vals: vals.GetVals()}
 		if errors.IsErrCassandraNotFound(errors.UnWrapAll(err)) {
-			return nil, status.WrapWithNotFound("Cassandra entry not found", &detail, err)
+			return mk, status.WrapWithNotFound("Cassandra entry not found", &detail, err)
 		}
-		return nil, status.WrapWithUnknown("Unknown error occurred", &detail, err)
+		return mk, status.WrapWithUnknown("Unknown error occurred", &detail, err)
 	}
-	return &payload.Meta_Keys{
-		Keys: keys,
-	}, nil
+	return mk, nil
 }
 
 func (s *server) SetMeta(ctx context.Context, kv *payload.Meta_KeyVal) (_ *payload.Empty, err error) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

I modified the behavior of GetMetas and GetMetasInverse methods.
They returns found values whenever passed argument contains invalid keys (and empty string values are returned).

<!--- Describe your changes in detail -->

### Related Issue:

This is a fix of #105 issue.

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Golang Version: 1.13.5
- Docker Version: 19.03.5
- Kubernetes Version: 1.16.3
- NGT Version: 1.8.4

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensure all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
