### PR TITLE
♻️ Refactoring compressor

### DIFF
--- a/charts/vald/templates/manager/compressor/configmap.yaml
+++ b/charts/vald/templates/manager/compressor/configmap.yaml
@@ -43,21 +43,6 @@ data:
       concurrent_limit: {{ .Values.compressor.compress.concurrent_limit }}
       buffer: {{ .Values.compressor.compress.buffer }}
       pod_ip: {{ .Values.compressor.compress.pod_ip | quote }}
-      compressor_port: {{ default .Values.defaults.server_config.servers.grpc.port .Values.compressor.server_config.servers.grpc.port }}
-      compressor_name: {{ .Values.compressor.name | quote }}
-      compressor_namespace: {{ .Values.compressor.compress.compressor_namespace | quote }}
-      compressor_dns: {{ .Values.compressor.name }}.{{ .Release.Namespace }}.svc.cluster.local
-      node_name: {{ .Values.compressor.compress.node_name | quote }}
-      discoverer:
-        host: {{ .Values.discoverer.name }}.{{ .Release.Namespace }}.svc.cluster.local
-        port: {{ default .Values.defaults.server_config.servers.grpc.port .Values.discoverer.server_config.servers.grpc.port }}
-        duration: {{ .Values.compressor.compress.discoverer.duration }}
-        discover_client:
-          {{- $discoverClient := dict "Values" .Values.compressor.compress.discoverer.discover_client "default" .Values.defaults.grpc.client }}
-          {{- include "vald.grpc.client" $discoverClient | nindent 10 }}
-        agent_client:
-          {{- $agentClient := dict "Values" .Values.compressor.compress.discoverer.agent_client "default" .Values.defaults.grpc.client }}
-          {{- include "vald.grpc.client" $agentClient | nindent 10 }}
       registerer:
         buffer: {{ .Values.compressor.compress.registerer.buffer }}
         backoff:
@@ -71,3 +56,9 @@ data:
         worker:
           concurrent_limit: {{ .Values.compressor.compress.registerer.worker.concurrent_limit }}
           buffer: {{ .Values.compressor.compress.registerer.worker.buffer }}
+        compressor:
+          host: {{ .Values.compressor.name }}.{{ .Release.Namespace }}.svc.cluster.local
+          port: {{ default .Values.defaults.server_config.servers.grpc.port .Values.compressor.server_config.servers.grpc.port }}
+          client:
+            {{- $compressorClient := dict "Values" .Values.compressor.compress.registerer.compressor.client "default" .Values.defaults.grpc.client }}
+            {{- include "vald.grpc.client" $compressorClient | nindent 12 }}

--- a/charts/vald/templates/manager/compressor/configmap.yaml
+++ b/charts/vald/templates/manager/compressor/configmap.yaml
@@ -38,4 +38,36 @@ data:
         {{- $backupClient := dict "Values" .Values.compressor.backup.client "default" .Values.defaults.grpc.client }}
         {{- include "vald.grpc.client" $backupClient | nindent 8 }}
     compressor:
-      {{- toYaml .Values.compressor.compress | nindent 6 }}
+      compress_algorithm: {{ .Values.compressor.compress.compress_algorithm }}
+      compression_level:  {{ .Values.compressor.compress.compression_level }}
+      concurrent_limit: {{ .Values.compressor.compress.concurrent_limit }}
+      buffer: {{ .Values.compressor.compress.buffer }}
+      pod_ip: {{ .Values.compressor.compress.pod_ip }}
+      compressor_port: {{ default .Values.defaults.server_config.servers.grpc.port .Values.compressor.server_config.servers.grpc.port }}
+      compressor_name: {{ .Values.compressor.name | quote }}
+      compressor_namespace: {{ .Values.compressor.compress.compressor_namespace | quote }}
+      compressor_dns: {{ .Values.compressor.name }}.{{ .Release.Namespace }}.svc.cluster.local
+      node_name: {{ .Values.compressor.compress.node_name }}
+      discoverer:
+        host: {{ .Values.discoverer.name }}.{{ .Release.Namespace }}.svc.cluster.local
+        port: {{ default .Values.defaults.server_config.servers.grpc.port .Values.discoverer.server_config.servers.grpc.port }}
+        duration: {{ .Values.compressor.compress.discoverer.duration }}
+        discover_client:
+          {{- $discoverClient := dict "Values" .Values.compressor.compress.discoverer.discover_client "default" .Values.defaults.grpc.client }}
+          {{- include "vald.grpc.client" $discoverClient | nindent 10 }}
+        agent_client:
+          {{- $agentClient := dict "Values" .Values.compressor.compress.discoverer.agent_client "default" .Values.defaults.grpc.client }}
+          {{- include "vald.grpc.client" $agentClient | nindent 10 }}
+      registerer:
+        buffer: {{ .Values.compressor.compress.registerer.buffer }}
+        backoff:
+          initial_duration: {{ .Values.compressor.compress.registerer.backoff.initial_duration }}
+          backoff_time_limit:  {{ .Values.compressor.compress.registerer.backoff.backoff_time_limit }}
+          maximum_duration:  {{ .Values.compressor.compress.registerer.backoff.maximum_duration }}
+          jitter_limit:  {{ .Values.compressor.compress.registerer.backoff.jitter_limit }}
+          backoff_factor:  {{ .Values.compressor.compress.registerer.backoff.backoff_factor }}
+          retry_count:  {{ .Values.compressor.compress.registerer.backoff.retry_count }}
+          enable_error_log:  {{ .Values.compressor.compress.registerer.backoff.enable_error_log }}
+        worker:
+          concurrent_limit: {{ .Values.compressor.compress.registerer.worker.concurrent_limit }}
+          buffer: {{ .Values.compressor.compress.registerer.worker.buffer }}

--- a/charts/vald/templates/manager/compressor/configmap.yaml
+++ b/charts/vald/templates/manager/compressor/configmap.yaml
@@ -38,16 +38,16 @@ data:
         {{- $backupClient := dict "Values" .Values.compressor.backup.client "default" .Values.defaults.grpc.client }}
         {{- include "vald.grpc.client" $backupClient | nindent 8 }}
     compressor:
-      compress_algorithm: {{ .Values.compressor.compress.compress_algorithm }}
-      compression_level:  {{ .Values.compressor.compress.compression_level }}
+      compress_algorithm: {{ .Values.compressor.compress.compress_algorithm | quote }}
+      compression_level: {{ .Values.compressor.compress.compression_level }}
       concurrent_limit: {{ .Values.compressor.compress.concurrent_limit }}
       buffer: {{ .Values.compressor.compress.buffer }}
-      pod_ip: {{ .Values.compressor.compress.pod_ip }}
+      pod_ip: {{ .Values.compressor.compress.pod_ip | quote }}
       compressor_port: {{ default .Values.defaults.server_config.servers.grpc.port .Values.compressor.server_config.servers.grpc.port }}
       compressor_name: {{ .Values.compressor.name | quote }}
       compressor_namespace: {{ .Values.compressor.compress.compressor_namespace | quote }}
       compressor_dns: {{ .Values.compressor.name }}.{{ .Release.Namespace }}.svc.cluster.local
-      node_name: {{ .Values.compressor.compress.node_name }}
+      node_name: {{ .Values.compressor.compress.node_name | quote }}
       discoverer:
         host: {{ .Values.discoverer.name }}.{{ .Release.Namespace }}.svc.cluster.local
         port: {{ default .Values.defaults.server_config.servers.grpc.port .Values.discoverer.server_config.servers.grpc.port }}
@@ -61,13 +61,13 @@ data:
       registerer:
         buffer: {{ .Values.compressor.compress.registerer.buffer }}
         backoff:
-          initial_duration: {{ .Values.compressor.compress.registerer.backoff.initial_duration }}
-          backoff_time_limit:  {{ .Values.compressor.compress.registerer.backoff.backoff_time_limit }}
-          maximum_duration:  {{ .Values.compressor.compress.registerer.backoff.maximum_duration }}
-          jitter_limit:  {{ .Values.compressor.compress.registerer.backoff.jitter_limit }}
-          backoff_factor:  {{ .Values.compressor.compress.registerer.backoff.backoff_factor }}
-          retry_count:  {{ .Values.compressor.compress.registerer.backoff.retry_count }}
-          enable_error_log:  {{ .Values.compressor.compress.registerer.backoff.enable_error_log }}
+          initial_duration: {{ .Values.compressor.compress.registerer.backoff.initial_duration | quote }}
+          backoff_time_limit: {{ .Values.compressor.compress.registerer.backoff.backoff_time_limit | quote }}
+          maximum_duration: {{ .Values.compressor.compress.registerer.backoff.maximum_duration | quote }}
+          jitter_limit: {{ .Values.compressor.compress.registerer.backoff.jitter_limit | quote }}
+          backoff_factor: {{ .Values.compressor.compress.registerer.backoff.backoff_factor }}
+          retry_count: {{ .Values.compressor.compress.registerer.backoff.retry_count }}
+          enable_error_log: {{ .Values.compressor.compress.registerer.backoff.enable_error_log }}
         worker:
           concurrent_limit: {{ .Values.compressor.compress.registerer.worker.concurrent_limit }}
           buffer: {{ .Values.compressor.compress.registerer.worker.buffer }}

--- a/charts/vald/templates/manager/compressor/configmap.yaml
+++ b/charts/vald/templates/manager/compressor/configmap.yaml
@@ -41,24 +41,11 @@ data:
       compress_algorithm: {{ .Values.compressor.compress.compress_algorithm | quote }}
       compression_level: {{ .Values.compressor.compress.compression_level }}
       concurrent_limit: {{ .Values.compressor.compress.concurrent_limit }}
-      buffer: {{ .Values.compressor.compress.buffer }}
-      pod_ip: {{ .Values.compressor.compress.pod_ip | quote }}
-      registerer:
-        buffer: {{ .Values.compressor.compress.registerer.buffer }}
-        backoff:
-          initial_duration: {{ .Values.compressor.compress.registerer.backoff.initial_duration | quote }}
-          backoff_time_limit: {{ .Values.compressor.compress.registerer.backoff.backoff_time_limit | quote }}
-          maximum_duration: {{ .Values.compressor.compress.registerer.backoff.maximum_duration | quote }}
-          jitter_limit: {{ .Values.compressor.compress.registerer.backoff.jitter_limit | quote }}
-          backoff_factor: {{ .Values.compressor.compress.registerer.backoff.backoff_factor }}
-          retry_count: {{ .Values.compressor.compress.registerer.backoff.retry_count }}
-          enable_error_log: {{ .Values.compressor.compress.registerer.backoff.enable_error_log }}
-        worker:
-          concurrent_limit: {{ .Values.compressor.compress.registerer.worker.concurrent_limit }}
-          buffer: {{ .Values.compressor.compress.registerer.worker.buffer }}
-        compressor:
-          host: {{ .Values.compressor.name }}.{{ .Release.Namespace }}.svc.cluster.local
-          port: {{ default .Values.defaults.server_config.servers.grpc.port .Values.compressor.server_config.servers.grpc.port }}
-          client:
-            {{- $compressorClient := dict "Values" .Values.compressor.compress.registerer.compressor.client "default" .Values.defaults.grpc.client }}
-            {{- include "vald.grpc.client" $compressorClient | nindent 12 }}
+    registerer:
+      concurrent_limit: {{ .Values.compressor.registerer.concurrent_limit }}
+      compressor:
+        host: {{ .Values.compressor.name }}.{{ .Release.Namespace }}.svc.cluster.local
+        port: {{ default .Values.defaults.server_config.servers.grpc.port .Values.compressor.server_config.servers.grpc.port }}
+        client:
+          {{- $compressorClient := dict "Values" .Values.compressor.registerer.compressor.client "default" .Values.defaults.grpc.client }}
+          {{- include "vald.grpc.client" $compressorClient | nindent 12 }}

