### PR TITLE
🐛  Add gRPC interceptor to recover panic in handlers

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,3 +1,18 @@
+#
+# Copyright (C) 2019-2020 Vdaas.org Vald team ( kpango, rinx, kmrmt )
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 {
   "files": [
     "README.md"

--- a/internal/db/storage/blob/s3/s3_test.go
+++ b/internal/db/storage/blob/s3/s3_test.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/db/storage/blob"
 	"github.com/vdaas/vald/internal/errgroup"
+	"github.com/vdaas/vald/internal/errors"
 	"go.uber.org/goleak"
 )
 

--- a/internal/net/grpc/interceptor.go
+++ b/internal/net/grpc/interceptor.go
@@ -1,0 +1,63 @@
+//
+// Copyright (C) 2019-2020 Vdaas.org Vald team ( kpango, rinx, kmrmt )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package grpc provides generic functionality for grpc
+package grpc
+
+import (
+	"context"
+
+	"github.com/vdaas/vald/internal/safety"
+	"google.golang.org/grpc"
+)
+
+type UnaryServerInterceptor = grpc.UnaryServerInterceptor
+type StreamServerInterceptor = grpc.StreamServerInterceptor
+
+var (
+	UnaryInterceptor       = grpc.UnaryInterceptor
+	ChainUnaryInterceptor  = grpc.ChainUnaryInterceptor
+	StreamInterceptor      = grpc.StreamInterceptor
+	ChainStreamInterceptor = grpc.ChainStreamInterceptor
+)
+
+func RecoverInterceptor() UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (resp interface{}, err error) {
+		err = safety.RecoverWithoutPanicFunc(func() (err error) {
+			resp, err = handler(ctx, req)
+			return err
+		})()
+		return resp, err
+	}
+}
+
+func RecoverStreamInterceptor() StreamServerInterceptor {
+	return func(
+		srv interface{},
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		return safety.RecoverWithoutPanicFunc(func() (err error) {
+			return handler(srv, ss)
+		})()
+	}
+}

