### PR TITLE
feature add read from file config functionallity

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,9 +19,11 @@ package config
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+	"unsafe"
 
 	"github.com/vdaas/vald/internal/net/http/json"
 	yaml "gopkg.in/yaml.v2"
@@ -35,6 +37,11 @@ type Default struct {
 	// TZ represent system time location .
 	TZ string `json:"time_zone" yaml:"time_zone"`
 }
+
+const (
+	fileValuePrefix = "file://"
+	envSymbol       = "_"
+)
 
 func (c *Default) Bind() *Default {
 	c.Version = GetActualValue(c.Version)
@@ -72,12 +79,31 @@ func Read(path string, cfg interface{}) error {
 	return err
 }
 
-// GetActualValue returns the environment variable value if the val has prefix and suffix "_", otherwise the val will directly return.
-func GetActualValue(val string) string {
-	if checkPrefixAndSuffix(val, "_", "_") {
-		return os.ExpandEnv(os.Getenv(strings.TrimPrefix(strings.TrimSuffix(val, "_"), "_")))
+// GetActualValue returns the environment variable value if the val has prefix and suffix "_",
+// if actual value start with file://{path} the return value will read from file
+// otherwise the val will directly return.
+func GetActualValue(val string) (res string) {
+	if checkPrefixAndSuffix(val, envSymbol, envSymbol) {
+		val = strings.TrimPrefix(strings.TrimSuffix(val, envSymbol), envSymbol)
+		if !strings.HasPrefix(val, "$") {
+			val = "$" + val
+		}
 	}
-	return os.ExpandEnv(val)
+	res = os.ExpandEnv(val)
+	if strings.HasPrefix(res, fileValuePrefix) {
+		path := strings.TrimPrefix(res, fileValuePrefix)
+		file, err := os.OpenFile(path, os.O_RDONLY, 0600)
+		defer file.Close()
+		if err != nil {
+			return
+		}
+		body, err := ioutil.ReadAll(file)
+		if err != nil {
+			return
+		}
+		res = *(*string)(unsafe.Pointer(&body))
+	}
+	return
 }
 
 func GetActualValues(vals []string) []string {


### PR DESCRIPTION
Signed-off-by: kpango <i.can.feel.gravity@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

enables file read config.
for example
```yaml
password: "file:///etc/password"
```
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Golang Version: 1.13.5
- Docker Version: 19.03.5
- Kubernetes Version: 1.16.3
- NGT Version: 1.8.4

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [x] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensure all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
