### PR TITLE
addd test case for `internal/versions`

### DIFF
--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,73 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/vdaas/vald/internal/errors"
+)
+
+func TestCheck(t *testing.T) {
+	type args struct {
+		cur string
+		max string
+		min string
+	}
+
+	type test struct {
+		name string
+		args args
+		want error
+	}
+
+	tests := []test{
+		{
+			name: "return nil",
+			args: args{
+				cur: "1.0.5",
+				max: "1.0.10",
+				min: "1.0.0",
+			},
+			want: nil,
+		},
+
+		{
+			name: "return error when cur format is invalid",
+			args: args{
+				cur: "vald",
+				max: "1.0.10",
+				min: "1.0.0",
+			},
+			want: errors.New("Malformed version: vald"),
+		},
+
+		{
+			name: "return error when min format is invalid",
+			args: args{
+				cur: "1.5.10",
+				max: "vald",
+				min: "1.0.0",
+			},
+			want: errors.New("Malformed constraint:  <= vald"),
+		},
+
+		{
+			name: "return error when min format is invalid",
+			args: args{
+				cur: "1.0.10",
+				max: "1.0.5",
+				min: "1.0.0",
+			},
+			want: errors.ErrInvalidConfigVersion("1.0.10", ">= 1.0.0, <= 1.0.5"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Check(tt.args.cur, tt.args.max, tt.args.min)
+			if !errors.Is(tt.want, err) {
+				t.Error(err)
+			}
+		})
+	}
+
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -69,5 +69,4 @@ func TestCheck(t *testing.T) {
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

I added test case for `internal/versions`.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Golang Version: 1.13.5
- Docker Version: 19.03.5
- Kubernetes Version: 1.16.3
- NGT Version: 1.8.4

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensure all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
