### PR TITLE
✨ add trace spans and metrics for agent-ngt and index-manager

### DIFF
--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -752,6 +752,8 @@ agent:
     auto_index_length: 100
     # agent.ngt.auto_save_index_duration -- duration of automatic save index
     auto_save_index_duration: 35m
+    # agent.ngt.initial_delay_max_duration -- maximum duration for initial delay
+    initial_delay_max_duration: 3m
     # agent.ngt.dimension -- vector dimension
     dimension: 4096
     # agent.ngt.bulk_insert_chunk_size -- bulk insert chunk size

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	go.uber.org/goleak v1.0.0
 	golang.org/x/mod v0.3.0 // indirect
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
-	golang.org/x/tools v0.0.0-20200519015757-0d0afa43d58a // indirect
+	golang.org/x/tools v0.0.0-20200520220537-cf2d1e09c845 // indirect
 	gonum.org/v1/hdf5 v0.0.0-20200504100616-496fefe91614
 	gonum.org/v1/netlib v0.0.0-20200317120129-c5a04cffd98a // indirect
 	gonum.org/v1/plot v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -645,6 +645,8 @@ golang.org/x/tools v0.0.0-20200515220128-d3bf790afa53 h1:vmsb6v0zUdmUlXfwKaYrHPP
 golang.org/x/tools v0.0.0-20200515220128-d3bf790afa53/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200519015757-0d0afa43d58a h1:gILuVKC+ZPD6g/tj6zBOdnOH1ZHI0zZ86+KLMogc6/s=
 golang.org/x/tools v0.0.0-20200519015757-0d0afa43d58a/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200520220537-cf2d1e09c845 h1:F4gQH8TKyCccYDuNHX5TfZwiM8QWnPbSPUFE96qvGbs=
+golang.org/x/tools v0.0.0-20200520220537-cf2d1e09c845/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/internal/config/ngt.go
+++ b/internal/config/ngt.go
@@ -52,6 +52,9 @@ type NGT struct {
 	// AutoIndexLength represent auto index length limit
 	AutoIndexLength int `yaml:"auto_index_length" json:"auto_index_length"`
 
+	// InitialDelayMaxDuration represent maximum duration for initial delay
+	InitialDelayMaxDuration string `yaml:"initial_delay_max_duration" json:"initial_delay_max_duration"`
+
 	// EnableInMemoryMode enables on memory ngt indexing mode
 	EnableInMemoryMode bool `yaml:"enable_in_memory_mode" json:"enable_in_memory_mode"`
 }
@@ -63,5 +66,6 @@ func (n *NGT) Bind() *NGT {
 	n.AutoIndexCheckDuration = GetActualValue(n.AutoIndexCheckDuration)
 	n.AutoIndexDurationLimit = GetActualValue(n.AutoIndexDurationLimit)
 	n.AutoSaveIndexDuration = GetActualValue(n.AutoSaveIndexDuration)
+	n.InitialDelayMaxDuration = GetActualValue(n.InitialDelayMaxDuration)
 	return n
 }

--- a/pkg/agent/ngt/handler/grpc/handler.go
+++ b/pkg/agent/ngt/handler/grpc/handler.go
@@ -356,7 +356,7 @@ func (s *server) CreateIndex(ctx context.Context, c *payload.Control_CreateIndex
 		}
 	}()
 	res = new(payload.Empty)
