### PR TITLE
Fix failing the test of `internal/net/middleware`

### DIFF
--- a/internal/net/http/middleware/timeout_test.go
+++ b/internal/net/http/middleware/timeout_test.go
@@ -112,7 +112,7 @@ func TestWrap(t *testing.T) {
 			}
 		}(),
 		func() test {
-			wantErr := errors.Errorf("faild")
+			wantErr := errors.New("faild")
 
 			var cnt int
 			h := func(w http.ResponseWriter, req *http.Request) (code int, err error) {


### PR DESCRIPTION
Signed-off-by: hlts2 <hiroto.funakoshi.hiroto@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

I fixed failing the test of `internal/net/middleware`.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.3
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.11.5

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
