### PR TITLE
internal/db/storage/blob/s3: remove ctx from struct

### DIFF
--- a/.github/workflows/dockers-agent-sidecar-image.yml
+++ b/.github/workflows/dockers-agent-sidecar-image.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - 'internal/**'
       - '!internal/db/**'
-      - 'internal/db/storage/blob'
+      - 'internal/db/storage/blob/**'
       - '!internal/k8s/**'
       - 'apis/grpc/**'
       - 'pkg/agent/sidecar/**'
@@ -23,7 +23,7 @@ on:
     paths:
       - 'internal/**'
       - '!internal/db/**'
-      - 'internal/db/storage/blob'
+      - 'internal/db/storage/blob/**'
       - '!internal/k8s/**'
       - 'apis/grpc/**'
       - 'pkg/agent/sidecar/**'

--- a/internal/db/storage/blob/s3/writer/writer.go
+++ b/internal/db/storage/blob/s3/writer/writer.go
@@ -40,8 +40,6 @@ type writer struct {
 
 	pw io.WriteCloser
 	wg *sync.WaitGroup
-
-	ctx context.Context
 }
 
 type Writer interface {
@@ -59,8 +57,6 @@ func New(opts ...Option) Writer {
 }
 
 func (w *writer) Open(ctx context.Context) (err error) {
-	w.ctx = ctx
-
 	w.wg = new(sync.WaitGroup)
 
 	var pr io.ReadCloser
@@ -73,7 +69,7 @@ func (w *writer) Open(ctx context.Context) (err error) {
 		defer w.wg.Done()
 		defer pr.Close()
 
-		return w.upload(pr)
+		return w.upload(ctx, pr)
 	}))
 
 	return err
@@ -92,14 +88,14 @@ func (w *writer) Close() error {
 }
 
 func (w *writer) Write(p []byte) (n int, err error) {
-	if w.ctx == nil || w.pw == nil {
+	if w.pw == nil {
 		return 0, errors.ErrStorageWriterNotOpened
 	}
 
 	return w.pw.Write(p)
 }
 
-func (w *writer) upload(body io.Reader) (err error) {
+func (w *writer) upload(ctx context.Context, body io.Reader) (err error) {
 	uploader := s3manager.NewUploaderWithClient(
 		w.service,
 		func(u *s3manager.Uploader) {
@@ -112,7 +108,7 @@ func (w *writer) upload(body io.Reader) (err error) {
 		Body:   body,
 	}
 
-	res, err := uploader.UploadWithContext(w.ctx, input)
+	res, err := uploader.UploadWithContext(ctx, input)
 	if err != nil {
 		log.Error("upload failed with error: ", err)
 		return err

--- a/internal/db/storage/blob/s3/writer/writer_test.go
+++ b/internal/db/storage/blob/s3/writer/writer_test.go
@@ -80,7 +80,7 @@ func TestNew(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -112,7 +112,6 @@ func Test_writer_Open(t *testing.T) {
 		maxPartSize int64
 		pw          io.WriteCloser
 		wg          *sync.WaitGroup
-		ctx         context.Context
 	}
 	type want struct {
 		err error
@@ -148,7 +147,6 @@ func Test_writer_Open(t *testing.T) {
 		           maxPartSize: 0,
 		           pw: nil,
 		           wg: sync.WaitGroup{},
-		           ctx: nil,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
@@ -171,7 +169,6 @@ func Test_writer_Open(t *testing.T) {
 		           maxPartSize: 0,
 		           pw: nil,
 		           wg: sync.WaitGroup{},
-		           ctx: nil,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
@@ -182,7 +179,7 @@ func Test_writer_Open(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -200,7 +197,6 @@ func Test_writer_Open(t *testing.T) {
 				maxPartSize: test.fields.maxPartSize,
 				pw:          test.fields.pw,
 				wg:          test.fields.wg,
-				ctx:         test.fields.ctx,
 			}
 
 			err := w.Open(test.args.ctx)
@@ -221,7 +217,6 @@ func Test_writer_Close(t *testing.T) {
 		maxPartSize int64
 		pw          io.WriteCloser
 		wg          *sync.WaitGroup
-		ctx         context.Context
 	}
 	type want struct {
 		err error
@@ -253,7 +248,6 @@ func Test_writer_Close(t *testing.T) {
 		           maxPartSize: 0,
 		           pw: nil,
 		           wg: sync.WaitGroup{},
-		           ctx: nil,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
@@ -273,7 +267,6 @@ func Test_writer_Close(t *testing.T) {
 		           maxPartSize: 0,
 		           pw: nil,
 		           wg: sync.WaitGroup{},
-		           ctx: nil,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
@@ -284,7 +277,7 @@ func Test_writer_Close(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -302,7 +295,6 @@ func Test_writer_Close(t *testing.T) {
 				maxPartSize: test.fields.maxPartSize,
 				pw:          test.fields.pw,
 				wg:          test.fields.wg,
-				ctx:         test.fields.ctx,
 			}
 
 			err := w.Close()
@@ -326,7 +318,6 @@ func Test_writer_Write(t *testing.T) {
 		maxPartSize int64
 		pw          io.WriteCloser
 		wg          *sync.WaitGroup
-		ctx         context.Context
 	}
 	type want struct {
 		wantN int
@@ -366,7 +357,6 @@ func Test_writer_Write(t *testing.T) {
 		           maxPartSize: 0,
 		           pw: nil,
 		           wg: sync.WaitGroup{},
-		           ctx: nil,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
@@ -389,7 +379,6 @@ func Test_writer_Write(t *testing.T) {
 		           maxPartSize: 0,
 		           pw: nil,
 		           wg: sync.WaitGroup{},
-		           ctx: nil,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
@@ -400,7 +389,7 @@ func Test_writer_Write(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -418,7 +407,6 @@ func Test_writer_Write(t *testing.T) {
 				maxPartSize: test.fields.maxPartSize,
 				pw:          test.fields.pw,
 				wg:          test.fields.wg,
-				ctx:         test.fields.ctx,
 			}
 
 			gotN, err := w.Write(test.args.p)
@@ -432,6 +420,7 @@ func Test_writer_Write(t *testing.T) {
 
 func Test_writer_upload(t *testing.T) {
 	type args struct {
+		ctx  context.Context
 		body io.Reader
 	}
 	type fields struct {
@@ -442,7 +431,6 @@ func Test_writer_upload(t *testing.T) {
 		maxPartSize int64
 		pw          io.WriteCloser
 		wg          *sync.WaitGroup
-		ctx         context.Context
 	}
 	type want struct {
 		err error
@@ -468,6 +456,7 @@ func Test_writer_upload(t *testing.T) {
 		   {
 		       name: "test_case_1",
 		       args: args {
+		           ctx: nil,
 		           body: nil,
 		       },
 		       fields: fields {
@@ -478,7 +467,6 @@ func Test_writer_upload(t *testing.T) {
 		           maxPartSize: 0,
 		           pw: nil,
 		           wg: sync.WaitGroup{},
-		           ctx: nil,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
@@ -491,6 +479,7 @@ func Test_writer_upload(t *testing.T) {
 		       return test {
 		           name: "test_case_2",
 		           args: args {
+		           ctx: nil,
 		           body: nil,
 		           },
 		           fields: fields {
@@ -501,7 +490,6 @@ func Test_writer_upload(t *testing.T) {
 		           maxPartSize: 0,
 		           pw: nil,
 		           wg: sync.WaitGroup{},
-		           ctx: nil,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
@@ -512,7 +500,7 @@ func Test_writer_upload(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -530,10 +518,9 @@ func Test_writer_upload(t *testing.T) {
 				maxPartSize: test.fields.maxPartSize,
 				pw:          test.fields.pw,
 				wg:          test.fields.wg,
-				ctx:         test.fields.ctx,
 			}
 
-			err := w.upload(test.args.body)
+			err := w.upload(test.args.ctx, test.args.body)
 			if err := test.checkFunc(test.want, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
- removed ctx from struct because of anti-pattern.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
nothing.

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
nothing.

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.3
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.11.5

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [X] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
