### PR TITLE
[patch] Make bidirectional stream concurrency configurable

### DIFF
--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -17,7 +17,9 @@
 // Package config providers configuration type and load configuration logic
 package config
 
-import "github.com/vdaas/vald/internal/servers/server"
+import (
+	"github.com/vdaas/vald/internal/servers/server"
+)
 
 type Servers struct {
 	// Server represent server configuration.
@@ -133,6 +135,15 @@ func (s *Servers) Bind() *Servers {
 		}
 	}
 	return s
+}
+
+func (s *Servers) GetGRPCStreamConcurrency() (c int) {
+	for _, s := range s.Servers {
+		if s.GRPC != nil {
+			return s.GRPC.BidirectionalStreamConcurrency
+		}
+	}
+	return 0
 }
 
 func (h *HTTP) Bind() *HTTP {

--- a/pkg/agent/ngt/handler/grpc/option.go
+++ b/pkg/agent/ngt/handler/grpc/option.go
@@ -35,6 +35,8 @@ func WithNGT(n service.NGT) Option {
 
 func WithStreamConcurrency(c int) Option {
 	return func(s *server) {
-		s.streamConcurrency = c
+		if c != 0 {
+			s.streamConcurrency = c
+		}
 	}
 }

--- a/pkg/agent/ngt/usecase/agentd.go
+++ b/pkg/agent/ngt/usecase/agentd.go
@@ -47,7 +47,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	if err != nil {
 		return nil, err
 	}
-	g := handler.New(handler.WithNGT(ngt))
+	g := handler.New(
+		handler.WithNGT(ngt),
+		handler.WithStreamConcurrency(cfg.Server.GetGRPCStreamConcurrency()),
+	)
 	eg := errgroup.Get()
 
 	srv, err := starter.New(

--- a/pkg/gateway/vald/handler/grpc/option.go
+++ b/pkg/gateway/vald/handler/grpc/option.go
@@ -96,6 +96,8 @@ func WithReplicationCount(rep int) Option {
 
 func WithStreamConcurrency(c int) Option {
 	return func(s *server) {
-		s.streamConcurrency = c
+		if c != 0 {
+			s.streamConcurrency = c
+		}
 	}
 }

--- a/pkg/gateway/vald/usecase/vald.go
+++ b/pkg/gateway/vald/usecase/vald.go
@@ -138,6 +138,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		handler.WithFilters(filter),
 		handler.WithErrGroup(eg),
 		handler.WithReplicationCount(cfg.Gateway.IndexReplica),
+		handler.WithStreamConcurrency(cfg.Server.GetGRPCStreamConcurrency()),
 	)
 
 	srv, err := starter.New(

--- a/pkg/manager/index/handler/grpc/option.go
+++ b/pkg/manager/index/handler/grpc/option.go
@@ -96,6 +96,8 @@ func WithReplicationCount(rep int) Option {
 
 func WithStreamConcurrency(c int) Option {
 	return func(s *server) {
-		s.streamConcurrency = c
+		if c != 0 {
+			s.streamConcurrency = c
+		}
 	}
 }

--- a/pkg/manager/replication/handler/grpc/option.go
+++ b/pkg/manager/replication/handler/grpc/option.go
@@ -96,6 +96,8 @@ func WithReplicationCount(rep int) Option {
 
 func WithStreamConcurrency(c int) Option {
 	return func(s *server) {
-		s.streamConcurrency = c
+		if c != 0 {
+			s.streamConcurrency = c
+		}
 	}
 }

--- a/vald/values.yaml
+++ b/vald/values.yaml
@@ -42,6 +42,7 @@ defaults:
           mode: GRPC
           probe_wait_time: "3s"
           grpc:
+            bidirectional_stream_concurrency: 20
             max_receive_message_size: 0
             max_send_message_size: 0
             initial_window_size: 0


### PR DESCRIPTION
Signed-off-by: Rintaro Okamura <rintaro.okamura@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
make bidirectional stream concurrency configurable by bidirectional_stream_concurrency field in gRPC server config.

NOTE: the handlers of index manager and replication manager are not modified.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Golang Version: 1.13.6
- Docker Version: 19.03.5
- Kubernetes Version: 1.16.3
- NGT Version: 1.8.4

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [X] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensure all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
