### PR TITLE
Fix typos

### DIFF
--- a/docs/overview/architecture.md
+++ b/docs/overview/architecture.md
@@ -241,5 +241,5 @@ For more information about Kube-apiserver, please refer to [the official documen
 
 #### Custom Resources
 
-Custom Resources in Vald is a [Custom Resouce Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) implementation.
+Custom Resources in Vald is a [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) implementation.
 It provides flexibility for users to control the Vald deployment such as pod startup sequence, etc.

--- a/docs/user/get-started.md
+++ b/docs/user/get-started.md
@@ -263,7 +263,7 @@ This chapter shows how to perform a search action in Vald with fashion-mnist dat
         ```go
         glg.Infof("Start search %d times", testCount)
         for i, vec := range test[:testCount] {
-            res, err := client.Seach(ctx, &payload.Search_Request){
+            res, err := client.Search(ctx, &payload.Search_Request){
                 Vector: vec,
                 Config: &payload.Search_Config{
                     Num: 10,


### PR DESCRIPTION
Hi,

This tiny PR will fix : 

- 1 typo in `docs/overview/architecture.md`
- 1 typo in `docs/user/get-started.md`



Best! :robot: