### PR TITLE
use printf instead of echo

### DIFF
--- a/Makefile.d/functions.mk
+++ b/Makefile.d/functions.mk
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-red    = /bin/echo -e "\x1b[31m\#\# $1\x1b[0m"
-green  = /bin/echo -e "\x1b[32m\#\# $1\x1b[0m"
-yellow = /bin/echo -e "\x1b[33m\#\# $1\x1b[0m"
-blue   = /bin/echo -e "\x1b[34m\#\# $1\x1b[0m"
-pink   = /bin/echo -e "\x1b[35m\#\# $1\x1b[0m"
-cyan   = /bin/echo -e "\x1b[36m\#\# $1\x1b[0m"
+red    = printf "\x1b[31m\#\# %s\x1b[0m\n" $1
+green  = printf "\x1b[32m\#\# %s\x1b[0m\n" $1
+yellow = printf "\x1b[33m\#\# %s\x1b[0m\n" $1
+blue   = printf "\x1b[34m\#\# %s\x1b[0m\n" $1
+pink   = printf "\x1b[35m\#\# %s\x1b[0m\n" $1
+cyan   = printf "\x1b[36m\#\# %s\x1b[0m\n" $1
 
 define go-get
 	GO111MODULE=on go get -u $1


### PR DESCRIPTION
macOS echo cannot use color format.
printf can use colored, so I changed printf from echo.

### Description:

replace echo with printf and fix format.

### Related Issue:

nothing

### How Has This Been Tested?:

![image](https://user-images.githubusercontent.com/413873/71878087-2b400180-316e-11ea-9ad9-90eb555e1e60.png)

### Environment:

- Golang Version: 1.13.5
- Docker Version: 19.03.5
- Kubernetes Version: 1.17.0
- NGT Version: 1.8.4

### Types of changes:

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [x] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensure all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