--- a/internal/net/grpc/stream.go
+++ b/internal/net/grpc/stream.go
@@ -66,7 +66,7 @@ func BidirectionalStream(ctx context.Context, stream grpc.ServerStream,
 				return err
 			}
 			if data != nil {
-				eg.Go(safety.RecoverFunc(func() (err error) {
+				eg.Go(safety.RecoverWithoutPanicFunc(func() (err error) {
 					var res interface{}
 					res, err = f(ctx, data)
 					if err != nil {

--- a/internal/net/grpc/stream.go
+++ b/internal/net/grpc/stream.go
@@ -42,7 +42,7 @@ func BidirectionalStream(ctx context.Context, stream grpc.ServerStream,
 		eg.Limitation(concurrency)
 	}
 
-	mu := &sync.Mutex{}
+	var mu sync.Mutex
 
 	errMap := sync.Map{}
 

--- a/internal/safety/safety.go
+++ b/internal/safety/safety.go
@@ -26,6 +26,14 @@ import (
 )
 
 func RecoverFunc(fn func() error) func() error {
+	return recoverFunc(fn, true)
+}
+
+func RecoverWithoutPanicFunc(fn func() error) func() error {
+	return recoverFunc(fn, false)
+}
+
+func recoverFunc(fn func() error, withPanic bool) func() error {
 	return func() (err error) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -33,8 +41,10 @@ func RecoverFunc(fn func() error) func() error {
 				switch x := r.(type) {
 				case runtime.Error:
 					err = errors.ErrRuntimeError(err, x)
-					log.Error(err, info.Get())
-					panic(err)
+					if withPanic {
+						log.Error(err, info.Get())
+						panic(err)
+					}
 				case string:
 					err = errors.ErrPanicString(err, x)
 				case error:

--- a/internal/servers/server/option.go
+++ b/internal/servers/server/option.go
@@ -230,9 +230,16 @@ func WithGRPCServer(srv *grpc.Server) Option {
 
 func WithGRPCOption(opts ...grpc.ServerOption) Option {
 	return func(s *server) {
-		if opts != nil {
-			s.grpc.opts = opts
+		if opts == nil {
+			return
 		}
+
+		if s.grpc.opts == nil {
+			s.grpc.opts = opts
+			return
+		}
+
+		s.grpc.opts = append(s.grpc.opts, opts...)
 	}
 }
 

--- a/pkg/agent/core/ngt/usecase/agentd.go
+++ b/pkg/agent/core/ngt/usecase/agentd.go
@@ -61,6 +61,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
 			agent.RegisterAgentServer(srv, g)
 		}),
+		server.WithGRPCOption(
+			grpc.ChainUnaryInterceptor(grpc.RecoverInterceptor()),
+			grpc.ChainStreamInterceptor(grpc.RecoverStreamInterceptor()),
+		),
 		server.WithPreStartFunc(func() error {
 			// TODO check unbackupped upstream
 			return nil

--- a/pkg/agent/sidecar/handler/grpc/handler_test.go
+++ b/pkg/agent/sidecar/handler/grpc/handler_test.go
@@ -21,8 +21,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/apis/grpc/agent/sidecar"
+	"github.com/vdaas/vald/internal/errors"
 	"go.uber.org/goleak"
 )
 

--- a/pkg/agent/sidecar/usecase/initcontainer/initcontainer.go
+++ b/pkg/agent/sidecar/usecase/initcontainer/initcontainer.go
@@ -99,6 +99,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
 			sidecar.RegisterSidecarServer(srv, g)
 		}),
+		server.WithGRPCOption(
+			grpc.ChainUnaryInterceptor(grpc.RecoverInterceptor()),
+			grpc.ChainStreamInterceptor(grpc.RecoverStreamInterceptor()),
+		),
 		server.WithPreStopFunction(func() error {
 			// TODO notify another gateway and scheduler
 			return nil

--- a/pkg/agent/sidecar/usecase/initcontainer/initcontainer_test.go
+++ b/pkg/agent/sidecar/usecase/initcontainer/initcontainer_test.go
@@ -21,8 +21,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/errgroup"
+	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/observability"
 	"github.com/vdaas/vald/internal/runner"
 	"github.com/vdaas/vald/internal/servers/starter"

--- a/pkg/agent/sidecar/usecase/sidecar/sidecar.go
+++ b/pkg/agent/sidecar/usecase/sidecar/sidecar.go
@@ -100,6 +100,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
 			sidecar.RegisterSidecarServer(srv, g)
 		}),
+		server.WithGRPCOption(
+			grpc.ChainUnaryInterceptor(grpc.RecoverInterceptor()),
+			grpc.ChainStreamInterceptor(grpc.RecoverStreamInterceptor()),
+		),
 		server.WithPreStopFunction(func() error {
 			// TODO notify another gateway and scheduler
 			return nil

--- a/pkg/agent/sidecar/usecase/sidecar/sidecar_test.go
+++ b/pkg/agent/sidecar/usecase/sidecar/sidecar_test.go
@@ -21,8 +21,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/errgroup"
+	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/observability"
 	"github.com/vdaas/vald/internal/runner"
 	"github.com/vdaas/vald/internal/servers/starter"

--- a/pkg/discoverer/k8s/usecase/discovered.go
+++ b/pkg/discoverer/k8s/usecase/discovered.go
@@ -66,6 +66,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
 			discoverer.RegisterDiscovererServer(srv, h)
 		}),
+		server.WithGRPCOption(
+			grpc.ChainUnaryInterceptor(grpc.RecoverInterceptor()),
+			grpc.ChainStreamInterceptor(grpc.RecoverStreamInterceptor()),
+		),
 		server.WithPreStartFunc(func() error {
 			// TODO check unbackupped upstream
 			return nil

--- a/pkg/gateway/vald/usecase/vald.go
+++ b/pkg/gateway/vald/usecase/vald.go
@@ -193,6 +193,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
 			vald.RegisterValdServer(srv, v)
 		}),
+		server.WithGRPCOption(
+			grpc.ChainUnaryInterceptor(grpc.RecoverInterceptor()),
+			grpc.ChainStreamInterceptor(grpc.RecoverStreamInterceptor()),
+		),
 		server.WithPreStopFunction(func() error {
 			// TODO notify another gateway and scheduler
 			return nil

--- a/pkg/manager/backup/cassandra/usecase/backupd.go
+++ b/pkg/manager/backup/cassandra/usecase/backupd.go
@@ -57,6 +57,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
 			backup.RegisterBackupServer(srv, g)
 		}),
+		server.WithGRPCOption(
+			grpc.ChainUnaryInterceptor(grpc.RecoverInterceptor()),
+			grpc.ChainStreamInterceptor(grpc.RecoverStreamInterceptor()),
+		),
 		server.WithPreStartFunc(func() error {
 			// TODO check unbackupped upstream
 			return nil

--- a/pkg/manager/backup/mysql/usecase/backupd.go
+++ b/pkg/manager/backup/mysql/usecase/backupd.go
@@ -57,6 +57,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
 			backup.RegisterBackupServer(srv, g)
 		}),
+		server.WithGRPCOption(
+			grpc.ChainUnaryInterceptor(grpc.RecoverInterceptor()),
+			grpc.ChainStreamInterceptor(grpc.RecoverStreamInterceptor()),
+		),
 		server.WithPreStartFunc(func() error {
 			// TODO check unbackupped upstream
 			return nil

--- a/pkg/manager/compressor/usecase/compressord.go
+++ b/pkg/manager/compressor/usecase/compressord.go
@@ -155,6 +155,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
 			compressor.RegisterBackupServer(srv, g)
 		}),
+		server.WithGRPCOption(
+			grpc.ChainUnaryInterceptor(grpc.RecoverInterceptor()),
+			grpc.ChainStreamInterceptor(grpc.RecoverStreamInterceptor()),
+		),
 		server.WithPreStartFunc(func() error {
 			// TODO check unbackupped upstream
 			return nil

--- a/pkg/manager/index/usecase/indexer.go
+++ b/pkg/manager/index/usecase/indexer.go
@@ -114,6 +114,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
 			index.RegisterIndexServer(srv, idx)
 		}),
+		server.WithGRPCOption(
+			grpc.ChainUnaryInterceptor(grpc.RecoverInterceptor()),
+			grpc.ChainStreamInterceptor(grpc.RecoverStreamInterceptor()),
+		),
 		server.WithPreStopFunction(func() error {
 			// TODO notify another gateway and scheduler
 			return nil

--- a/pkg/manager/replication/agent/usecase/backupd.go
+++ b/pkg/manager/replication/agent/usecase/backupd.go
@@ -56,6 +56,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
 			agent.RegisterReplicationServer(srv, g)
 		}),
+		server.WithGRPCOption(
+			grpc.ChainUnaryInterceptor(grpc.RecoverInterceptor()),
+			grpc.ChainStreamInterceptor(grpc.RecoverStreamInterceptor()),
+		),
 		server.WithPreStartFunc(func() error {
 			// TODO check unbackupped upstream
 			return nil

--- a/pkg/manager/replication/controller/usecase/discovered.go
+++ b/pkg/manager/replication/controller/usecase/discovered.go
@@ -60,6 +60,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
 			controller.RegisterReplicationServer(srv, g)
 		}),
+		server.WithGRPCOption(
+			grpc.ChainUnaryInterceptor(grpc.RecoverInterceptor()),
+			grpc.ChainStreamInterceptor(grpc.RecoverStreamInterceptor()),
+		),
 		server.WithPreStartFunc(func() error {
 			// TODO check unbackupped upstream
 			return nil

--- a/pkg/meta/cassandra/usecase/meta.go
+++ b/pkg/meta/cassandra/usecase/meta.go
@@ -57,6 +57,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
 			meta.RegisterMetaServer(srv, g)
 		}),
+		server.WithGRPCOption(
+			grpc.ChainUnaryInterceptor(grpc.RecoverInterceptor()),
+			grpc.ChainStreamInterceptor(grpc.RecoverStreamInterceptor()),
+		),
 		server.WithPreStartFunc(func() error {
 			// TODO check unbackupped upstream
 			return nil

--- a/pkg/meta/redis/usecase/meta.go
+++ b/pkg/meta/redis/usecase/meta.go
@@ -57,6 +57,10 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		server.WithGRPCRegistFunc(func(srv *grpc.Server) {
 			meta.RegisterMetaServer(srv, g)
 		}),
+		server.WithGRPCOption(
+			grpc.ChainUnaryInterceptor(grpc.RecoverInterceptor()),
+			grpc.ChainStreamInterceptor(grpc.RecoverStreamInterceptor()),
+		),
 		server.WithPreStartFunc(func() error {
 			// TODO check unbackupped upstream
 			return nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
- Added gRPC interceptor to recover panic in handlers
- Refactor BidirectionalStream func.
    - https://github.com/grpc/grpc-go/blob/fff75ae40fde3e38ad4dc57695d639c8a99cb1ba/stream.go#L1305-L1307

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Nothing.

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local.

### Environment:

<!--- Please change the versions below along with your environment -->

- Golang Version: 1.14.3
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.11.5

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
