### PR TITLE
[patch] discovery logic changed

### DIFF
--- a/internal/client/discoverer/discover.go
+++ b/internal/client/discoverer/discover.go
@@ -225,85 +225,65 @@ func (c *client) discover(ctx context.Context, ech chan<- error) (err error) {
 	log.Info("starting discoverer discovery")
 	connected := make([]string, 0, len(c.GetAddrs()))
 	var cur sync.Map
-	if _, err = c.dscClient.Do(ctx, c.dscAddr, func(ctx context.Context,
+	if _, err = c.dscClient.Do(ctx, c.dscAddr, func(ictx context.Context,
 		conn *grpc.ClientConn, copts ...grpc.CallOption) (interface{}, error) {
 		nodes, err := discoverer.NewDiscovererClient(conn).
-			Nodes(ctx, &payload.Discoverer_Request{
+			Nodes(ictx, &payload.Discoverer_Request{
 				Namespace: c.namespace,
 				Name:      c.name,
 				Node:      c.nodeName,
 			}, copts...)
 		if err != nil {
-			log.Warn("failed to call discoverer.Node API")
 			return nil, errors.ErrRPCCallFailed(c.dscAddr, err)
 		}
-		var wg sync.WaitGroup
-		cctx, cancel := context.WithCancel(ctx)
-		pch := make(chan string, len(nodes.GetNodes()))
-		for _, n := range nodes.GetNodes() {
-			select {
-			case <-cctx.Done():
-				return nil, cctx.Err()
-			default:
-				if n != nil && n.GetPods() != nil && n.GetPods().GetPods() != nil {
-					node := n
-					wg.Add(1)
-					c.eg.Go(safety.RecoverFunc(func() (err error) {
-						defer wg.Done()
-						log.Debug("processing node name = %s", node.GetName())
-						for _, pod := range node.GetPods().GetPods() {
-							select {
-							case <-cctx.Done():
-								log.Debug("exit pods loop by context")
-								return nil
-							default:
-								log.Debug("%#v", pod)
-								if pod != nil && pod.GetIp() != "" {
-									log.Debug("processing pod name = %s", pod.GetName())
-									addr := fmt.Sprintf("%s:%d", pod.GetIp(), c.port)
-									if err = c.connect(ctx, addr); err != nil {
-										err = errors.ErrAddrCouldNotDiscover(err, addr)
-										log.Warn(err)
-										ech <- err
-										err = nil
-									} else {
-										if c.autoconn {
-											cur.Store(addr, struct{}{})
-										}
-										pch <- addr
-									}
+		maxPodLen := 0
+		podLength := 0
+		for _, node := range nodes.GetNodes() {
+			l := len(node.GetPods().GetPods())
+			podLength += l
+			if l > maxPodLen {
+				maxPodLen = l
+			}
+		}
+		addrs := make([]string, 0, podLength)
+		for i := 0; i < maxPodLen; i++ {
+			for _, node := range nodes.GetNodes() {
+				select {
+				case <-ictx.Done():
+					return nil, ictx.Err()
+				default:
+					if node != nil && node.GetPods() != nil {
+						pods := node.GetPods().GetPods()
+						if i < len(pods) {
+							addr := fmt.Sprintf("%s:%d", pods[i].GetIp(), c.port)
+							if err = c.connect(ctx, addr); err != nil {
+								err = errors.ErrAddrCouldNotDiscover(err, addr)
+								log.Debug(err)
+								ech <- err
+								err = nil
+							} else {
+								if c.autoconn {
+									cur.Store(addr, struct{}{})
 								}
+								addrs = append(addrs, addr)
 							}
+							break
 						}
-						log.Debug("finished node = " + node.GetName())
-						return nil
-					}))
+					}
 				}
 			}
 		}
-		c.eg.Go(safety.RecoverFunc(func() error {
-			wg.Wait()
-			cancel()
-			return nil
-		}))
-		for {
-			select {
-			case <-cctx.Done():
-				if len(connected) == 0 {
-					log.Warn("connected addr is zero")
-					return nil, errors.ErrAddrCouldNotDiscover(err, c.dns)
-				}
-				if c.onDiscover != nil {
-					return nil, c.onDiscover(ctx, c, connected)
-				}
-				return nil, nil
-			case addr := <-pch:
-				log.Debug("connected addr = " + addr)
-				connected = append(connected, addr)
-			}
+		connected = addrs
+		if len(connected) == 0 {
+			log.Warn("connected addr is zero")
+			return nil, errors.ErrAddrCouldNotDiscover(err, c.dns)
 		}
+		if c.onDiscover != nil {
+			return nil, c.onDiscover(ctx, c, connected)
+		}
+		return nil, nil
 	}); err != nil {
-		log.Warn("failed to discover addrs from discoverer API, trying to discover from dns..., %v", err)
+		log.Warn("failed to discover addrs from discoverer API, trying to discover from dns...\t" + err.Error())
 		connected, err = c.dnsDiscovery(ctx, ech)
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: kpango <i.can.feel.gravity@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:
internal/client/discoverer/discovery.go.discover uses alot of goroutine, but it's not necessary, so I removed them and replaced to searial logic.
we don't need such a speed for discovery
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Golang Version: 1.13.5
- Docker Version: 19.03.5
- Kubernetes Version: 1.16.3
- NGT Version: 1.8.4

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [x] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensure all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
