### PR TITLE
Accessing empty slice with no boundary checking causing error

### DIFF
--- a/internal/core/converter/tensorflow/tensorflow.go
+++ b/internal/core/converter/tensorflow/tensorflow.go
@@ -109,7 +109,7 @@ func (t *tensorflow) GetVector(inputs ...string) ([]float64, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(tensors) == 0 || tensors[0].Value() == nil {
+	if len(tensors) == 0 || tensors[0] == nil || tensors[0].Value() == nil {
 		return nil, errors.ErrNilTensorTF(tensors)
 	}
 
@@ -128,7 +128,7 @@ func (t *tensorflow) GetVector(inputs ...string) ([]float64, error) {
 		if !ok {
 			return nil, errors.ErrFailedToCastTF(tensors[0].Value())
 		}
-		if len(value) == 0 || value[0] == nil {
+		if len(value) == 0 || len(value[0]) == 0 {
 			return nil, errors.ErrNilTensorValueTF(value)
 		}
 		return value[0][0], nil

--- a/internal/core/converter/tensorflow/tensorflow.go
+++ b/internal/core/converter/tensorflow/tensorflow.go
@@ -109,38 +109,35 @@ func (t *tensorflow) GetVector(inputs ...string) ([]float64, error) {
 	if err != nil {
 		return nil, err
 	}
-	if tensors == nil || tensors[0] == nil || tensors[0].Value() == nil {
+	if len(tensors) == 0 || tensors[0].Value() == nil {
 		return nil, errors.ErrNilTensorTF(tensors)
 	}
 
 	switch t.ndim {
 	case TwoDim:
 		value, ok := tensors[0].Value().([][]float64)
-		if ok {
-			if value == nil {
-				return nil, errors.ErrNilTensorValueTF(value)
-			}
-			return value[0], nil
-		} else {
+		if !ok {
 			return nil, errors.ErrFailedToCastTF(tensors[0].Value())
 		}
+		if value == nil {
+			return nil, errors.ErrNilTensorValueTF(value)
+		}
+		return value[0], nil
 	case ThreeDim:
 		value, ok := tensors[0].Value().([][][]float64)
-		if ok {
-			if value == nil || value[0] == nil {
-				return nil, errors.ErrNilTensorValueTF(value)
-			}
-			return value[0][0], nil
-		} else {
+		if !ok {
 			return nil, errors.ErrFailedToCastTF(tensors[0].Value())
 		}
+		if len(value) == 0 || value[0] == nil {
+			return nil, errors.ErrNilTensorValueTF(value)
+		}
+		return value[0][0], nil
 	default:
 		value, ok := tensors[0].Value().([]float64)
-		if ok {
-			return value, nil
-		} else {
+		if !ok {
 			return nil, errors.ErrFailedToCastTF(tensors[0].Value())
 		}
+		return value, nil
 	}
 }
 
@@ -149,7 +146,7 @@ func (t *tensorflow) GetValue(inputs ...string) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if tensors == nil || tensors[0] == nil {
+	if len(tensors) == 0 || tensors[0] == nil {
 		return nil, errors.ErrNilTensorTF(tensors)
 	}
 	return tensors[0].Value(), nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR add the boundary checking before accessing the slice.
If the slice is empty, the access of the `slice[...]` will cause panic and this PR fix this bug.
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/vdaas/vald/issues/413

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Golang Version: 1.14.3
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.11.5

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
