### PR TITLE
Fix`internal/log/format` to match the test template

### DIFF
--- a/internal/log/format/format_test.go
+++ b/internal/log/format/format_test.go
@@ -23,110 +23,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestString(t *testing.T) {
-	type test struct {
-		name   string
-		format Format
-		want   string
-	}
-
-	tests := []test{
-		{
-			name:   "returns raw",
-			format: RAW,
-			want:   "raw",
-		},
-
-		{
-			name:   "returns json",
-			format: JSON,
-			want:   "json",
-		},
-
-		{
-			name:   "returns ltsv",
-			format: LTSV,
-			want:   "ltsv",
-		},
-
-		{
-			name:   "returns unknown",
-			format: Format(100),
-			want:   "unknown",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.format.String()
-			if got != tt.want {
-				t.Errorf("not equals. want: %v, but got: %v", tt.want, got)
-			}
-		})
-	}
-}
-
-func TestAtof(t *testing.T) {
-	type test struct {
-		name string
-		str  string
-		want Format
-	}
-
-	tests := []test{
-		{
-			name: "returns RAW when str is raw",
-			str:  "raw",
-			want: RAW,
-		},
-
-		{
-			name: "returns RAW when str is RAw",
-			str:  "RAw",
-			want: RAW,
-		},
-
-		{
-			name: "returns JSON when str is json",
-			str:  "json",
-			want: JSON,
-		},
-
-		{
-			name: "returns JSON when str is JSOn",
-			str:  "JSOn",
-			want: JSON,
-		},
-
-		{
-			name: "returns LTSV when str is ltsv",
-			str:  "ltsv",
-			want: LTSV,
-		},
-
-		{
-			name: "returns LTSV when str is LTSv",
-			str:  "LTSv",
-			want: LTSV,
-		},
-
-		{
-			name: "returns Unknown when str is Vald",
-			str:  "Vald",
-			want: Unknown,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := Atof(tt.str)
-			if got != tt.want {
-				t.Errorf("not equals. want: %v, but got: %v", tt.want, got)
-			}
-		})
-	}
-}
-
 func TestFormat_String(t *testing.T) {
 	type want struct {
 		want string
@@ -146,30 +42,42 @@ func TestFormat_String(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
+		{
+			name: "returns raw when f is RAW",
+			f:    RAW,
+			want: want{
+				want: "raw",
+			},
+		},
 
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "returns json when f is JSON",
+			f:    JSON,
+			want: want{
+				want: "json",
+			},
+		},
+
+		{
+			name: "returns ltsv when f is LTSV",
+			f:    LTSV,
+			want: want{
+				want: "ltsv",
+			},
+		},
+
+		{
+			name: "returns unknown when f is 100",
+			f:    Format(100),
+			want: want{
+				want: "unknown",
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -185,6 +93,103 @@ func TestFormat_String(t *testing.T) {
 				tt.Errorf("error = %v", err)
 			}
 
+		})
+	}
+}
+
+func TestAtof(t *testing.T) {
+	type want struct {
+		want Format
+	}
+	type test struct {
+		name       string
+		str        string
+		want       want
+		checkFunc  func(want, Format) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got Format) error {
+		if !reflect.DeepEqual(got, w.want) {
+			return errors.Errorf("got = %v, want %v", got, w.want)
+		}
+		return nil
+	}
+
+	tests := []test{
+		{
+			name: "returns RAW when str is `raw`",
+			str:  "raw",
+			want: want{
+				want: RAW,
+			},
+		},
+
+		{
+			name: "returns RAW when str is `RAw`",
+			str:  "RAw",
+			want: want{
+				want: RAW,
+			},
+		},
+
+		{
+			name: "returns JSON when str is `json`",
+			str:  "json",
+			want: want{
+				want: JSON,
+			},
+		},
+
+		{
+			name: "returns JSON when str is `JSOn`",
+			str:  "JSOn",
+			want: want{
+				want: JSON,
+			},
+		},
+
+		{
+			name: "returns LTSV when str is `ltsv`",
+			str:  "ltsv",
+			want: want{
+				want: LTSV,
+			},
+		},
+
+		{
+			name: "returns LTSV when str is `LTSv`",
+			str:  "LTSv",
+			want: want{
+				LTSV,
+			},
+		},
+
+		{
+			name: "returns Unknown when str is `Vald`",
+			str:  "Vald",
+			want: want{
+				want: Unknown,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			defer goleak.VerifyNone(tt)
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+			got := Atof(test.str)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }

--- a/internal/log/format/format_test.go
+++ b/internal/log/format/format_test.go
@@ -161,7 +161,7 @@ func TestAtof(t *testing.T) {
 			name: "returns LTSV when str is `LTSv`",
 			str:  "LTSv",
 			want: want{
-				LTSV,
+				want: LTSV,
 			},
 		},
 


### PR DESCRIPTION
Signed-off-by: hlts2 <hiroto.funakoshi.hiroto@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

I fixed `internal/log/foramt` to match the test template.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Golang Version: 1.14
- Docker Version: 19.03.5
- Kubernetes Version: 1.17.3
- NGT Version: 1.9.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly.
