### PR TITLE
Use internal log for exporters errors

### DIFF
--- a/internal/observability/exporter/jaeger/jaeger_option.go
+++ b/internal/observability/exporter/jaeger/jaeger_option.go
@@ -19,6 +19,7 @@ package jaeger
 
 import (
 	"contrib.go.opencensus.io/exporter/jaeger"
+	"github.com/vdaas/vald/internal/log"
 )
 
 type JaegerOption func(*jaegerOptions) error
@@ -26,6 +27,11 @@ type JaegerOption func(*jaegerOptions) error
 var (
 	jaegerDefaultOpts = []JaegerOption{
 		WithServiceName("vald"),
+		WithOnErrorFunc(func(err error) {
+			if err != nil {
+				log.Warnf("Error when uploading spans to Jaeger: %v", err)
+			}
+		}),
 	}
 )
 
@@ -77,6 +83,15 @@ func WithServiceName(serviceName string) JaegerOption {
 func WithBufferMaxCount(cnt int) JaegerOption {
 	return func(jo *jaegerOptions) error {
 		jo.BufferMaxCount = cnt
+		return nil
+	}
+}
+
+func WithOnErrorFunc(f func(error)) JaegerOption {
+	return func(jo *jaegerOptions) error {
+		if f != nil {
+			jo.OnError = f
+		}
 		return nil
 	}
 }

--- a/internal/observability/exporter/prometheus/prometheus_option.go
+++ b/internal/observability/exporter/prometheus/prometheus_option.go
@@ -17,12 +17,19 @@
 // Package prometheus provides a prometheus exporter.
 package prometheus
 
+import "github.com/vdaas/vald/internal/log"
+
 type PrometheusOption func(*prometheusOptions) error
 
 var (
 	prometheusDefaultOpts = []PrometheusOption{
 		WithEndpoint("/metrics"),
 		WithNamespace("vald"),
+		WithOnErrorFunc(func(err error) {
+			if err != nil {
+				log.Warnf("Failed to export to Prometheus: %v", err)
+			}
+		}),
 	}
 )
 
@@ -39,6 +46,15 @@ func WithNamespace(ns string) PrometheusOption {
 	return func(po *prometheusOptions) error {
 		if ns != "" {
 			po.options.Namespace = ns
+		}
+		return nil
+	}
+}
+
+func WithOnErrorFunc(f func(error)) PrometheusOption {
+	return func(po *prometheusOptions) error {
+		if f != nil {
+			po.options.OnError = f
 		}
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: Rintaro Okamura <rintaro.okamura@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
currently, errors occurred in Jaeger and Prometheus exporters are logged by their own logger.
this PR replaces their logger with Vald internal log package.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Nothing.

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Nothing.

### Environment:

<!--- Please change the versions below along with your environment -->

- Golang Version: 1.14
- Docker Version: 19.03.5
- Kubernetes Version: 1.16.3
- NGT Version: 1.9.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [X] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensure all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
