### PR TITLE
Fix gotests template

### DIFF
--- a/Makefile.d/functions.mk
+++ b/Makefile.d/functions.mk
@@ -104,13 +104,18 @@ define gen-test
 			 ./hack/tools"| \
 	while read dir; do \
 		files=`find $${dir} -type f -maxdepth 1 -name "*.go" -not -name '*_test.go' -not -name 'doc.go'`; \
+		tmp=`mktemp`; \
+		if [[ $${#files} -gt 0 ]]; then \
+			go list $${dir}| xargs printf '{"dir": "%s"}' > $${tmp}; \
+		fi; \
 		for file in $${files}; do \
 			path='./assets/test/templates/common';     \
 			if [[ $${file} =~ .*options?\.go ]] ; then \
 				path='./assets/test/templates/option'; \
 			fi; \
 			echo start generate test code: $${file}; \
-			gotests -w -template_dir $${path} -all $${file}; \
+			gotests -w -template_dir $${path} -template_params_file $${tmp} -all $${file}; \
 		done; \
+		rm $${tmp}; \
 	done
 endef

--- a/assets/test/templates/common/errors.tmpl
+++ b/assets/test/templates/common/errors.tmpl
@@ -1,0 +1,7 @@
+{{define "errors" }}
+{{- if eq (printf "%s" (index .TemplateParams "dir")) "github.com/vdaas/vald/internal/errors" -}}
+Errorf
+{{- else -}}
+errors.Errorf
+{{- end -}}
+{{end}}

--- a/assets/test/templates/common/function.tmpl
+++ b/assets/test/templates/common/function.tmpl
@@ -54,12 +54,12 @@ func {{ .TestName }}(t *testing.T) {
 
         {{- if .ReturnsError }}
             if !errors.Is(err, w.err) {
-                return errors.Errorf("got error = %v, want %v", err, w.err)
+                return {{ template "errors" $f }}("got error = %v, want %v", err, w.err)
             }
         {{- end }}
         {{- range .TestResults }} {{ $want := Want . }} {{ $got := Got . }}
             if !reflect.DeepEqual({{ $got }}, w.{{ $want }}) {
-                return errors.Errorf("got = %v, want %v", {{ $got }}, w.{{ $want }})
+                return {{ template "errors" $f }}("got = %v, want %v", {{ $got }}, w.{{ $want }})
             }
         {{- end }}
         return nil

--- a/assets/test/templates/option/errors.tmpl
+++ b/assets/test/templates/option/errors.tmpl
@@ -1,0 +1,1 @@
+../common/errors.tmpl

--- a/assets/test/templates/option/function.tmpl
+++ b/assets/test/templates/option/function.tmpl
@@ -51,10 +51,10 @@ func {{ .TestName }}(t *testing.T) {
     /*
     defaultCheckFunc := func(w want, obj *T, err error) error {
         if !errors.Is(err, w.err) {
-            return errors.Errorf("got error = %v, want %v", err, w.err)
+            return {{ template "errors" $f }}("got error = %v, want %v", err, w.err)
         }
         if !reflect.DeepEqual(obj, w.obj) {
-            return errors.Errorf("got = %v, want %v", obj, w.obj)
+            return {{ template "errors" $f }}("got = %v, want %v", obj, w.obj)
         }
         return nil
     }


### PR DESCRIPTION
Signed-off-by: hlts2 <hiroto.funakoshi.hiroto@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

We implement the test code based on the code automatically generated from the template. However, when I execute the go test command, the error occurs in internal / errors. The details of the error are cyclic imports. I think it's because the template uses errors.Errorf statically. Therefore, in case of errors in the same package, I want to put an implementation that removes the errors prefix in the template

I executed `go test` command on the generated test code from this template (pr contents). And 
when I checked error, no error occurred.

↓ The following is a piece of generated code.

<details>
<summary>Generated code (errors/cassandra_test.go  ) </summary>
<pre>
<code>
```go
func TestIsErrCassandraUnavailable(t *testing.T) {
	.....
	defaultCheckFunc := func(w want, got bool) error {
		if !reflect.DeepEqual(got, w.want) {
			return Errorf("got = %v, want %v", got, w.want)
		}
		return nil
	}
	...
```
</code>
</pre>
</details>

<details>
<summary>Generated code (backoff/backoff_test.go   ) </summary>
<pre>
<code>
```go
func Test_backoff_Do(t *testing.T) {
	...
	defaultCheckFunc := func(w want, gotRes interface{}, err error) error {
		if !errors.Is(err, w.err) {
			return errors.Errorf("got error = %v, want %v", err, w.err)
		}
		if !reflect.DeepEqual(gotRes, w.wantRes) {
			return errors.Errorf("got = %v, want %v", gotRes, w.wantRes)
		}
		return nil
	}
```
</code>
</pre>
</details>

### Related Issue:

https://github.com/vdaas/vald/issues/351

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Golang Version: 1.14
- Docker Version: 19.03.5
- Kubernetes Version: 1.17.3
- NGT Version: 1.9.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