-	err = s.ngt.CreateIndex(c.GetPoolSize())
+	err = s.ngt.CreateIndex(ctx, c.GetPoolSize())
 	if err != nil {
 		log.Errorf("[CreateIndex]\tUnknown error\t%+v", err)
 		if span != nil {

--- a/pkg/agent/ngt/service/ngt.go
+++ b/pkg/agent/ngt/service/ngt.go
@@ -72,7 +72,7 @@ type ngt struct {
 	lim      time.Duration // auto indexing time limit
 	dur      time.Duration // auto indexing check duration
 	sdur     time.Duration // auto save index check duration
-	idelaymx time.Duration // maximum duration for initial delay
+	idelay   time.Duration // initial delay duration
 	dps      uint32        // default pool size
 	ic       uint64        // insert count
 	nocie    uint64        // number of create index execution
@@ -175,7 +175,9 @@ func New(cfg *config.NGT) (nn NGT, err error) {
 		if err != nil {
 			d = 0
 		}
-		n.idelaymx = d
+		n.idelay = time.Duration(
+			int64(rand.LimitedUint32(uint64(d/time.Second))),
+		) * time.Second
 	}
 
 	n.alen = cfg.AutoIndexLength
@@ -213,7 +215,7 @@ func (n *ngt) Start(ctx context.Context) <-chan error {
 		}
 		defer close(ech)
 
-		time.Sleep(time.Duration(rand.LimitedUint32(uint64(n.idelaymx))))
+		time.Sleep(n.idelay)
 
 		tick := time.NewTicker(n.dur)
 		sTick := time.NewTicker(n.sdur)

--- a/pkg/agent/ngt/service/ngt.go
+++ b/pkg/agent/ngt/service/ngt.go
@@ -215,7 +215,14 @@ func (n *ngt) Start(ctx context.Context) <-chan error {
 		}
 		defer close(ech)
 
-		time.Sleep(n.idelay)
+		timer := time.NewTimer(n.idelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+		timer.Stop()
 
 		tick := time.NewTicker(n.dur)
 		sTick := time.NewTicker(n.sdur)

--- a/pkg/agent/ngt/service/ngt_test.go
+++ b/pkg/agent/ngt/service/ngt_test.go
@@ -1791,6 +1791,7 @@ func Test_ngt_GetObject(t *testing.T) {
 
 func Test_ngt_CreateIndex(t *testing.T) {
 	type args struct {
+		ctx      context.Context
 		poolSize uint32
 	}
 	type fields struct {
@@ -1916,7 +1917,7 @@ func Test_ngt_CreateIndex(t *testing.T) {
 				dcd:      test.fields.dcd,
 			}
 
-			err := n.CreateIndex(test.args.poolSize)
+			err := n.CreateIndex(test.args.ctx, test.args.poolSize)
 			if err := test.checkFunc(test.want, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/pkg/manager/index/service/indexer.go
+++ b/pkg/manager/index/service/indexer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/log"
 	"github.com/vdaas/vald/internal/net/grpc"
+	"github.com/vdaas/vald/internal/observability/trace"
 	"github.com/vdaas/vald/internal/safety"
 )
 
@@ -126,6 +127,13 @@ func (idx *index) Start(ctx context.Context) (<-chan error, error) {
 }
 
 func (idx *index) execute(ctx context.Context, enableLowIndexSkip bool) (err error) {
+	ctx, span := trace.StartSpan(ctx, "vald/manager-index/service/Indexer.execute")
+	defer func() {
+		if span != nil {
+			span.End()
+		}
+	}()
+
 	if idx.indexing.Load().(bool) {
 		return nil
 	}
@@ -168,6 +176,13 @@ func (idx *index) execute(ctx context.Context, enableLowIndexSkip bool) (err err
 }
 
 func (idx *index) loadInfos(ctx context.Context) (err error) {
+	ctx, span := trace.StartSpan(ctx, "vald/manager-index/service/Indexer.loadInfos")
+	defer func() {
+		if span != nil {
+			span.End()
+		}
+	}()
+
 	var u, ucu uint32
 	var infoMap indexInfos
 	err = idx.client.GetClient().RangeConcurrent(ctx, len(idx.client.GetAddrs(ctx)),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->

- add trace spans for several functions that called by daemons
- add metrics about create index execution (agent)
- add `initial_delay_max_duration` that affects to start auto-index daemon after random duration within it.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#343

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
nothing.

### Environment:

<!--- Please change the versions below along with your environment -->

- Golang Version: 1.14.3
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.11.5

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [X] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
