### PR TITLE
Add WithOperation func to loadtest usecase

### DIFF
--- a/pkg/tools/cli/loadtest/usecase/load.go
+++ b/pkg/tools/cli/loadtest/usecase/load.go
@@ -41,11 +41,12 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		eg: errgroup.Get(),
 	}
 
-	run.client = grpc.New(
-		grpc.WithAddrs(append([]string{cfg.Addr}, cfg.Client.Addrs...)...),
-		grpc.WithInsecure(cfg.Client.DialOption.Insecure),
+	clientOpts := append(
+		cfg.Client.Opts(),
+		grpc.WithAddrs(cfg.Addr),
 		grpc.WithErrGroup(run.eg),
 	)
+	run.client = grpc.New(clientOpts...)
 
 	run.loader, err = service.NewLoader(
 		service.WithOperation(cfg.Method),

--- a/pkg/tools/cli/loadtest/usecase/load.go
+++ b/pkg/tools/cli/loadtest/usecase/load.go
@@ -55,6 +55,7 @@ func (r *run) PreStart(ctx context.Context) (err error) {
 	)
 
 	opts := []service.Option{
+		service.WithOperation(r.cfg.Method),
 		service.WithAddr(r.cfg.Addr),
 		service.WithDataset(r.cfg.Dataset),
 		service.WithClient(r.client),

--- a/pkg/tools/cli/loadtest/usecase/load.go
+++ b/pkg/tools/cli/loadtest/usecase/load.go
@@ -31,7 +31,6 @@ import (
 
 type run struct {
 	eg     errgroup.Group
-	cfg    *config.Data
 	loader service.Loader
 	client grpc.Client
 }
@@ -39,8 +38,25 @@ type run struct {
 // New returns Runner instance.
 func New(cfg *config.Data) (r runner.Runner, err error) {
 	run := &run{
-		cfg: cfg,
-		eg:  errgroup.Get(),
+		eg: errgroup.Get(),
+	}
+
+	run.client = grpc.New(
+		grpc.WithAddrs(append([]string{cfg.Addr}, cfg.Client.Addrs...)...),
+		grpc.WithInsecure(cfg.Client.DialOption.Insecure),
+		grpc.WithErrGroup(run.eg),
+	)
+
+	run.loader, err = service.NewLoader(
+		service.WithOperation(cfg.Method),
+		service.WithAddr(cfg.Addr),
+		service.WithDataset(cfg.Dataset),
+		service.WithClient(run.client),
+		service.WithConcurrency(cfg.Concurrency),
+		service.WithProgressDuration(cfg.ProgressDuration),
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	return run, nil
@@ -48,26 +64,6 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 
 // PreStart initializes load tester and returns error if occurred.
 func (r *run) PreStart(ctx context.Context) (err error) {
-	r.client = grpc.New(
-		grpc.WithAddrs(append([]string{r.cfg.Addr}, r.cfg.Client.Addrs...)...),
-		grpc.WithInsecure(r.cfg.Client.DialOption.Insecure),
-		grpc.WithErrGroup(r.eg),
-	)
-
-	opts := []service.Option{
-		service.WithOperation(r.cfg.Method),
-		service.WithAddr(r.cfg.Addr),
-		service.WithDataset(r.cfg.Dataset),
-		service.WithClient(r.client),
-		service.WithConcurrency(r.cfg.Concurrency),
-		service.WithProgressDuration(r.cfg.ProgressDuration),
-	}
-
-	r.loader, err = service.NewLoader(opts...)
-	if err != nil {
-		return err
-	}
-
 	return r.loader.Prepare(ctx)
 }
 


### PR DESCRIPTION
Signed-off-by: Rintaro Okamura <rintaro.okamura@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
I found that the `method` variable is not passed to loadtest service. without it, the loadtest app does not work correctly.
fixed it.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
nothing.

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
nothing.

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.3
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.11.5

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