--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -382,6 +382,10 @@ defaults:
     prometheus:
       # defaults.observability.prometheus.enabled -- Prometheus exporter enabled
       enabled: false
+      # defaults.observability.prometheus.endpoint -- Prometheus exporter endpoint
+      endpoint: /metrics
+      # defaults.observability.prometheus.namespace -- prefix of exported metrics name
+      namespace: vald
     jaeger:
       # defaults.observability.jaeger.enabled -- Jaeger exporter enabled
       enabled: false
@@ -844,8 +848,16 @@ compressor:
       target: manager-backup
       image: busybox
       sleepDuration: 2
-  # compressor.env -- (list) environment variables
-  env: null
+  # compressor.env -- environment variables
+  env:
+    - name: MY_POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: MY_POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
   # compressor.volumeMounts -- (list) volume mounts
   volumeMounts: null
   # compressor.volumes -- (list) volumes
@@ -890,6 +902,36 @@ compressor:
     concurrent_limit: 10
     # compressor.compress.buffer -- size of buffer
     buffer: 100
+    # compressor.compress.pod_ip -- ip address of the pod
+    pod_ip: _MY_POD_IP_
+    # compressor.compress.compressor_namespace -- namespace of compressor
+    compressor_namespace: _MY_POD_NAMESPACE_
+    # compressor.compress.node_name -- node name
+    node_name: ""
+    discoverer:
+      # compressor.compress.discoverer.duration -- discoverer duration
+      duration: 1s
+      # compressor.compress.discoverer.discover_client -- gRPC client for discoverer (overrides defaults.grpc.client)
+      discover_client: {}
+      # compressor.compress.discoverer.agent_client -- gRPC client for compressor (overrides defaults.grpc.client)
+      agent_client: {}
+    registerer:
+      # compressor.compress.registerer.buffer -- size of registerer buffer
+      buffer: 100
+      # compressor.compress.registerer.backoff -- backoff configuration of registerer
+      backoff:
+        initial_duration: 5ms
+        backoff_time_limit: 5s
+        maximum_duration: 5s
+        jitter_limit: 100ms
+        backoff_factor: 1.1
+        retry_count: 100
+        enable_error_log: true
+      worker:
+        # compressor.compress.registerer.worker.concurrent_limit -- concurrency limit of registerer worker
+        concurrent_limit: 10
+        # compressor.compress.registerer.worker.buffer -- size of registerer worker buffer
+        buffer: 100
 
 backupManager:
   # backupManager.version -- version of backup manager config

--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -896,30 +896,12 @@ compressor:
     compression_level: 3
     # compressor.compress.concurrent_limit -- concurrency limit
     concurrent_limit: 10
-    # compressor.compress.buffer -- size of buffer
-    buffer: 100
-    # compressor.compress.pod_ip -- ip address of the pod
-    pod_ip: _MY_POD_IP_
-    registerer:
-      # compressor.compress.registerer.buffer -- size of registerer buffer
-      buffer: 1000000
-      # compressor.compress.registerer.backoff -- backoff configuration of registerer
-      backoff:
-        initial_duration: 5ms
-        backoff_time_limit: 5s
-        maximum_duration: 5s
-        jitter_limit: 100ms
-        backoff_factor: 1.1
-        retry_count: 100
-        enable_error_log: true
-      worker:
-        # compressor.compress.registerer.worker.concurrent_limit -- concurrency limit of registerer worker
-        concurrent_limit: 10
-        # compressor.compress.registerer.worker.buffer -- size of registerer worker buffer
-        buffer: 0
-      compressor:
-        # compressor.compress.registerer.compressor.client -- gRPC client for compressor (overrides defaults.grpc.client)
-        client: {}
+  registerer:
+    # compressor.registerer.concurrent_limit -- concurrency limit of registerer worker
+    concurrent_limit: 10
+    compressor:
+      # compressor.registerer.compressor.client -- gRPC client for compressor (overrides defaults.grpc.client)
+      client: {}
 
 backupManager:
   # backupManager.version -- version of backup manager config

--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -848,6 +848,11 @@ compressor:
       target: manager-backup
       image: busybox
       sleepDuration: 2
+    - type: wait-for
+      name: wait-for-discoverer
+      target: discoverer
+      image: busybox
+      sleepDuration: 2
   # compressor.env -- environment variables
   env:
     - name: MY_POD_NAMESPACE

--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -902,7 +902,7 @@ compressor:
     pod_ip: _MY_POD_IP_
     registerer:
       # compressor.compress.registerer.buffer -- size of registerer buffer
-      buffer: 100
+      buffer: 1000000
       # compressor.compress.registerer.backoff -- backoff configuration of registerer
       backoff:
         initial_duration: 5ms
@@ -916,7 +916,7 @@ compressor:
         # compressor.compress.registerer.worker.concurrent_limit -- concurrency limit of registerer worker
         concurrent_limit: 10
         # compressor.compress.registerer.worker.buffer -- size of registerer worker buffer
-        buffer: 100
+        buffer: 0
       compressor:
         # compressor.compress.registerer.compressor.client -- gRPC client for compressor (overrides defaults.grpc.client)
         client: {}

--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -855,10 +855,6 @@ compressor:
       sleepDuration: 2
   # compressor.env -- environment variables
   env:
-    - name: MY_POD_NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
     - name: MY_POD_IP
       valueFrom:
         fieldRef:
@@ -909,17 +905,6 @@ compressor:
     buffer: 100
     # compressor.compress.pod_ip -- ip address of the pod
     pod_ip: _MY_POD_IP_
-    # compressor.compress.compressor_namespace -- namespace of compressor
-    compressor_namespace: _MY_POD_NAMESPACE_
-    # compressor.compress.node_name -- node name
-    node_name: ""
-    discoverer:
-      # compressor.compress.discoverer.duration -- discoverer duration
-      duration: 1s
-      # compressor.compress.discoverer.discover_client -- gRPC client for discoverer (overrides defaults.grpc.client)
-      discover_client: {}
-      # compressor.compress.discoverer.agent_client -- gRPC client for compressor (overrides defaults.grpc.client)
-      agent_client: {}
     registerer:
       # compressor.compress.registerer.buffer -- size of registerer buffer
       buffer: 100
@@ -937,6 +922,9 @@ compressor:
         concurrent_limit: 10
         # compressor.compress.registerer.worker.buffer -- size of registerer worker buffer
         buffer: 100
+      compressor:
+        # compressor.compress.registerer.compressor.client -- gRPC client for compressor (overrides defaults.grpc.client)
+        client: {}
 
 backupManager:
   # backupManager.version -- version of backup manager config

--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -848,11 +848,6 @@ compressor:
       target: manager-backup
       image: busybox
       sleepDuration: 2
-    - type: wait-for
-      name: wait-for-discoverer
-      target: discoverer
-      image: busybox
-      sleepDuration: 2
   # compressor.env -- environment variables
   env:
     - name: MY_POD_IP

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	go.uber.org/automaxprocs v1.3.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9
-	golang.org/x/tools v0.0.0-20200402223321-bcf690261a44 // indirect
+	golang.org/x/tools v0.0.0-20200406213809-066fd1390ee0 // indirect
 	gonum.org/v1/hdf5 v0.0.0-20191105085658-fe04b73f3b53
 	gonum.org/v1/plot v0.7.0
 	google.golang.org/genproto v0.0.0-20200401122417-09ab7b7031d2

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	go.uber.org/automaxprocs v1.3.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9
-	golang.org/x/tools v0.0.0-20200406213809-066fd1390ee0 // indirect
+	golang.org/x/tools v0.0.0-20200413015812-1f08ef6002a8 // indirect
 	gonum.org/v1/hdf5 v0.0.0-20191105085658-fe04b73f3b53
 	gonum.org/v1/plot v0.7.0
 	google.golang.org/genproto v0.0.0-20200401122417-09ab7b7031d2

--- a/go.sum
+++ b/go.sum
@@ -603,6 +603,8 @@ golang.org/x/tools v0.0.0-20200402223321-bcf690261a44 h1:bMm0eoDiGkM5VfIyKjxDvof
 golang.org/x/tools v0.0.0-20200402223321-bcf690261a44/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200406213809-066fd1390ee0 h1:PaUgOASiqoF4KlotK7/3XKYFGN5Hw5jh/SHqOVpQBcI=
 golang.org/x/tools v0.0.0-20200406213809-066fd1390ee0/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200413015812-1f08ef6002a8 h1:1TnYi6m8UoNpEKS1wxgR8GcHPe2YDgYoDjAedVuX+Q0=
+golang.org/x/tools v0.0.0-20200413015812-1f08ef6002a8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/go.sum
+++ b/go.sum
@@ -601,6 +601,8 @@ golang.org/x/tools v0.0.0-20200401192744-099440627f01 h1:ysQJ/fU6laLOZJseIeOqXl6
 golang.org/x/tools v0.0.0-20200401192744-099440627f01/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200402223321-bcf690261a44 h1:bMm0eoDiGkM5VfIyKjxDvoflW5GLp7+VCo+60n8F+TE=
 golang.org/x/tools v0.0.0-20200402223321-bcf690261a44/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200406213809-066fd1390ee0 h1:PaUgOASiqoF4KlotK7/3XKYFGN5Hw5jh/SHqOVpQBcI=
+golang.org/x/tools v0.0.0-20200406213809-066fd1390ee0/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/internal/client/compressor/option.go
+++ b/internal/client/compressor/option.go
@@ -27,14 +27,14 @@ var (
 	defaultOpts = []Option{}
 )
 
