### PR TITLE
♻️ Compressor: backup vectors in queue using PostStop function

### DIFF
--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -895,7 +895,7 @@ compressor:
   # compressor.revisionHistoryLimit -- number of old history to retain to allow rollback
   revisionHistoryLimit: 2
   # compressor.terminationGracePeriodSeconds -- duration in seconds pod needs to terminate gracefully
-  terminationGracePeriodSeconds: 30
+  terminationGracePeriodSeconds: 120
   podPriority:
     # compressor.podPriority.enabled -- compressor pod PriorityClass enabled
     enabled: true

--- a/pkg/manager/compressor/service/registerer.go
+++ b/pkg/manager/compressor/service/registerer.go
@@ -34,7 +34,7 @@ import (
 type Registerer interface {
 	PreStart(ctx context.Context) error
 	Start(ctx context.Context) (<-chan error, error)
-	PreStop(ctx context.Context) error
+	PostStop(ctx context.Context) error
 	Register(ctx context.Context, meta *payload.Backup_MetaVector) error
 	RegisterMulti(ctx context.Context, metas *payload.Backup_MetaVectors) error
 	Len() uint64
@@ -75,8 +75,8 @@ func (r *registerer) Start(ctx context.Context) (<-chan error, error) {
 	return r.worker.Start(ctx)
 }
 
-func (r *registerer) PreStop(ctx context.Context) error {
-	log.Info("compressor registerer service prestop processing...")
+func (r *registerer) PostStop(ctx context.Context) error {
+	log.Info("compressor registerer service poststop processing...")
 
 	r.worker.Pause()
 
@@ -104,11 +104,11 @@ func (r *registerer) PreStop(ctx context.Context) error {
 
 	err = r.forwardMetas(ctx)
 	if err != nil {
-		log.Errorf("compressor registerer service prestop failed: %v", err)
+		log.Errorf("compressor registerer service poststop failed: %v", err)
 		return err
 	}
 
-	log.Info("compressor registerer service prestop completed")
+	log.Info("compressor registerer service poststop completed")
 
 	return nil
 }

--- a/pkg/manager/compressor/usecase/compressord.go
+++ b/pkg/manager/compressor/usecase/compressord.go
@@ -294,9 +294,6 @@ func (r *run) Start(ctx context.Context) (<-chan error, error) {
 }
 
 func (r *run) PreStop(ctx context.Context) error {
-	if r.registerer != nil {
-		return r.registerer.PreStop(ctx)
-	}
 	return nil
 }
 
@@ -308,5 +305,8 @@ func (r *run) Stop(ctx context.Context) error {
 }
 
 func (r *run) PostStop(ctx context.Context) error {
+	if r.registerer != nil {
+		return r.registerer.PostStop(ctx)
+	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Rintaro Okamura <rintaro.okamura@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->

Currently, vectors in registerer queue are send to other compressor during PreStop function in shutdown process.
However, it may be an issue that vectors in queue lost with terminating pods.
In this PR, backup processes will be run during PostStop function in shutdown process.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Nothing.

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
my K8s cluster.

### Environment:

<!--- Please change the versions below along with your environment -->

- Golang Version: 1.14
- Docker Version: 19.03.5
- Kubernetes Version: 1.17.3
- NGT Version: 1.9.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [X] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
