### PR TITLE
Fix k8s manifests for loadtest jobs

### DIFF
--- a/k8s/tools/cli/loadtest/cronjob.yaml
+++ b/k8s/tools/cli/loadtest/cronjob.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: vald-loadtest
@@ -30,9 +30,10 @@ spec:
       backoffLimit: 10
       template:
         metadata:
-          app: vald-loadtest
-          app.kubernetes.io/name: vald
-          app.kubernetes.io/component: loadtest
+          labels:
+            app: vald-loadtest
+            app.kubernetes.io/name: vald
+            app.kubernetes.io/component: loadtest
         spec:
           containers:
             - name: vald-loadtest

--- a/k8s/tools/cli/loadtest/job.yaml
+++ b/k8s/tools/cli/loadtest/job.yaml
@@ -26,9 +26,10 @@ spec:
   backoffLimit: 5
   template:
     metadata:
-      app: vald-loadtest
-      app.kubernetes.io/name: vald
-      app.kubernetes.io/component: loadtest
+      labels:
+        app: vald-loadtest
+        app.kubernetes.io/name: vald
+        app.kubernetes.io/component: loadtest
     spec:
       containers:
         - name: vald-loadtest


### PR DESCRIPTION
Signed-off-by: Rintaro Okamura <rintaro.okamura@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
I've found several mistakes in k8s manifests of loadtest jobs while i'm trying to apply them.
fixed them.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Nothing.

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
nothing.

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.3
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.11.5

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