-func WithBackupAddr(addr string) Option {
+func WithAddr(addr string) Option {
 	return func(c *client) error {
 		c.addr = addr
 		return nil
 	}
 }
 
-func WithBackupClient(gc grpc.Client) Option {
+func WithClient(gc grpc.Client) Option {
 	return func(c *client) error {
 		if gc != nil {
 			c.client = gc

--- a/internal/config/compress.go
+++ b/internal/config/compress.go
@@ -65,63 +65,28 @@ type Compressor struct {
 
 	// ConcurrentLimit represents limitation of compression worker concurrency
 	ConcurrentLimit int `json:"concurrent_limit" yaml:"concurrent_limit"`
-
-	// Buffer represents capacity of buffer for compression
-	Buffer int `json:"buffer" yaml:"buffer"`
-
-	// PodIP represents pod ip of compressor instance. it is recommended to use status.podIP field of k8s pod
-	PodIP string `json:"pod_ip" yaml:"pod_ip"`
-
-	// Registerer represents registerer options
-	Registerer *CompressorRegisterer `json:"registerer" yaml:"registerer"`
-}
-
-type CompressorRegisterer struct {
-	// Buffer represents capacity of buffer for registerer
-	Buffer int `json:"buffer" yaml:"buffer"`
-
-	// Backoff represents backoff configuration of registerer
-	Backoff *Backoff `json:"backoff" yaml:"backoff"`
-
-	// Worker represents worker options
-	Worker *Worker `json:"worker" yaml:"worker"`
-
-	// Compressor represents gRPC client config of compressor client (for forwarding use)
-	Compressor *BackupManager `json:"compressor" yaml:"compressor"`
-}
-
-type Worker struct {
-	// ConcurrentLimit represents limitation of worker
-	ConcurrentLimit int `json:"concurrent_limit" yaml:"concurrent_limit"`
-
-	// Buffer represents capacity of buffer for worker
-	Buffer int `json:"buffer" yaml:"buffer"`
 }
 
 func (c *Compressor) Bind() *Compressor {
 	c.CompressAlgorithm = GetActualValue(c.CompressAlgorithm)
 
-	c.PodIP = GetActualValue(c.PodIP)
-
-	if c.Registerer == nil {
-		c.Registerer = new(CompressorRegisterer)
-	}
-
-	if c.Registerer.Backoff != nil {
-		c.Registerer.Backoff = c.Registerer.Backoff.Bind()
-	} else {
-		c.Registerer.Backoff = new(Backoff)
-	}
-
-	if c.Registerer.Worker == nil {
-		c.Registerer.Worker = new(Worker)
-	}
-
-	if c.Registerer.Compressor != nil {
-		c.Registerer.Compressor = c.Registerer.Compressor.Bind()
-	} else {
-		c.Registerer.Compressor = new(BackupManager)
-	}
-
 	return c
+}
+
+type CompressorRegisterer struct {
+	// ConcurrentLimit represents limitation of worker
+	ConcurrentLimit int `json:"concurrent_limit" yaml:"concurrent_limit"`
+
+	// Compressor represents gRPC client config of compressor client (for forwarding use)
+	Compressor *BackupManager `json:"compressor" yaml:"compressor"`
+}
+
+func (cr *CompressorRegisterer) Bind() *CompressorRegisterer {
+	if cr.Compressor != nil {
+		cr.Compressor = cr.Compressor.Bind()
+	} else {
+		cr.Compressor = new(BackupManager)
+	}
+
+	return cr
 }

--- a/internal/config/compress.go
+++ b/internal/config/compress.go
@@ -128,14 +128,14 @@ func (c *Compressor) Bind() *Compressor {
 		c.Discoverer = new(DiscovererClient)
 	}
 
-	if c.Registerer != nil {
-		if c.Registerer.Backoff != nil {
-			c.Registerer.Backoff = c.Registerer.Backoff.Bind()
-		} else {
-			c.Registerer.Backoff = new(Backoff)
-		}
-	} else {
+	if c.Registerer == nil {
 		c.Registerer = new(CompressorRegisterer)
+	}
+
+	if c.Registerer.Backoff != nil {
+		c.Registerer.Backoff = c.Registerer.Backoff.Bind()
+	} else {
+		c.Registerer.Backoff = new(Backoff)
 	}
 
 	if c.Registerer.Worker == nil {

--- a/internal/config/compress.go
+++ b/internal/config/compress.go
@@ -69,8 +69,8 @@ type Compressor struct {
 	// Buffer represents capacity of buffer for compression
 	Buffer int `json:"buffer" yaml:"buffer"`
 
-	// PodName represents pod name of compressor instance. it is recommended to use metadata.name field of k8s pod
-	PodName string `json:"pod_name" yaml:"pod_name"`
+	// PodIP represents pod ip of compressor instance. it is recommended to use status.podIP field of k8s pod
+	PodIP string `json:"pod_ip" yaml:"pod_ip"`
 
 	// CompressorPort represents compressor port number
 	CompressorPort int `json:"compressor_port" yaml:"compressor_port"`
@@ -116,7 +116,7 @@ type Worker struct {
 func (c *Compressor) Bind() *Compressor {
 	c.CompressAlgorithm = GetActualValue(c.CompressAlgorithm)
 
-	c.PodName = GetActualValue(c.PodName)
+	c.PodIP = GetActualValue(c.PodIP)
 
 	c.CompressorName = GetActualValue(c.CompressorName)
 	c.CompressorNamespace = GetActualValue(c.CompressorNamespace)

--- a/internal/config/compress.go
+++ b/internal/config/compress.go
@@ -72,24 +72,6 @@ type Compressor struct {
 	// PodIP represents pod ip of compressor instance. it is recommended to use status.podIP field of k8s pod
 	PodIP string `json:"pod_ip" yaml:"pod_ip"`
 
-	// CompressorPort represents compressor port number
-	CompressorPort int `json:"compressor_port" yaml:"compressor_port"`
-
-	// CompressorName represents compressors meta_name for service discovery
-	CompressorName string `json:"compressor_name" yaml:"compressor_name"`
-
-	// CompressorNamespace represents compressor namespace location
-	CompressorNamespace string `json:"compressor_namespace" yaml:"compressor_namespace"`
-
-	// CompressorDNS represents compressor dns A record for service discovery
-	CompressorDNS string `json:"compressor_dns" yaml:"compressor_dns"`
-
-	// NodeName represents node name
-	NodeName string `json:"node_name" yaml:"node_name"`
-
-	// Discoverer represents agent discoverer service configuration
-	Discoverer *DiscovererClient `json:"discoverer" yaml:"discoverer"`
-
 	// Registerer represents registerer options
 	Registerer *CompressorRegisterer `json:"registerer" yaml:"registerer"`
 }
@@ -103,6 +85,9 @@ type CompressorRegisterer struct {
 
 	// Worker represents worker options
 	Worker *Worker `json:"worker" yaml:"worker"`
+
+	// Compressor represents gRPC client config of compressor client (for forwarding use)
+	Compressor *BackupManager `json:"compressor" yaml:"compressor"`
 }
 
 type Worker struct {
@@ -118,16 +103,6 @@ func (c *Compressor) Bind() *Compressor {
 
 	c.PodIP = GetActualValue(c.PodIP)
 
-	c.CompressorName = GetActualValue(c.CompressorName)
-	c.CompressorNamespace = GetActualValue(c.CompressorNamespace)
-	c.CompressorDNS = GetActualValue(c.CompressorDNS)
-
-	if c.Discoverer != nil {
-		c.Discoverer = c.Discoverer.Bind()
-	} else {
-		c.Discoverer = new(DiscovererClient)
-	}
-
 	if c.Registerer == nil {
 		c.Registerer = new(CompressorRegisterer)
 	}
@@ -140,6 +115,12 @@ func (c *Compressor) Bind() *Compressor {
 
 	if c.Registerer.Worker == nil {
 		c.Registerer.Worker = new(Worker)
+	}
+
+	if c.Registerer.Compressor != nil {
+		c.Registerer.Compressor = c.Registerer.Compressor.Bind()
+	} else {
+		c.Registerer.Compressor = new(BackupManager)
 	}
 
 	return c

--- a/internal/errors/compressor.go
+++ b/internal/errors/compressor.go
@@ -35,4 +35,12 @@ var (
 	ErrCompressFailed = New("compress failed")
 
 	ErrDecompressFailed = New("decompress failed")
+
+	ErrCompressorRegistererIsNotRunning = func() error {
+		return Errorf("compressor registerers is not running")
+	}
+
+	ErrCompressorRegistererChannelIsFull = func() error {
+		return Errorf("compressor registerer channel is full")
+	}
 )

--- a/internal/errors/worker.go
+++ b/internal/errors/worker.go
@@ -18,6 +18,10 @@
 package errors
 
 var (
+	ErrWorkerIsNotRunning = func(name string) error {
+		return Errorf("worker %s is not running", name)
+	}
+
 	ErrWorkerChannelIsFull = func(name string) error {
 		return Errorf("worker channel is full. cannot send job to worker: %s", name)
 	}

--- a/internal/errors/worker.go
+++ b/internal/errors/worker.go
@@ -1,0 +1,24 @@
+//
+// Copyright (C) 2019-2020 Vdaas.org Vald team ( kpango, rinx, kmrmt )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package errors provides error types and function
+package errors
+
+var (
+	ErrWorkerChannelIsFull = func(name string) error {
+		return Errorf("worker channel is full. cannot send job to worker: %s", name)
+	}
+)

--- a/internal/errors/worker.go
+++ b/internal/errors/worker.go
@@ -21,8 +21,4 @@ var (
 	ErrWorkerIsNotRunning = func(name string) error {
 		return Errorf("worker %s is not running", name)
 	}
-
-	ErrWorkerChannelIsFull = func(name string) error {
-		return Errorf("worker channel is full. cannot send job to worker: %s", name)
-	}
 )

--- a/internal/errors/worker.go
+++ b/internal/errors/worker.go
@@ -21,4 +21,8 @@ var (
 	ErrWorkerIsNotRunning = func(name string) error {
 		return Errorf("worker %s is not running", name)
 	}
+
+	ErrJobFuncIsNil = func() error {
+		return New("JobFunc is nil")
+	}
 )

--- a/internal/errors/worker.go
+++ b/internal/errors/worker.go
@@ -22,6 +22,10 @@ var (
 		return Errorf("worker %s is not running", name)
 	}
 
+	ErrQueueIsNotRunning = func() error {
+		return Errorf("queue is not running")
+	}
+
 	ErrJobFuncIsNil = func() error {
 		return New("JobFunc is nil")
 	}

--- a/internal/observability/metrics/manager/compressor/compressor.go
+++ b/internal/observability/metrics/manager/compressor/compressor.go
@@ -44,18 +44,13 @@ func New(c service.Compressor, r service.Registerer) metrics.Metric {
 			metrics.ValdOrg+"/manager/compressor/registerer_buffer_count",
 			"Compressor registerer buffer count",
 			metrics.UnitDimensionless),
-		registererWorkerBufferCount: *metrics.Int64(
-			metrics.ValdOrg+"/manager/compressor/registerer_worker_buffer_count",
-			"Compressor registerer worker buffer count",
-			metrics.UnitDimensionless),
 	}
 }
 
 func (c *compressorMetrics) Measurement(ctx context.Context) ([]metrics.Measurement, error) {
 	return []metrics.Measurement{
-		c.compressorBufferCount.M(int64(c.compressor.WorkerLen())),
+		c.compressorBufferCount.M(int64(c.compressor.Len())),
 		c.registererBufferCount.M(int64(c.registerer.Len())),
-		c.registererWorkerBufferCount.M(int64(c.registerer.WorkerLen())),
 	}, nil
 }
 
@@ -75,12 +70,6 @@ func (c *compressorMetrics) View() []*metrics.View {
 			Name:        "compressor_registerer_buffer_count",
 			Description: "Compressor registerer buffer count",
 			Measure:     &c.registererBufferCount,
-			Aggregation: metrics.LastValue(),
-		},
-		&metrics.View{
-			Name:        "compressor_registerer_worker_buffer_count",
-			Description: "Compressor registerer worker buffer count",
-			Measure:     &c.registererWorkerBufferCount,
 			Aggregation: metrics.LastValue(),
 		},
 	}

--- a/internal/observability/metrics/manager/compressor/compressor.go
+++ b/internal/observability/metrics/manager/compressor/compressor.go
@@ -34,11 +34,20 @@ type compressorMetrics struct {
 
 func New(c service.Compressor, r service.Registerer) metrics.Metric {
 	return &compressorMetrics{
-		compressor:                  c,
-		registerer:                  r,
-		compressorBufferCount:       *metrics.Int64(metrics.ValdOrg+"/manager/compressor/compressor_buffer_count", "Compressor compressor buffer count", metrics.UnitDimensionless),
-		registererBufferCount:       *metrics.Int64(metrics.ValdOrg+"/manager/compressor/registerer_buffer_count", "Compressor registerer buffer count", metrics.UnitDimensionless),
-		registererWorkerBufferCount: *metrics.Int64(metrics.ValdOrg+"/manager/compressor/registerer_worker_buffer_count", "Compressor registerer worker buffer count", metrics.UnitDimensionless),
+		compressor: c,
+		registerer: r,
+		compressorBufferCount: *metrics.Int64(
+			metrics.ValdOrg+"/manager/compressor/compressor_buffer_count",
+			"Compressor compressor buffer count",
+			metrics.UnitDimensionless),
+		registererBufferCount: *metrics.Int64(
+			metrics.ValdOrg+"/manager/compressor/registerer_buffer_count",
+			"Compressor registerer buffer count",
+			metrics.UnitDimensionless),
+		registererWorkerBufferCount: *metrics.Int64(
+			metrics.ValdOrg+"/manager/compressor/registerer_worker_buffer_count",
+			"Compressor registerer worker buffer count",
+			metrics.UnitDimensionless),
 	}
 }
 

--- a/internal/observability/metrics/manager/compressor/compressor.go
+++ b/internal/observability/metrics/manager/compressor/compressor.go
@@ -1,0 +1,78 @@
+//
+// Copyright (C) 2019-2020 Vdaas.org Vald team ( kpango, rinx, kmrmt )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package compressor provides functions for compressor stats
+package compressor
+
+import (
+	"context"
+
+	"github.com/vdaas/vald/internal/observability/metrics"
+	"github.com/vdaas/vald/pkg/manager/compressor/service"
+)
+
+type compressorMetrics struct {
+	compressor                  service.Compressor
+	registerer                  service.Registerer
+	compressorBufferCount       metrics.Int64Measure
+	registererBufferCount       metrics.Int64Measure
+	registererWorkerBufferCount metrics.Int64Measure
+}
+
+func New(c service.Compressor, r service.Registerer) metrics.Metric {
+	return &compressorMetrics{
+		compressor:                  c,
+		registerer:                  r,
+		compressorBufferCount:       *metrics.Int64(metrics.ValdOrg+"/manager/compressor/compressor_buffer_count", "Compressor compressor buffer count", metrics.UnitDimensionless),
+		registererBufferCount:       *metrics.Int64(metrics.ValdOrg+"/manager/compressor/registerer_buffer_count", "Compressor registerer buffer count", metrics.UnitDimensionless),
+		registererWorkerBufferCount: *metrics.Int64(metrics.ValdOrg+"/manager/compressor/registerer_worker_buffer_count", "Compressor registerer worker buffer count", metrics.UnitDimensionless),
+	}
+}
+
+func (c *compressorMetrics) Measurement(ctx context.Context) ([]metrics.Measurement, error) {
+	return []metrics.Measurement{
+		c.compressorBufferCount.M(int64(c.compressor.WorkerLen())),
+		c.registererBufferCount.M(int64(c.registerer.Len())),
+		c.registererWorkerBufferCount.M(int64(c.registerer.WorkerLen())),
+	}, nil
+}
+
+func (c *compressorMetrics) MeasurementWithTags(ctx context.Context) ([]metrics.MeasurementWithTags, error) {
+	return []metrics.MeasurementWithTags{}, nil
+}
+
+func (c *compressorMetrics) View() []*metrics.View {
+	return []*metrics.View{
+		&metrics.View{
+			Name:        "compressor_compressor_buffer_count",
+			Description: "Compressor compressor buffer count",
+			Measure:     &c.compressorBufferCount,
+			Aggregation: metrics.LastValue(),
+		},
+		&metrics.View{
+			Name:        "compressor_registerer_buffer_count",
+			Description: "Compressor registerer buffer count",
+			Measure:     &c.registererBufferCount,
+			Aggregation: metrics.LastValue(),
+		},
+		&metrics.View{
+			Name:        "compressor_registerer_worker_buffer_count",
+			Description: "Compressor registerer worker buffer count",
+			Measure:     &c.registererWorkerBufferCount,
+			Aggregation: metrics.LastValue(),
+		},
+	}
+}

--- a/internal/worker/queue.go
+++ b/internal/worker/queue.go
@@ -71,11 +71,11 @@ func (q *queue) Start(ctx context.Context) {
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
-				case j := <-q.inCh:
-					s = append(s, j)
-					q.qLen.Store(uint64(len(s)))
 				case q.outCh <- j:
 					s = s[1:]
+					q.qLen.Store(uint64(len(s)))
+				case j := <-q.inCh:
+					s = append(s, j)
 					q.qLen.Store(uint64(len(s)))
 				}
 			} else {

--- a/internal/worker/queue.go
+++ b/internal/worker/queue.go
@@ -1,0 +1,101 @@
+//
+// Copyright (C) 2019-2020 Vdaas.org Vald team ( kpango, rinx, kmrmt )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package worker provides worker processes
+package worker
+
+import (
+	"context"
+	"reflect"
+	"sync/atomic"
+
+	"github.com/vdaas/vald/internal/errgroup"
+	"github.com/vdaas/vald/internal/errors"
+	"github.com/vdaas/vald/internal/safety"
+)
+
+type Queue interface {
+	Start(ctx context.Context)
+	InCh() chan<- JobFunc
+	OutCh() <-chan JobFunc
+	Len() uint64
+}
+
+type queue struct {
+	buffer int
+	eg     errgroup.Group
+	inCh   chan JobFunc
+	outCh  chan JobFunc
+	qLen   atomic.Value
+}
+
+func NewQueue(opts ...QueueOption) (Queue, error) {
+	q := new(queue)
+	for _, opt := range append(defaultQueueOpts, opts...) {
+		if err := opt(q); err != nil {
+			return nil, errors.ErrOptionFailed(err, reflect.ValueOf(opt))
+		}
+	}
+
+	q.qLen.Store(uint64(0))
+
+	return q, nil
+}
+
+func (q *queue) Start(ctx context.Context) {
+	q.inCh = make(chan JobFunc, q.buffer)
+	q.outCh = make(chan JobFunc)
+
+	s := make([]JobFunc, 0)
+
+	q.eg.Go(safety.RecoverFunc(func() (err error) {
+		defer close(q.inCh)
+		defer close(q.outCh)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case j := <-q.inCh:
+				s = append(s, j)
+				q.qLen.Store(uint64(len(s)))
+			default:
+			}
+
+			if len(s) > 0 {
+				j := s[0]
+				select {
+				case q.outCh <- j:
+					s = s[1:]
+					q.qLen.Store(uint64(len(s)))
+				default:
+				}
+			}
+		}
+	}))
+}
+
+func (q *queue) InCh() chan<- JobFunc {
+	return q.inCh
+}
+
+func (q *queue) OutCh() <-chan JobFunc {
+	return q.outCh
+}
+
+func (q *queue) Len() uint64 {
+	return q.qLen.Load().(uint64)
+}

--- a/internal/worker/queue_option.go
+++ b/internal/worker/queue_option.go
@@ -1,0 +1,49 @@
+//
+// Copyright (C) 2019-2020 Vdaas.org Vald team ( kpango, rinx, kmrmt )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package worker provides worker processes
+package worker
+
+import (
+	"github.com/vdaas/vald/internal/errgroup"
+)
+
+type QueueOption func(q *queue) error
+
+var (
+	defaultQueueOpts = []QueueOption{
+		WithQueueBuffer(10),
+		WithQueueErrGroup(errgroup.Get()),
+	}
+)
+
+func WithQueueBuffer(buffer int) QueueOption {
+	return func(q *queue) error {
+		if buffer > 0 {
+			q.buffer = buffer
+		}
+		return nil
+	}
+}
+
+func WithQueueErrGroup(eg errgroup.Group) QueueOption {
+	return func(q *queue) error {
+		if eg != nil {
+			q.eg = eg
+		}
+		return nil
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -45,6 +45,7 @@ type Worker interface {
 	IsRunning() bool
 	Name() string
 	Len() uint64
+	Jobs() []*Job
 	Dispatch(ctx context.Context, f *Job) error
 }
 
@@ -166,6 +167,10 @@ func (w *worker) Name() string {
 
 func (w *worker) Len() uint64 {
 	return atomic.LoadUint64(&w.qLen)
+}
+
+func (w *worker) Jobs() []*Job {
+	return w.q
 }
 
 func (w *worker) Dispatch(ctx context.Context, f *Job) error {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -99,15 +99,17 @@ func (w *worker) startJobLoop(ctx context.Context) (<-chan error, error) {
 				}
 				return eg.Wait()
 			case job := <-w.queue.OutCh():
-				eg.Go(safety.RecoverFunc(func() (err error) {
-					defer atomic.AddUint64(&w.completedCount, 1)
-					err = job(ctx)
-					if err != nil {
-						log.Debug(err)
-					}
+				if job != nil {
+					eg.Go(safety.RecoverFunc(func() (err error) {
+						defer atomic.AddUint64(&w.completedCount, 1)
+						err = job(ctx)
+						if err != nil {
+							log.Debug(err)
+						}
 
-					return err
-				}))
+						return err
+					}))
+				}
 			}
 		}
 	}))

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -32,6 +32,7 @@ import (
 type Worker interface {
 	Start(ctx context.Context) <-chan error
 	IsRunning() bool
+	Name() string
 	Dispatch(ctx context.Context, f func() error) error
 }
 
@@ -94,6 +95,10 @@ func (w *worker) Start(ctx context.Context) <-chan error {
 
 func (w *worker) IsRunning() bool {
 	return w.running.Load().(bool)
+}
+
+func (w *worker) Name() string {
+	return w.name
 }
 
 func (w *worker) Dispatch(ctx context.Context, f func() error) error {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -122,7 +122,11 @@ func (w *worker) Dispatch(ctx context.Context, f WorkerJobFunc) error {
 		select {
 		case w.jobCh <- f:
 		default:
-			return errors.ErrWorkerChannelIsFull(w.name)
+			err := errors.ErrWorkerChannelIsFull(w.name)
+			if span != nil {
+				span.SetStatus(trace.StatusCodeUnavailable(err.Error()))
+			}
+			return err
 		}
 	}
 	return nil

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vdaas/vald/internal/errgroup"
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/log"
+	"github.com/vdaas/vald/internal/observability/trace"
 	"github.com/vdaas/vald/internal/safety"
 )
 
@@ -110,6 +111,13 @@ func (w *worker) Len() int {
 }
 
 func (w *worker) Dispatch(ctx context.Context, f WorkerJobFunc) error {
+	ctx, span := trace.StartSpan(ctx, "vald/internal/worker/Worker.Dispatch")
+	defer func() {
+		if span != nil {
+			span.End()
+		}
+	}()
+
 	if f != nil {
 		select {
 		case w.jobCh <- f:

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -93,13 +93,15 @@ func (w *worker) Start(ctx context.Context) <-chan error {
 			case job := <-w.jobCh:
 				w.wg.Add(1)
 				eg.Go(safety.RecoverFunc(func() (err error) {
-					defer w.wg.Done()
 					err = job(ctx)
 					if err != nil {
 						log.Debug(err)
+						w.wg.Done()
 						runtime.Gosched()
 						ech <- err
+						return err
 					}
+					w.wg.Done()
 					return nil
 				}))
 			}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1,0 +1,108 @@
+//
+// Copyright (C) 2019-2020 Vdaas.org Vald team ( kpango, rinx, kmrmt )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package worker provides worker processes
+package worker
+
+import (
+	"context"
+	"reflect"
+	"runtime"
+	"sync/atomic"
+
+	"github.com/vdaas/vald/internal/errgroup"
+	"github.com/vdaas/vald/internal/errors"
+	"github.com/vdaas/vald/internal/log"
+	"github.com/vdaas/vald/internal/safety"
+)
+
+type Worker interface {
+	Start(ctx context.Context) <-chan error
+	IsRunning() bool
+	Dispatch(ctx context.Context, f func() error) error
+}
+
+type worker struct {
+	name       string
+	limitation int
+	buffer     int
+	running    atomic.Value
+	eg         errgroup.Group
+	jobCh      chan func() error
+}
+
+func NewWorker(opts ...WorkerOption) (Worker, error) {
+	w := new(worker)
+	for _, opt := range append(defaultWorkerOpts, opts...) {
+		if err := opt(w); err != nil {
+			return nil, errors.ErrOptionFailed(err, reflect.ValueOf(opt))
+		}
+	}
+	w.running.Store(false)
+
+	return w, nil
+}
+
+func (w *worker) Start(ctx context.Context) <-chan error {
+	ech := make(chan error, 1)
+
+	eg, ctx := errgroup.New(ctx)
+	eg.Limitation(w.limitation)
+
+	w.jobCh = make(chan func() error, w.buffer)
+
+	w.running.Store(true)
+	w.eg.Go(safety.RecoverFunc(func() (err error) {
+		defer close(w.jobCh)
+		for {
+			select {
+			case <-ctx.Done():
+				w.running.Store(false)
+				if err = ctx.Err(); err != nil {
+					return errors.Wrap(eg.Wait(), err.Error())
+				}
+				return eg.Wait()
+			case job := <-w.jobCh:
+				eg.Go(safety.RecoverFunc(func() (err error) {
+					err = job()
+					if err != nil {
+						log.Debug(err)
+						runtime.Gosched()
+						ech <- err
+					}
+					return nil
+				}))
+			}
+		}
+	}))
+
+	return ech
+}
+
+func (w *worker) IsRunning() bool {
+	return w.running.Load().(bool)
+}
+
+func (w *worker) Dispatch(ctx context.Context, f func() error) error {
+	if f != nil {
+		select {
+		case w.jobCh <- f:
+		default:
+			return errors.ErrWorkerChannelIsFull(w.name)
+		}
+	}
+	return nil
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -35,6 +35,7 @@ type Worker interface {
 	Start(ctx context.Context) <-chan error
 	IsRunning() bool
 	Name() string
+	Len() int
 	Dispatch(ctx context.Context, f WorkerJobFunc) error
 }
 
@@ -54,6 +55,7 @@ func NewWorker(opts ...WorkerOption) (Worker, error) {
 			return nil, errors.ErrOptionFailed(err, reflect.ValueOf(opt))
 		}
 	}
+
 	w.running.Store(false)
 
 	return w, nil
@@ -101,6 +103,10 @@ func (w *worker) IsRunning() bool {
 
 func (w *worker) Name() string {
 	return w.name
+}
+
+func (w *worker) Len() int {
+	return len(w.jobCh)
 }
 
 func (w *worker) Dispatch(ctx context.Context, f WorkerJobFunc) error {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -34,6 +34,8 @@ type WorkerJobFunc func(context.Context) error
 
 type Worker interface {
 	Start(ctx context.Context) <-chan error
+	Pause(ctx context.Context)
+	Resume(ctx context.Context)
 	IsRunning() bool
 	Name() string
 	Len() int
@@ -96,6 +98,14 @@ func (w *worker) Start(ctx context.Context) <-chan error {
 	}))
 
 	return ech
+}
+
+func (w *worker) Pause(ctx context.Context) {
+	w.running.Store(false)
+}
+
+func (w *worker) Resume(ctx context.Context) {
+	w.running.Store(true)
 }
 
 func (w *worker) IsRunning() bool {

--- a/internal/worker/worker_option.go
+++ b/internal/worker/worker_option.go
@@ -26,8 +26,7 @@ type WorkerOption func(w *worker) error
 var (
 	defaultWorkerOpts = []WorkerOption{
 		WithName("worker"),
-		WithLimitation(0),
-		WithBuffer(0),
+		WithLimitation(10),
 		WithErrGroup(errgroup.Get()),
 	}
 )
@@ -43,14 +42,9 @@ func WithName(name string) WorkerOption {
 
 func WithLimitation(limit int) WorkerOption {
 	return func(w *worker) error {
-		w.limitation = limit
-		return nil
-	}
-}
-
-func WithBuffer(b int) WorkerOption {
-	return func(w *worker) error {
-		w.buffer = b
+		if limit > 0 {
+			w.limitation = limit
+		}
 		return nil
 	}
 }

--- a/internal/worker/worker_option.go
+++ b/internal/worker/worker_option.go
@@ -27,7 +27,7 @@ var (
 	defaultWorkerOpts = []WorkerOption{
 		WithName("worker"),
 		WithLimitation(0),
-		WithBuffer(10),
+		WithBuffer(0),
 		WithErrGroup(errgroup.Get()),
 	}
 )

--- a/internal/worker/worker_option.go
+++ b/internal/worker/worker_option.go
@@ -14,53 +14,51 @@
 // limitations under the License.
 //
 
-// Package service
-package service
+// Package worker provides worker processes
+package worker
 
 import (
 	"github.com/vdaas/vald/internal/errgroup"
-	"github.com/vdaas/vald/internal/worker"
 )
 
-type CompressorOption func(c *compressor) error
+type WorkerOption func(w *worker) error
 
 var (
-	defaultCompressorOpts = []CompressorOption{
-		WithWorker(),
-		WithCompressAlgorithm("gob"),
+	defaultWorkerOpts = []WorkerOption{
+		WithName("worker"),
+		WithLimitation(0),
+		WithBuffer(10),
 		WithErrGroup(errgroup.Get()),
 	}
 )
 
-func WithCompressAlgorithm(name string) CompressorOption {
-	return func(c *compressor) error {
-		c.algorithm = name
-		return nil
-	}
-}
-
-func WithCompressionLevel(level int) CompressorOption {
-	return func(c *compressor) error {
-		c.compressionLevel = level
-		return nil
-	}
-}
-
-func WithWorker(opts ...worker.WorkerOption) CompressorOption {
-	return func(c *compressor) error {
-		w, err := worker.NewWorker(opts...)
-		if err != nil {
-			return err
+func WithName(name string) WorkerOption {
+	return func(w *worker) error {
+		if name != "" {
+			w.name = name
 		}
-		c.worker = w
 		return nil
 	}
 }
 
-func WithErrGroup(eg errgroup.Group) CompressorOption {
-	return func(c *compressor) error {
+func WithLimitation(limit int) WorkerOption {
+	return func(w *worker) error {
+		w.limitation = limit
+		return nil
+	}
+}
+
+func WithBuffer(b int) WorkerOption {
+	return func(w *worker) error {
+		w.buffer = b
+		return nil
+	}
+}
+
+func WithErrGroup(eg errgroup.Group) WorkerOption {
+	return func(w *worker) error {
 		if eg != nil {
-			c.eg = eg
+			w.eg = eg
 		}
 		return nil
 	}

--- a/k8s/operator/helm/valdrelease.yaml
+++ b/k8s/operator/helm/valdrelease.yaml
@@ -20,5 +20,4 @@ metadata:
   name: vald-cluster
   namespace: default
 # the values of Helm chart for Vald can be placed under the `spec` field.
-spec:
-  {}
+spec: {}

--- a/pkg/manager/compressor/config/config.go
+++ b/pkg/manager/compressor/config/config.go
@@ -39,6 +39,9 @@ type Data struct {
 
 	// Compressor represent compressor configuration
 	Compressor *config.Compressor `json:"compressor" yaml:"compressor"`
+
+	// Registerer represent registerer configuration
+	Registerer *config.CompressorRegisterer `json:"registerer" yaml:"registerer"`
 }
 
 func NewConfig(path string) (cfg *Data, err error) {
@@ -66,6 +69,10 @@ func NewConfig(path string) (cfg *Data, err error) {
 
 	if cfg.Compressor != nil {
 		cfg.Compressor = cfg.Compressor.Bind()
+	}
+
+	if cfg.Registerer != nil {
+		cfg.Registerer = cfg.Registerer.Bind()
 	}
 
 	return cfg, nil

--- a/pkg/manager/compressor/handler/grpc/handler.go
+++ b/pkg/manager/compressor/handler/grpc/handler.go
@@ -35,6 +35,7 @@ type Server compressor.BackupServer
 type server struct {
 	backup     service.Backup
 	compressor service.Compressor
+	registerer service.Registerer
 }
 
 func New(opts ...Option) Server {
@@ -109,30 +110,14 @@ func (s *server) Register(ctx context.Context, meta *payload.Backup_MetaVector) 
 			span.End()
 		}
 	}()
-	uuid := meta.GetUuid()
-	vector, err := s.compressor.Compress(ctx, meta.GetVector())
+
+	err = s.registerer.Register(ctx, meta)
 	if err != nil {
-		log.Errorf("[Register]\tcompress returns unknown error\t%+v", err)
+		log.Errorf("[Register]\tregisterer returns error\t%+v", err)
 		if span != nil {
 			span.SetStatus(trace.StatusCodeInternal(err.Error()))
 		}
-		return nil, status.WrapWithInternal(fmt.Sprintf("Register API uuid %s's could not compress", uuid), err, info.Get())
-	}
-
-	mvec := &payload.Backup_Compressed_MetaVector{
-		Uuid:   meta.GetUuid(),
-		Meta:   meta.GetMeta(),
-		Vector: vector,
-		Ips:    meta.GetIps(),
-	}
-
-	err = s.backup.Register(ctx, mvec)
-	if err != nil {
-		log.Errorf("[Register]\tbackup returns unknown error\t%+v", err)
-		if span != nil {
-			span.SetStatus(trace.StatusCodeInternal(err.Error()))
-		}
-		return nil, status.WrapWithInternal(fmt.Sprintf("Register API uuid %s's could not register %#v", uuid, mvec), err, info.Get())
+		return nil, status.WrapWithInternal(fmt.Sprintf("Register API uuid %s could not processed", meta.GetUuid()), err, info.Get())
 	}
 
 	return new(payload.Empty), nil
@@ -145,48 +130,14 @@ func (s *server) RegisterMulti(ctx context.Context, metas *payload.Backup_MetaVe
 			span.End()
 		}
 	}()
-	mvs := metas.GetVectors()
-	vectors := make([][]float32, 0, len(mvs))
-	for _, mv := range mvs {
-		vectors = append(vectors, mv.GetVector())
-	}
 
-	compressedVecs, err := s.compressor.MultiCompress(ctx, vectors)
+	err = s.registerer.RegisterMulti(ctx, metas)
 	if err != nil {
-		log.Errorf("[RegisterMulti]\tinternal error\t%+v", err)
-		uuids := make([]string, 0, len(mvs))
-		for _, mv := range mvs {
-			uuids = append(uuids, mv.GetUuid())
-		}
+		log.Errorf("[RegisterMulti]\tregisterer returns error\t%+v", err)
 		if span != nil {
 			span.SetStatus(trace.StatusCodeInternal(err.Error()))
 		}
-		return nil, status.WrapWithInternal(fmt.Sprintf("RegisterMulti API uuids %#v's could not compress", uuids), err, info.Get())
-	}
-
-	compressedMVs := make([]*payload.Backup_Compressed_MetaVector, 0, len(mvs))
-	for i, mv := range mvs {
-		compressedMVs = append(compressedMVs, &payload.Backup_Compressed_MetaVector{
-			Uuid:   mv.GetUuid(),
-			Meta:   mv.GetMeta(),
-			Vector: compressedVecs[i],
-			Ips:    mv.GetIps(),
-		})
-	}
-
-	err = s.backup.RegisterMultiple(ctx, &payload.Backup_Compressed_MetaVectors{
-		Vectors: compressedMVs,
-	})
-	if err != nil {
-		log.Errorf("[RegisterMulti]\tunknown error\t%+v", err)
-		uuids := make([]string, 0, len(mvs))
-		for _, mv := range mvs {
-			uuids = append(uuids, mv.GetUuid())
-		}
-		if span != nil {
-			span.SetStatus(trace.StatusCodeInternal(err.Error()))
-		}
-		return nil, status.WrapWithInternal(fmt.Sprintf("RegisterMulti API uuids %#v's could not register %#v", uuids, compressedMVs), err, info.Get())
+		return nil, status.WrapWithInternal("RegisterMulti API could not processed", err, info.Get())
 	}
 
 	return new(payload.Empty), nil

--- a/pkg/manager/compressor/handler/grpc/handler.go
+++ b/pkg/manager/compressor/handler/grpc/handler.go
@@ -117,7 +117,8 @@ func (s *server) Register(ctx context.Context, meta *payload.Backup_MetaVector) 
 		if span != nil {
 			span.SetStatus(trace.StatusCodeInternal(err.Error()))
 		}
-		return nil, status.WrapWithInternal(fmt.Sprintf("Register API uuid %s could not processed", meta.GetUuid()), err, info.Get())
+		return nil, status.WrapWithInternal(
+			fmt.Sprintf("Register API uuid %s could not processed", meta.GetUuid()), err, info.Get())
 	}
 
 	return new(payload.Empty), nil

--- a/pkg/manager/compressor/handler/grpc/option.go
+++ b/pkg/manager/compressor/handler/grpc/option.go
@@ -31,8 +31,14 @@ func WithCompressor(c service.Compressor) Option {
 	}
 }
 
-func WithBackup(c service.Backup) Option {
+func WithBackup(b service.Backup) Option {
 	return func(s *server) {
-		s.backup = c
+		s.backup = b
+	}
+}
+
+func WithRegisterer(r service.Registerer) Option {
+	return func(s *server) {
+		s.registerer = r
 	}
 }

--- a/pkg/manager/compressor/service/compress.go
+++ b/pkg/manager/compressor/service/compress.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vdaas/vald/internal/config"
 	"github.com/vdaas/vald/internal/errgroup"
 	"github.com/vdaas/vald/internal/errors"
+	"github.com/vdaas/vald/internal/observability/trace"
 	"github.com/vdaas/vald/internal/safety"
 	"github.com/vdaas/vald/internal/worker"
 )
@@ -101,6 +102,13 @@ func (c *compressor) Start(ctx context.Context) <-chan error {
 }
 
 func (c *compressor) dispatchCompress(ctx context.Context, vectors ...[]float32) (results [][]byte, errs error) {
+	ctx, span := trace.StartSpan(ctx, "vald/manager-compressor/service/Compressor.dispatchCompress")
+	defer func() {
+		if span != nil {
+			span.End()
+		}
+	}()
+
 	results = make([][]byte, len(vectors))
 
 	mu := new(sync.Mutex)
@@ -159,6 +167,13 @@ func (c *compressor) dispatchCompress(ctx context.Context, vectors ...[]float32)
 }
 
 func (c *compressor) dispatchDecompress(ctx context.Context, bytess ...[]byte) (results [][]float32, errs error) {
+	ctx, span := trace.StartSpan(ctx, "vald/manager-compressor/service/Compressor.dispatchDecompress")
+	defer func() {
+		if span != nil {
+			span.End()
+		}
+	}()
+
 	results = make([][]float32, len(bytess))
 
 	mu := new(sync.Mutex)
@@ -217,6 +232,13 @@ func (c *compressor) dispatchDecompress(ctx context.Context, bytess ...[]byte) (
 }
 
 func (c *compressor) Compress(ctx context.Context, vector []float32) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "vald/manager-compressor/service/Compressor.Compress")
+	defer func() {
+		if span != nil {
+			span.End()
+		}
+	}()
+
 	ress, err := c.dispatchCompress(ctx, vector)
 	if err != nil {
 		return nil, err
@@ -229,6 +251,13 @@ func (c *compressor) Compress(ctx context.Context, vector []float32) ([]byte, er
 }
 
 func (c *compressor) Decompress(ctx context.Context, bytes []byte) ([]float32, error) {
+	ctx, span := trace.StartSpan(ctx, "vald/manager-compressor/service/Compressor.Decompress")
+	defer func() {
+		if span != nil {
+			span.End()
+		}
+	}()
+
 	ress, err := c.dispatchDecompress(ctx, bytes)
 	if err != nil {
 		return nil, err
@@ -241,9 +270,23 @@ func (c *compressor) Decompress(ctx context.Context, bytes []byte) ([]float32, e
 }
 
 func (c *compressor) MultiCompress(ctx context.Context, vectors [][]float32) ([][]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "vald/manager-compressor/service/Compressor.MultiCompress")
+	defer func() {
+		if span != nil {
+			span.End()
+		}
+	}()
+
 	return c.dispatchCompress(ctx, vectors...)
 }
 
 func (c *compressor) MultiDecompress(ctx context.Context, bytess [][]byte) ([][]float32, error) {
+	ctx, span := trace.StartSpan(ctx, "vald/manager-compressor/service/Compressor.MultiDecompress")
+	defer func() {
+		if span != nil {
+			span.End()
+		}
+	}()
+
 	return c.dispatchDecompress(ctx, bytess...)
 }

--- a/pkg/manager/compressor/service/compress.go
+++ b/pkg/manager/compressor/service/compress.go
@@ -120,8 +120,8 @@ func (c *compressor) dispatchCompress(ctx context.Context, vectors ...[]float32)
 
 		for iter, vector := range vectors {
 			wg.Add(1)
-			err := c.worker.Dispatch(ctx, func(i int, v []float32) *worker.Job {
-				f := func(ctx context.Context) error {
+			err := c.worker.Dispatch(ctx, func(i int, v []float32) worker.JobFunc {
+				return func(ctx context.Context) error {
 					defer wg.Done()
 
 					select {
@@ -143,11 +143,6 @@ func (c *compressor) dispatchCompress(ctx context.Context, vectors ...[]float32)
 					mu.Unlock()
 
 					return nil
-				}
-
-				return &worker.Job{
-					Fn:   f,
-					Data: vector,
 				}
 			}(iter, vector))
 			if err != nil {
@@ -188,8 +183,8 @@ func (c *compressor) dispatchDecompress(ctx context.Context, bytess ...[]byte) (
 
 		for iter, bytes := range bytess {
 			wg.Add(1)
-			err := c.worker.Dispatch(ctx, func(i int, b []byte) *worker.Job {
-				f := func(ctx context.Context) error {
+			err := c.worker.Dispatch(ctx, func(i int, b []byte) worker.JobFunc {
+				return func(ctx context.Context) error {
 					defer wg.Done()
 
 					select {
@@ -211,11 +206,6 @@ func (c *compressor) dispatchDecompress(ctx context.Context, bytess ...[]byte) (
 					mu.Unlock()
 
 					return nil
-				}
-
-				return &worker.Job{
-					Fn:   f,
-					Data: bytes,
 				}
 			}(iter, bytes))
 			if err != nil {

--- a/pkg/manager/compressor/service/compress.go
+++ b/pkg/manager/compressor/service/compress.go
@@ -37,6 +37,7 @@ type Compressor interface {
 	Decompress(ctx context.Context, bytes []byte) ([]float32, error)
 	MultiCompress(ctx context.Context, vectors [][]float32) ([][]byte, error)
 	MultiDecompress(ctx context.Context, bytess [][]byte) ([][]float32, error)
+	WorkerLen() int
 }
 
 type compressor struct {
@@ -319,4 +320,8 @@ func (c *compressor) MultiDecompress(ctx context.Context, bytess [][]byte) ([][]
 	}
 
 	return vectors, err
+}
+
+func (c *compressor) WorkerLen() int {
+	return c.worker.Len()
 }

--- a/pkg/manager/compressor/service/compress.go
+++ b/pkg/manager/compressor/service/compress.go
@@ -38,6 +38,8 @@ type Compressor interface {
 	MultiCompress(ctx context.Context, vectors [][]float32) ([][]byte, error)
 	MultiDecompress(ctx context.Context, bytess [][]byte) ([][]float32, error)
 	Len() uint64
+	TotalRequested() uint64
+	TotalCompleted() uint64
 }
 
 type compressor struct {
@@ -320,4 +322,12 @@ func (c *compressor) MultiDecompress(ctx context.Context, bytess [][]byte) ([][]
 
 func (c *compressor) Len() uint64 {
 	return c.worker.Len()
+}
+
+func (c *compressor) TotalRequested() uint64 {
+	return c.worker.TotalRequested()
+}
+
+func (c *compressor) TotalCompleted() uint64 {
+	return c.worker.TotalCompleted()
 }

--- a/pkg/manager/compressor/service/compress_option.go
+++ b/pkg/manager/compressor/service/compress_option.go
@@ -48,11 +48,7 @@ func WithCompressionLevel(level int) CompressorOption {
 
 func WithCompressorWorker(opts ...worker.WorkerOption) CompressorOption {
 	return func(c *compressor) error {
-		w, err := worker.NewWorker(opts...)
-		if err != nil {
-			return err
-		}
-		c.worker = w
+		c.workerOpts = opts
 		return nil
 	}
 }

--- a/pkg/manager/compressor/service/registerer.go
+++ b/pkg/manager/compressor/service/registerer.go
@@ -1,0 +1,97 @@
+//
+// Copyright (C) 2019-2020 Vdaas.org Vald team ( kpango, rinx, kmrmt )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package service
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/vdaas/vald/apis/grpc/payload"
+	"github.com/vdaas/vald/internal/errgroup"
+	"github.com/vdaas/vald/internal/errors"
+	"github.com/vdaas/vald/internal/worker"
+)
+
+type Registerer interface {
+	Start(ctx context.Context) <-chan error
+	PreStop(ctx context.Context) error
+	Register(ctx context.Context, meta *payload.Backup_MetaVector) error
+	RegisterMulti(ctx context.Context, metas *payload.Backup_MetaVectors) error
+}
+
+type registerer struct {
+	worker     worker.Worker
+	eg         errgroup.Group
+	backup     Backup
+	compressor Compressor
+}
+
+func NewRegisterer(opts ...RegistererOption) (Registerer, error) {
+	r := new(registerer)
+	for _, opt := range append(defaultRegistererOpts, opts...) {
+		if err := opt(r); err != nil {
+			return nil, errors.ErrOptionFailed(err, reflect.ValueOf(opt))
+		}
+	}
+
+	return r, nil
+}
+
+func (r *registerer) Start(ctx context.Context) <-chan error {
+	return r.worker.Start(ctx)
+}
+
+func (r *registerer) PreStop(ctx context.Context) error {
+	// TODO backup all index data here
+	return nil
+}
+
+func (r *registerer) Register(ctx context.Context, meta *payload.Backup_MetaVector) error {
+	if !r.worker.IsRunning() {
+		return errors.ErrWorkerIsNotRunning(r.worker.Name())
+	}
+
+	return r.worker.Dispatch(ctx, func() error {
+		// TODO use parent ctx
+		ctx := context.Background()
+		vector, err := r.compressor.Compress(ctx, meta.GetVector())
+		if err != nil {
+			return err
+		}
+
+		return r.backup.Register(
+			ctx,
+			&payload.Backup_Compressed_MetaVector{
+				Uuid:   meta.GetUuid(),
+				Meta:   meta.GetMeta(),
+				Vector: vector,
+				Ips:    meta.GetIps(),
+			},
+		)
+	})
+}
+
+func (r *registerer) RegisterMulti(ctx context.Context, metas *payload.Backup_MetaVectors) error {
+	var err, errs error
+	for _, meta := range metas.GetVectors() {
+		err = r.Register(ctx, meta)
+		if err != nil {
+			errs = errors.Wrap(errs, err.Error())
+		}
+	}
+	return errs
+}

--- a/pkg/manager/compressor/service/registerer.go
+++ b/pkg/manager/compressor/service/registerer.go
@@ -48,7 +48,6 @@ type registerer struct {
 	eg         errgroup.Group
 	backup     Backup
 	compressor Compressor
-	addr       string
 	client     client.Client
 	metas      map[string]*payload.Backup_MetaVector
 	metasMux   sync.Mutex

--- a/pkg/manager/compressor/service/registerer.go
+++ b/pkg/manager/compressor/service/registerer.go
@@ -118,7 +118,6 @@ func (r *registerer) PreStop(ctx context.Context) error {
 	r.running.Store(false)
 
 	r.worker.Pause()
-	r.worker.Wait()
 
 	err := r.forwardMetas(ctx)
 	if err != nil {

--- a/pkg/manager/compressor/service/registerer.go
+++ b/pkg/manager/compressor/service/registerer.go
@@ -306,7 +306,7 @@ func (r *registerer) forwardMetas(ctx context.Context) (errs error) {
 		}
 	}()
 
-	return
+	return errs
 }
 
 func (r *registerer) Len() int {

--- a/pkg/manager/compressor/service/registerer.go
+++ b/pkg/manager/compressor/service/registerer.go
@@ -208,8 +208,6 @@ func (r *registerer) registerProcessFunc(meta *payload.Backup_MetaVector) *worke
 
 		vector, err = r.compressor.Compress(ctx, meta.GetVector())
 		if err != nil {
-			log.Debugf("re-enqueueing uuid %s", meta.GetUuid())
-
 			if span != nil {
 				span.SetStatus(trace.StatusCodeInternal(err.Error()))
 			}
@@ -227,8 +225,6 @@ func (r *registerer) registerProcessFunc(meta *payload.Backup_MetaVector) *worke
 			},
 		)
 		if err != nil {
-			log.Debugf("re-enqueueing uuid %s", meta.GetUuid())
-
 			if span != nil {
 				span.SetStatus(trace.StatusCodeInternal(err.Error()))
 			}
@@ -238,8 +234,9 @@ func (r *registerer) registerProcessFunc(meta *payload.Backup_MetaVector) *worke
 	}
 
 	return &worker.Job{
-		Fn:   f,
-		Data: meta,
+		Fn:    f,
+		Data:  meta,
+		Retry: true,
 	}
 }
 

--- a/pkg/manager/compressor/service/registerer.go
+++ b/pkg/manager/compressor/service/registerer.go
@@ -125,9 +125,14 @@ func (r *registerer) PreStop(ctx context.Context) error {
 	log.Info("compressor registerer service prestop processing...")
 
 	r.running.Store(false)
-	r.worker.Pause(ctx)
+	err := r.worker.PreStop(ctx)
+	if err != nil {
+		return err
+	}
 
-	err := r.forwardMetas(ctx)
+	r.worker.Wait()
+
+	err = r.forwardMetas(ctx)
 	if err != nil {
 		log.Errorf("compressor registerer service prestop failed: %v", err)
 		return err

--- a/pkg/manager/compressor/service/registerer.go
+++ b/pkg/manager/compressor/service/registerer.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"runtime"
 	"sync/atomic"
@@ -234,6 +235,7 @@ func (r *registerer) registerProcessFunc(meta *payload.Backup_MetaVector) *worke
 	}
 
 	return &worker.Job{
+		Name:  fmt.Sprintf("registering uuid %s", meta.GetUuid()),
 		Fn:    f,
 		Data:  meta,
 		Retry: true,

--- a/pkg/manager/compressor/service/registerer.go
+++ b/pkg/manager/compressor/service/registerer.go
@@ -321,6 +321,8 @@ func (r *registerer) registerJob(meta *payload.Backup_MetaVector) worker.WorkerJ
 func (r *registerer) forwardMetas(ctx context.Context) (errs error) {
 	var err error
 
+	log.Debugf("compressor registerer queued meta-vector count: %s", r.Len())
+
 	func() {
 		for {
 			select {

--- a/pkg/manager/compressor/service/registerer.go
+++ b/pkg/manager/compressor/service/registerer.go
@@ -41,6 +41,8 @@ type Registerer interface {
 	Register(ctx context.Context, meta *payload.Backup_MetaVector) error
 	RegisterMulti(ctx context.Context, metas *payload.Backup_MetaVectors) error
 	Len() uint64
+	TotalRequested() uint64
+	TotalCompleted() uint64
 }
 
 type registerer struct {
@@ -171,6 +173,14 @@ func (r *registerer) RegisterMulti(ctx context.Context, metas *payload.Backup_Me
 
 func (r *registerer) Len() uint64 {
 	return r.worker.Len()
+}
+
+func (r *registerer) TotalRequested() uint64 {
+	return r.worker.TotalRequested()
+}
+
+func (r *registerer) TotalCompleted() uint64 {
+	return r.worker.TotalCompleted()
 }
 
 func (r *registerer) startConnectionMonitor(ctx context.Context) <-chan error {

--- a/pkg/manager/compressor/service/registerer.go
+++ b/pkg/manager/compressor/service/registerer.go
@@ -314,6 +314,7 @@ func (r *registerer) forwardMetas(ctx context.Context) (errs error) {
 				if !ok {
 					return
 				}
+				log.Debugf("forwarding uuid %s", v.GetUuid())
 				_, err = r.client.Do(
 					ctx,
 					r.addr,

--- a/pkg/manager/compressor/service/registerer.go
+++ b/pkg/manager/compressor/service/registerer.go
@@ -245,13 +245,14 @@ func (r *registerer) registerProcessFunc(meta *payload.Backup_MetaVector) *worke
 
 func (r *registerer) forwardMetas(ctx context.Context) (errs error) {
 	var err error
+	var meta *payload.Backup_MetaVector
 
-	log.Debugf("compressor registerer queued meta-vector count: %d", r.Len())
+	jobs := r.worker.Jobs()
+	log.Debugf("compressor registerer queued meta-vector count: %d", len(jobs))
 
-	// TODO read all metas from worker queue
-	var metas []*payload.Backup_MetaVector
+	for _, job := range jobs {
+		meta = job.Data.(*payload.Backup_MetaVector)
 
-	for _, meta := range metas {
 		log.Debugf("forwarding uuid %s", meta.GetUuid())
 
 		_, err = r.client.Do(

--- a/pkg/manager/compressor/service/registerer_option.go
+++ b/pkg/manager/compressor/service/registerer_option.go
@@ -33,11 +33,7 @@ var (
 
 func WithRegistererWorker(opts ...worker.WorkerOption) RegistererOption {
 	return func(r *registerer) error {
-		w, err := worker.NewWorker(opts...)
-		if err != nil {
-			return err
-		}
-		r.worker = w
+		r.workerOpts = opts
 		return nil
 	}
 }

--- a/pkg/manager/compressor/service/registerer_option.go
+++ b/pkg/manager/compressor/service/registerer_option.go
@@ -18,8 +18,8 @@
 package service
 
 import (
+	client "github.com/vdaas/vald/internal/client/compressor"
 	"github.com/vdaas/vald/internal/errgroup"
-	"github.com/vdaas/vald/internal/net/grpc"
 	"github.com/vdaas/vald/internal/worker"
 )
 
@@ -66,14 +66,7 @@ func WithRegistererCompressor(c Compressor) RegistererOption {
 	}
 }
 
-func WithRegistererAddr(addr string) RegistererOption {
-	return func(r *registerer) error {
-		r.addr = addr
-		return nil
-	}
-}
-
-func WithRegistererClient(c grpc.Client) RegistererOption {
+func WithRegistererClient(c client.Client) RegistererOption {
 	return func(r *registerer) error {
 		if c != nil {
 			r.client = c

--- a/pkg/manager/compressor/service/registerer_option.go
+++ b/pkg/manager/compressor/service/registerer_option.go
@@ -19,9 +19,9 @@ package service
 
 import (
 	"github.com/vdaas/vald/internal/backoff"
-	"github.com/vdaas/vald/internal/client/discoverer"
 	"github.com/vdaas/vald/internal/config"
 	"github.com/vdaas/vald/internal/errgroup"
+	"github.com/vdaas/vald/internal/net/grpc"
 	"github.com/vdaas/vald/internal/worker"
 )
 
@@ -78,7 +78,14 @@ func WithRegistererCompressor(c Compressor) RegistererOption {
 	}
 }
 
-func WithRegistererDiscoverer(c discoverer.Client) RegistererOption {
+func WithRegistererAddr(addr string) RegistererOption {
+	return func(r *registerer) error {
+		r.addr = addr
+		return nil
+	}
+}
+
+func WithRegistererClient(c grpc.Client) RegistererOption {
 	return func(r *registerer) error {
 		if c != nil {
 			r.client = c

--- a/pkg/manager/compressor/service/registerer_option.go
+++ b/pkg/manager/compressor/service/registerer_option.go
@@ -22,45 +22,48 @@ import (
 	"github.com/vdaas/vald/internal/worker"
 )
 
-type CompressorOption func(c *compressor) error
+type RegistererOption func(r *registerer) error
 
 var (
-	defaultCompressorOpts = []CompressorOption{
-		WithCompressorWorker(),
-		WithCompressAlgorithm("gob"),
-		WithCompressorErrGroup(errgroup.Get()),
+	defaultRegistererOpts = []RegistererOption{
+		WithRegistererWorker(),
+		WithRegistererErrGroup(errgroup.Get()),
 	}
 )
 
-func WithCompressAlgorithm(name string) CompressorOption {
-	return func(c *compressor) error {
-		c.algorithm = name
-		return nil
-	}
-}
-
-func WithCompressionLevel(level int) CompressorOption {
-	return func(c *compressor) error {
-		c.compressionLevel = level
-		return nil
-	}
-}
-
-func WithCompressorWorker(opts ...worker.WorkerOption) CompressorOption {
-	return func(c *compressor) error {
+func WithRegistererWorker(opts ...worker.WorkerOption) RegistererOption {
+	return func(r *registerer) error {
 		w, err := worker.NewWorker(opts...)
 		if err != nil {
 			return err
 		}
-		c.worker = w
+		r.worker = w
 		return nil
 	}
 }
 
-func WithCompressorErrGroup(eg errgroup.Group) CompressorOption {
-	return func(c *compressor) error {
+func WithRegistererErrGroup(eg errgroup.Group) RegistererOption {
+	return func(r *registerer) error {
 		if eg != nil {
-			c.eg = eg
+			r.eg = eg
+		}
+		return nil
+	}
+}
+
+func WithRegistererBackup(b Backup) RegistererOption {
+	return func(r *registerer) error {
+		if b != nil {
+			r.backup = b
+		}
+		return nil
+	}
+}
+
+func WithRegistererCompressor(c Compressor) RegistererOption {
+	return func(r *registerer) error {
+		if c != nil {
+			r.compressor = c
 		}
 		return nil
 	}

--- a/pkg/manager/compressor/service/registerer_option.go
+++ b/pkg/manager/compressor/service/registerer_option.go
@@ -18,8 +18,6 @@
 package service
 
 import (
-	"github.com/vdaas/vald/internal/backoff"
-	"github.com/vdaas/vald/internal/config"
 	"github.com/vdaas/vald/internal/errgroup"
 	"github.com/vdaas/vald/internal/net/grpc"
 	"github.com/vdaas/vald/internal/worker"
@@ -31,7 +29,6 @@ var (
 	defaultRegistererOpts = []RegistererOption{
 		WithRegistererWorker(),
 		WithRegistererErrGroup(errgroup.Get()),
-		WithRegistererBuffer(100),
 	}
 )
 
@@ -46,15 +43,6 @@ func WithRegistererErrGroup(eg errgroup.Group) RegistererOption {
 	return func(r *registerer) error {
 		if eg != nil {
 			r.eg = eg
-		}
-		return nil
-	}
-}
-
-func WithRegistererBuffer(buffer int) RegistererOption {
-	return func(r *registerer) error {
-		if buffer > 0 {
-			r.buffer = buffer
 		}
 		return nil
 	}
@@ -89,17 +77,6 @@ func WithRegistererClient(c grpc.Client) RegistererOption {
 	return func(r *registerer) error {
 		if c != nil {
 			r.client = c
-		}
-		return nil
-	}
-}
-
-func WithRegistererBackoff(cfg *config.Backoff) RegistererOption {
-	return func(r *registerer) error {
-		if cfg != nil &&
-			len(cfg.InitialDuration) != 0 &&
-			cfg.RetryCount > 2 {
-			r.backoff = backoff.New(cfg.Opts()...)
 		}
 		return nil
 	}

--- a/pkg/manager/compressor/usecase/compressord.go
+++ b/pkg/manager/compressor/usecase/compressord.go
@@ -194,8 +194,10 @@ func (r *run) PreStart(ctx context.Context) error {
 
 func (r *run) Start(ctx context.Context) (<-chan error, error) {
 	ech := make(chan error, 5)
+
 	var bech, cech, rech, sech, oech <-chan error
 	var err error
+
 	if r.observability != nil {
 		oech = r.observability.Start(ctx)
 	}

--- a/pkg/manager/compressor/usecase/compressord.go
+++ b/pkg/manager/compressor/usecase/compressord.go
@@ -178,17 +178,21 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 
 func (r *run) PreStart(ctx context.Context) error {
 	log.Info("daemon pre-start")
+
 	err := r.compressor.PreStart(ctx)
 	if err != nil {
 		return err
 	}
+
 	err = r.registerer.PreStart(ctx)
 	if err != nil {
 		return err
 	}
+
 	if r.observability != nil {
 		return r.observability.PreStart(ctx)
 	}
+
 	return nil
 }
 
@@ -201,6 +205,7 @@ func (r *run) Start(ctx context.Context) (<-chan error, error) {
 	if r.observability != nil {
 		oech = r.observability.Start(ctx)
 	}
+
 	if r.backup != nil {
 		bech, err = r.backup.Start(ctx)
 		if err != nil {
@@ -208,13 +213,17 @@ func (r *run) Start(ctx context.Context) (<-chan error, error) {
 			return nil, err
 		}
 	}
+
 	if r.compressor != nil {
 		cech = r.compressor.Start(ctx)
 	}
+
 	if r.registerer != nil {
 		rech = r.registerer.Start(ctx)
 	}
+
 	sech = r.server.ListenAndServe(ctx)
+
 	r.eg.Go(safety.RecoverFunc(func() (err error) {
 		log.Info("daemon start")
 		defer close(ech)

--- a/pkg/manager/compressor/usecase/compressord.go
+++ b/pkg/manager/compressor/usecase/compressord.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vdaas/vald/internal/net/grpc"
 	"github.com/vdaas/vald/internal/net/grpc/metric"
 	"github.com/vdaas/vald/internal/observability"
+	compressormetrics "github.com/vdaas/vald/internal/observability/metrics/manager/compressor"
 	"github.com/vdaas/vald/internal/runner"
 	"github.com/vdaas/vald/internal/safety"
 	"github.com/vdaas/vald/internal/servers/server"
@@ -180,7 +181,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 
 	var obs observability.Observability
 	if cfg.Observability.Enabled {
-		obs, err = observability.NewWithConfig(cfg.Observability)
+		obs, err = observability.NewWithConfig(
+			cfg.Observability,
+			compressormetrics.New(c, rg),
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/manager/compressor/usecase/compressord.go
+++ b/pkg/manager/compressor/usecase/compressord.go
@@ -84,7 +84,6 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 			worker.WithName("compressor"),
 			worker.WithLimitation(cfg.Compressor.ConcurrentLimit),
 			worker.WithBuffer(cfg.Compressor.Buffer),
-			worker.WithErrGroup(eg),
 		),
 		service.WithCompressorErrGroup(eg),
 	)
@@ -97,7 +96,6 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 			worker.WithName("registerer"),
 			worker.WithLimitation(cfg.Compressor.ConcurrentLimit),
 			worker.WithBuffer(cfg.Compressor.Buffer),
-			worker.WithErrGroup(eg),
 		),
 		service.WithRegistererErrGroup(eg),
 		service.WithRegistererBackup(b),
@@ -181,6 +179,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 func (r *run) PreStart(ctx context.Context) error {
 	log.Info("daemon pre-start")
 	err := r.compressor.PreStart(ctx)
+	if err != nil {
+		return err
+	}
+	err = r.registerer.PreStart(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/manager/compressor/usecase/compressord.go
+++ b/pkg/manager/compressor/usecase/compressord.go
@@ -120,7 +120,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 			cfg.Compressor.Discoverer.Port,
 		),
 		discoverer.WithDiscoverDuration(cfg.Compressor.Discoverer.Duration),
-		discoverer.WithOptions(cfg.Compressor.Discoverer.Client.Opts()...),
+		discoverer.WithOptions(cfg.Compressor.Discoverer.AgentClient.Opts()...),
 		discoverer.WithNodeName(cfg.Compressor.NodeName),
 		discoverer.WithOnDiscoverFunc(func(ctx context.Context, c discoverer.Client, addrs []string) error {
 			for i, addr := range addrs {

--- a/pkg/manager/compressor/usecase/compressord.go
+++ b/pkg/manager/compressor/usecase/compressord.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vdaas/vald/internal/safety"
 	"github.com/vdaas/vald/internal/servers/server"
 	"github.com/vdaas/vald/internal/servers/starter"
+	"github.com/vdaas/vald/internal/worker"
 	"github.com/vdaas/vald/pkg/manager/compressor/config"
 	handler "github.com/vdaas/vald/pkg/manager/compressor/handler/grpc"
 	"github.com/vdaas/vald/pkg/manager/compressor/handler/rest"
@@ -78,8 +79,11 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	c, err := service.NewCompressor(
 		service.WithCompressAlgorithm(cfg.Compressor.CompressAlgorithm),
 		service.WithCompressionLevel(cfg.Compressor.CompressionLevel),
-		service.WithLimitation(cfg.Compressor.ConcurrentLimit),
-		service.WithBuffer(cfg.Compressor.Buffer),
+		service.WithWorker(
+			worker.WithName("compressor"),
+			worker.WithLimitation(cfg.Compressor.ConcurrentLimit),
+			worker.WithBuffer(cfg.Compressor.Buffer),
+		),
 		service.WithErrGroup(eg),
 	)
 	if err != nil {

--- a/pkg/manager/compressor/usecase/compressord.go
+++ b/pkg/manager/compressor/usecase/compressord.go
@@ -92,7 +92,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	}
 
 	compressorClientOptions := append(
-		cfg.Compressor.Registerer.Compressor.Client.Opts(),
+		cfg.Registerer.Compressor.Client.Opts(),
 		grpc.WithErrGroup(eg),
 	)
 
@@ -108,12 +108,12 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	rg, err := service.NewRegisterer(
 		service.WithRegistererWorker(
 			worker.WithName("registerer"),
-			worker.WithLimitation(cfg.Compressor.Registerer.Worker.ConcurrentLimit),
+			worker.WithLimitation(cfg.Registerer.ConcurrentLimit),
 		),
 		service.WithRegistererErrGroup(eg),
 		service.WithRegistererBackup(b),
 		service.WithRegistererCompressor(c),
-		service.WithRegistererAddr(cfg.Compressor.Registerer.Compressor.Client.Addrs[0]),
+		service.WithRegistererAddr(cfg.Registerer.Compressor.Client.Addrs[0]),
 		service.WithRegistererClient(grpc.New(compressorClientOptions...)),
 	)
 	if err != nil {

--- a/pkg/manager/compressor/usecase/compressord.go
+++ b/pkg/manager/compressor/usecase/compressord.go
@@ -128,7 +128,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 					return err
 				}
 
-				if host == cfg.Compressor.PodName {
+				if host == cfg.Compressor.PodIP {
 					addrs = append(addrs[:i], addrs[i+1:]...)
 					addrs[len(addrs)-1] = ""
 					break

--- a/pkg/manager/compressor/usecase/compressord.go
+++ b/pkg/manager/compressor/usecase/compressord.go
@@ -243,6 +243,7 @@ func (r *run) Start(ctx context.Context) (<-chan error, error) {
 	if r.registerer != nil {
 		rech, err = r.registerer.Start(ctx)
 		if err != nil {
+			close(ech)
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Rintaro Okamura <rintaro.okamura@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->

Refactoring manager-compressor.
- extract worker loop
- add `Registerer` service that processes requested meta vector and registers it asynchronously
- in the PreStop phase, the terminated compressor sends meta_vectors in its queue to other compressor.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Nothing.

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local KinD.

### Environment:

<!--- Please change the versions below along with your environment -->

- Golang Version: 1.14
- Docker Version: 19.03.5
- Kubernetes Version: 1.17.3
- NGT Version: 1.9.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [X] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensure all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
