### PR TITLE
enable/disable client handler by observability enabled flag

### DIFF
--- a/pkg/manager/index/usecase/indexer.go
+++ b/pkg/manager/index/usecase/indexer.go
@@ -52,19 +52,48 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		indexer service.Indexer
 	)
 
+	discovererClientOptions := append(
+		cfg.Indexer.Discoverer.Client.Opts(),
+		grpc.WithErrGroup(eg),
+	)
+
+	grpcServerOptions := []server.Option{
+		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
+			index.RegisterIndexServer(srv, idx)
+		}),
+		server.WithPreStopFunction(func() error {
+			// TODO notify another gateway and scheduler
+			return nil
+		}),
+	}
+
+	var obs observability.Observability
+	if cfg.Observability.Enabled {
+		obs, err = observability.NewWithConfig(cfg.Observability)
+		if err != nil {
+			return nil, err
+		}
+		discovererClientOptions = append(
+			discovererClientOptions,
+			grpc.WithDialOptions(
+				grpc.WithStatsHandler(metric.NewClientHandler()),
+			),
+		)
+		grpcServerOptions = append(
+			grpcServerOptions,
+			server.WithGRPCOption(
+				grpc.StatsHandler(metric.NewServerHandler()),
+			),
+		)
+	}
+
 	client, err := discoverer.New(
 		discoverer.WithAutoConnect(true),
 		discoverer.WithName(cfg.Indexer.AgentName),
 		discoverer.WithNamespace(cfg.Indexer.AgentNamespace),
 		discoverer.WithPort(cfg.Indexer.AgentPort),
 		discoverer.WithServiceDNSARecord(cfg.Indexer.AgentDNS),
-		discoverer.WithDiscovererClient(grpc.New(
-			append(cfg.Indexer.Discoverer.Client.Opts(),
-				grpc.WithErrGroup(eg),
-				grpc.WithDialOptions(
-					grpc.WithStatsHandler(metric.NewClientHandler()),
-				),
-			)...)),
+		discoverer.WithDiscovererClient(grpc.New(discovererClientOptions...)),
 		discoverer.WithDiscovererHostPort(
 			cfg.Indexer.Discoverer.Host,
 			cfg.Indexer.Discoverer.Port,
@@ -95,30 +124,6 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		return nil, err
 	}
 	idx := handler.New(handler.WithIndexer(indexer))
-
-	grpcServerOptions := []server.Option{
-		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
-			index.RegisterIndexServer(srv, idx)
-		}),
-		server.WithPreStopFunction(func() error {
-			// TODO notify another gateway and scheduler
-			return nil
-		}),
-	}
-
-	var obs observability.Observability
-	if cfg.Observability.Enabled {
-		obs, err = observability.NewWithConfig(cfg.Observability)
-		if err != nil {
-			return nil, err
-		}
-		grpcServerOptions = append(
-			grpcServerOptions,
-			server.WithGRPCOption(
-				grpc.StatsHandler(metric.NewServerHandler()),
-			),
-		)
-	}
 
 	srv, err := starter.New(
 		starter.WithConfig(cfg.Server),

--- a/vald/values.yaml
+++ b/vald/values.yaml
@@ -530,8 +530,8 @@ compressor:
       cpu: 300m
       memory: 50Mi
     limits:
-      cpu: 500m
-      memory: 150Mi
+      cpu: 800m
+      memory: 500Mi
   backup:
     client: {}
   compress:


### PR DESCRIPTION
Signed-off-by: Rintaro Okamura <rintaro.okamura@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
I've noticed that gRPC client handler is always enabled.
in this pr, they are enabled/disabled by observability enabled flag.

the resource limits of compressor is revised here.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Nothing.

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Nothing.

### Environment:

<!--- Please change the versions below along with your environment -->

- Golang Version: 1.14
- Docker Version: 19.03.5
- Kubernetes Version: 1.16.3
- NGT Version: 1.9.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [X] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensure all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
