### PR TITLE
Add `internal/params` pacakge test

### DIFF
--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -658,7 +658,6 @@ We do not suggest to modify the generated code other than the `tests` variable, 
     ```
 
     Since the `port` variable is not used in this test case, you can delete the `port` definition in the test case.
-
     ```golang
     func Test_server_Addr(t *testing.T) {
         type fields struct {

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -278,7 +278,7 @@ This is an example of the unused variable declaration that does not cause a comp
 
 type server struct {
     addr string
-    port int
+    port int  // you have to delete this field.
 }
 
 // The `port` field of `server` is not used.

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -632,10 +632,10 @@ We do not suggest to modify the generated code other than the `tests` variable, 
 
 1. Unused Variables
 
-    Unused variable may increase the complexity of the source code, it may confuse the developer hence introduce a new bug.
+    An unused variable may increase the complexity of the source code, it may confuse the developer hence introduce a new bug.
     So please delete the unused variable.
     
-    Generally the unused variable should be reported during compilation, but in some case the compiler may not report an error. This is an example of the unused variable declaration that does not cause an compilation error.<br>
+    Generally, the unused variable should be reported during compilation, but in some cases, the compiler may not report an error. This is an example of the unused variable declaration that does not cause a compilation error.<br />
     
     ```go
     type server struct {

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -652,7 +652,7 @@ We do not suggest to modify the generated code other than the `tests` variable, 
         type fields struct {
             addr string
             port int
-	}
+    }
     type want struct {
         // generated test code
     ```

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -269,7 +269,7 @@ func (s *something) SetSignedTok(st string) {
 An unused variable may increase the complexity of the source code, it may confuse the developer hence introduce a new bug.
 So please delete the unused variable.
 
-Generally, the unused variable should be reported during compilation, but in some cases, the compiler may not report an error. This is an example of the unused variable declaration that does not cause a compilation error.<br />
+Generally, the unused variable should be reported during compilation, but in some cases, the compiler may not report an error. This is an example of the unused variable declaration that does not cause a compilation error.
 
 ```golang
 type server struct {

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -652,9 +652,9 @@ We do not suggest to modify the generated code other than the `tests` variable, 
         type fields struct {
             addr string
             port int
-    }
-    type want struct {
-    // generated test code
+        }
+        type want struct {
+            // generated test code
     ```
 
     Since the `port` variable is not used in this test case, you can delete the `port` definition in the test case.
@@ -664,7 +664,7 @@ We do not suggest to modify the generated code other than the `tests` variable, 
         type fields struct {
             addr string
             // port int   <-- this line should be deleted
-	}
-    type want struct {
-    // generated test code
+        }
+        type want struct {
+            // generated test code
     ```

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -630,7 +630,6 @@ We do not suggest to modify the generated code other than the `tests` variable, 
 1. Unused fields
 
     By default, the template provides `fields` structure to initialize object of the test target. 
-    
     But in some cases, not all `fields` are needed, so please delete the unnecessary fields.
 
     For example, the following struct and the corresponding function:

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -285,7 +285,6 @@ srv := &server {
 if err := srv.Run(); err != nil {
     log.Fatal(err)
 }
-
 ```
 
 ### Error handling

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -266,12 +266,10 @@ func (s *something) SetSignedTok(st string) {
 
 ### Unused Variables
 
-It is an error to declare a variable without using it.
-while a variable that is initialized but not used is at least a wasted computation and perhaps indicative of a larger bug.
-So please delete unused variables.
+An unused variable may increase the complexity of the source code, it may confuse the developer hence introduce a new bug.
+So please delete the unused variable.
 
-The following is an example of an unused variables that does not cause an error.<br>
-Please delete any variables that you don't need, as they can create bugs.
+Generally, the unused variable should be reported during compilation, but in some cases, the compiler may not report an error. This is an example of the unused variable declaration that does not cause a compilation error.<br />
 
 ```go
 type server struct {
@@ -555,30 +553,6 @@ After the command above executed, the file `*target*_test.go` will be generated 
 The test code generated follows the table-driven test format.
 You can implement your test code under the `tests` variable generated following the table-driven test format.
 
-### Unused Variables
-
-An unused variable may increase the complexity of the source code, it may confuse the developer hence introduce a new bug.
-So please delete the unused variable.
-
-Generally, the unused variable should be reported during compilation, but in some cases, the compiler may not report an error. This is an example of the unused variable declaration that does not cause a compilation error.<br />
-
-```go
-type server struct {
-    addr string
-    port int
-}
-
-srv := &server {
-    addr: "192.168.33.10:1234",
-    // port <- unused variables
-}
-
-if err := srv.Run(); err != nil {
-    log.Fatal(err)
-}
-
-```
-
 ### Customize test case
 
 We do not suggest to modify the generated code other than the `tests` variable, but in some cases, you may need to modify the generated code to meet your requirement, for example:
@@ -653,3 +627,17 @@ We do not suggest to modify the generated code other than the `tests` variable, 
         }
         // generated test code
     ```
+
+1. Unused fields
+
+    By default, the template provides `fields` structure to initialize object of the test target. But in some cases, not all `fields` are needed. So please delete unnecessary fields.
+
+    If the test case needs only `addr` of `fields`, please delete other fields.
+
+    ```go
+    type fields struct {
+        addr    string
+        // port    int   <- please delete this fields
+    }
+    ```
+    

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -630,7 +630,9 @@ We do not suggest to modify the generated code other than the `tests` variable, 
 
 1. Unused fields
 
-    By default, the template provides `fields` structure to initialize object of the test target. But in some cases, not all `fields` are needed. So please delete unnecessary fields.
+    By default, the template provides `fields` structure to initialize object of the test target. 
+    
+    But in some cases, not all `fields` are needed, so please delete the unnecessary fields.
 
     If the test case needs only `addr` of `fields`, please delete other fields.
 

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -654,7 +654,7 @@ We do not suggest to modify the generated code other than the `tests` variable, 
             port int
     }
     type want struct {
-        // generated test code
+    // generated test code
     ```
 
     Since the `port` variable is not used in this test case, you can delete the `port` definition in the test case.

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -653,7 +653,7 @@ We do not suggest to modify the generated code other than the `tests` variable, 
             addr string
             port int
 	}
-	type want struct {
+    type want struct {
         // generated test code
     ```
 

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -666,5 +666,5 @@ We do not suggest to modify the generated code other than the `tests` variable, 
             // port int   <-- this line should be deleted
 	}
     type want struct {
-        // generated test code
+    // generated test code
     ```

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -281,7 +281,7 @@ type server struct {
     port int
 }
 
-// The port number is included in `addr`, so the `port` field of `server` is not used.
+// The `port` field of `server` is not used.
 srv := &server {
     addr: "192.168.33.10:1234",
 }

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -631,7 +631,6 @@ We do not suggest to modify the generated code other than the `tests` variable, 
 
     By default, the template provides `fields` structure to initialize object of the test target. 
     But in some cases, not all `fields` are needed, so please delete the unnecessary fields.
-
     For example, the following struct and the corresponding function:
     
     ```golang

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -555,6 +555,30 @@ After the command above executed, the file `*target*_test.go` will be generated 
 The test code generated follows the table-driven test format.
 You can implement your test code under the `tests` variable generated following the table-driven test format.
 
+### Unused Variables
+
+An unused variable may increase the complexity of the source code, it may confuse the developer hence introduce a new bug.
+So please delete the unused variable.
+
+Generally, the unused variable should be reported during compilation, but in some cases, the compiler may not report an error. This is an example of the unused variable declaration that does not cause a compilation error.<br />
+
+```go
+type server struct {
+    addr string
+    port int
+}
+
+srv := &server {
+    addr: "192.168.33.10:1234",
+    // port <- unused variables
+}
+
+if err := srv.Run(); err != nil {
+    log.Fatal(err)
+}
+
+```
+
 ### Customize test case
 
 We do not suggest to modify the generated code other than the `tests` variable, but in some cases, you may need to modify the generated code to meet your requirement, for example:
@@ -628,28 +652,4 @@ We do not suggest to modify the generated code other than the `tests` variable, 
             test.beforeFunc(test.args)
         }
         // generated test code
-    ```
-
-1. Unused Variables
-
-    An unused variable may increase the complexity of the source code, it may confuse the developer hence introduce a new bug.
-    So please delete the unused variable.
-    
-    Generally, the unused variable should be reported during compilation, but in some cases, the compiler may not report an error. This is an example of the unused variable declaration that does not cause a compilation error.<br />
-    
-    ```go
-    type server struct {
-        addr string
-        port int
-    }
-    
-    srv := &server {
-        addr: "192.168.33.10:1234",
-        // port <- unused variables
-    }
-    
-    if err := srv.Run(); err != nil {
-        log.Fatal(err)
-    }
-    
     ```

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -643,7 +643,7 @@ We do not suggest to modify the generated code other than the `tests` variable, 
     }
     func (s *server) Addr() string {
         return s.addr
-     }
+    }
     ```
 
     And the generated test code is:

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -629,3 +629,27 @@ We do not suggest to modify the generated code other than the `tests` variable, 
         }
         // generated test code
     ```
+
+1. Unused Variables
+
+    Unused variable may increase the complexity of the source code, it may confuse the developer hence introduce a new bug.
+    So please delete the unused variable.
+    
+    Generally the unused variable should be reported during compilation, but in some case the compiler may not report an error. This is an example of the unused variable declaration that does not cause an compilation error.<br>
+    
+    ```go
+    type server struct {
+        addr string
+        port int
+    }
+    
+    srv := &server {
+        addr: "192.168.33.10:1234",
+        // port <- unused variables
+    }
+    
+    if err := srv.Run(); err != nil {
+        log.Fatal(err)
+    }
+    
+    ```

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -668,12 +668,3 @@ We do not suggest to modify the generated code other than the `tests` variable, 
 	type want struct {
         // generated test code
     ```
-
-
-    ```go
-    type fields struct {
-        addr    string
-        // port    int   <- please delete this fields
-    }
-    ```
-    

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -269,7 +269,8 @@ func (s *something) SetSignedTok(st string) {
 An unused variable may increase the complexity of the source code, it may confuse the developer hence introduce a new bug.
 So please delete the unused variable.
 
-Generally, the unused variable should be reported during compilation, but in some cases, the compiler may not report an error. This is an example of the unused variable declaration that does not cause a compilation error.
+Generally, the unused variable should be reported during compilation, but in some cases, the compiler may not report an error. 
+This is an example of the unused variable declaration that does not cause a compilation error.
 
 ```golang
 // In this case, this example are not using `port` field, but dose not cause a compilation error.

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -634,7 +634,41 @@ We do not suggest to modify the generated code other than the `tests` variable, 
     
     But in some cases, not all `fields` are needed, so please delete the unnecessary fields.
 
-    If the test case needs only `addr` of `fields`, please delete other fields.
+    For example, the following struct and the corresponding function:
+    
+    ```golang
+    type server struct {
+        addr string
+        port int
+    }
+    func (s *server) Addr() string {
+        return s.addr
+     }
+    ```
+
+    And the generated test code is:
+    ```golang
+    func Test_server_Addr(t *testing.T) {
+        type fields struct {
+            addr string
+            port int
+	}
+	type want struct {
+        // generated test code
+    ```
+
+    Since the `port` variable is not used in this test case, you can delete the `port` definition in the test case.
+
+    ```golang
+    func Test_server_Addr(t *testing.T) {
+        type fields struct {
+            addr string
+            // port int   <-- this line should be deleted
+	}
+	type want struct {
+        // generated test code
+    ```
+
 
     ```go
     type fields struct {

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -264,6 +264,32 @@ func (s *something) SetSignedTok(st string) {
 }
 ```
 
+### Unused Variables
+
+It is an error to declare a variable without using it.
+while a variable that is initialized but not used is at least a wasted computation and perhaps indicative of a larger bug.
+So please delete unused variables.
+
+The following is an example of an unused variables that does not cause an error.<br>
+Please delete any variables that you don't need, as they can create bugs.
+
+```go
+type server struct {
+    addr string
+    port int
+}
+
+srv := &server {
+    addr: "192.168.33.10:1234",
+    // port <- unused variables
+}
+
+if err := srv.Run(); err != nil {
+    log.Fatal(err)
+}
+
+```
+
 ### Error handling
 
 All errors should define in [internal/errors package](https://github.com/vdaas/vald/blob/master/internal/errors). All errors should be start with `Err` prefix, and all errors should be handle if possible.

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -271,7 +271,7 @@ So please delete the unused variable.
 
 Generally, the unused variable should be reported during compilation, but in some cases, the compiler may not report an error. This is an example of the unused variable declaration that does not cause a compilation error.<br />
 
-```go
+```golang
 type server struct {
     addr string
     port int

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -665,6 +665,6 @@ We do not suggest to modify the generated code other than the `tests` variable, 
             addr string
             // port int   <-- this line should be deleted
 	}
-	type want struct {
+    type want struct {
         // generated test code
     ```

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -272,14 +272,17 @@ So please delete the unused variable.
 Generally, the unused variable should be reported during compilation, but in some cases, the compiler may not report an error. This is an example of the unused variable declaration that does not cause a compilation error.
 
 ```golang
+// In this case, this example are not using `port` field, but dose not cause a compilation error.
+// So please delete `port` field of `server`.
+
 type server struct {
     addr string
     port int
 }
 
+// The port number is included in `addr`, so the `port` field of `server` is not used.
 srv := &server {
     addr: "192.168.33.10:1234",
-    // port <- unused variables
 }
 
 if err := srv.Run(); err != nil {

--- a/internal/params/option.go
+++ b/internal/params/option.go
@@ -30,36 +30,42 @@ var (
 	}
 )
 
+// WithConfigFilePathKeys returns Option that sets filePath.keys.
 func WithConfigFilePathKeys(keys ...string) Option {
 	return func(p *parser) {
 		p.filePath.keys = append(p.filePath.keys, keys...)
 	}
 }
 
+// WithConfigFilePathDefault returns Option that sets filePath.defaultPath.
 func WithConfigFilePathDefault(path string) Option {
 	return func(p *parser) {
 		p.filePath.defaultPath = path
 	}
 }
 
+// WithConfigFileDescription returns Option that sets filePath.description.
 func WithConfigFileDescription(desc string) Option {
 	return func(p *parser) {
 		p.filePath.description = desc
 	}
 }
 
+// WithVersionKeys returns Option that sets version.keys.
 func WithVersionKeys(keys ...string) Option {
 	return func(p *parser) {
 		p.version.keys = append(p.version.keys, keys...)
 	}
 }
 
+// WithVersionFlagDefault returns Option that sets version.defaultFlag.
 func WithVersionFlagDefault(flag bool) Option {
 	return func(p *parser) {
 		p.version.defaultFlag = flag
 	}
 }
 
+// WithVersionDescription returns Option that sets version.description.
 func WithVersionDescription(desc string) Option {
 	return func(p *parser) {
 		p.version.description = desc

--- a/internal/params/option_test.go
+++ b/internal/params/option_test.go
@@ -18,88 +18,64 @@
 package params
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/vdaas/vald/internal/errors"
 	"go.uber.org/goleak"
 )
 
 func TestWithConfigFilePathKeys(t *testing.T) {
-	type T = interface{}
+	type T = parser
 	type args struct {
 		keys []string
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got error = %v, want %v", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.c)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T) error {
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got = %v, want %v", obj, w.obj)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           keys: nil,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           keys: nil,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set success when keys is `key1`",
+			args: args{
+				keys: []string{
+					"key1",
+				},
+			},
+			want: want{
+				obj: &T{
+					filePath: struct {
+						keys        []string
+						defaultPath string
+						description string
+					}{
+						keys: []string{
+							"key1",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -107,112 +83,66 @@ func TestWithConfigFilePathKeys(t *testing.T) {
 				defer test.afterFunc(test.args)
 			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithConfigFilePathKeys(test.args.keys...)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithConfigFilePathKeys(test.args.keys...)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(tt.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+			got := WithConfigFilePathKeys(test.args.keys...)
+			obj := new(T)
+			got(obj)
+			if err := test.checkFunc(test.want, obj); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithConfigFilePathDefault(t *testing.T) {
-	type T = interface{}
+	type T = parser
 	type args struct {
 		path string
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got error = %v, want %v", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.c)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T) error {
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got = %v, want %v", obj, w.obj)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           path: "",
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           path: "",
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set success when path is `path`",
+			args: args{
+				path: "path",
+			},
+			want: want{
+				obj: &T{
+					filePath: struct {
+						keys        []string
+						defaultPath string
+						description string
+					}{
+						defaultPath: "path",
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -220,112 +150,66 @@ func TestWithConfigFilePathDefault(t *testing.T) {
 				defer test.afterFunc(test.args)
 			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithConfigFilePathDefault(test.args.path)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithConfigFilePathDefault(test.args.path)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(tt.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+			got := WithConfigFilePathDefault(test.args.path)
+			obj := new(T)
+			got(obj)
+			if err := test.checkFunc(test.want, obj); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithConfigFileDescription(t *testing.T) {
-	type T = interface{}
+	type T = parser
 	type args struct {
 		desc string
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got error = %v, want %v", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.c)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T) error {
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got = %v, want %v", obj, w.obj)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           desc: "",
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           desc: "",
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set success when desc is `desc`",
+			args: args{
+				desc: "desc",
+			},
+			want: want{
+				obj: &T{
+					filePath: struct {
+						keys        []string
+						defaultPath string
+						description string
+					}{
+						description: "desc",
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -333,112 +217,70 @@ func TestWithConfigFileDescription(t *testing.T) {
 				defer test.afterFunc(test.args)
 			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithConfigFileDescription(test.args.desc)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithConfigFileDescription(test.args.desc)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(tt.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+			got := WithConfigFileDescription(test.args.desc)
+			obj := new(T)
+			got(obj)
+			if err := test.checkFunc(test.want, obj); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithVersionKeys(t *testing.T) {
-	type T = interface{}
+	type T = parser
 	type args struct {
 		keys []string
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got error = %v, want %v", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.c)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T) error {
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got = %v, want %v", obj, w.obj)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           keys: nil,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           keys: nil,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set success when keys is `key1`",
+			args: args{
+				keys: []string{
+					"key1",
+				},
+			},
+			want: want{
+				obj: &T{
+					version: struct {
+						keys        []string
+						defaultFlag bool
+						description string
+					}{
+						keys: []string{
+							"key1",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -446,112 +288,66 @@ func TestWithVersionKeys(t *testing.T) {
 				defer test.afterFunc(test.args)
 			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithVersionKeys(test.args.keys...)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithVersionKeys(test.args.keys...)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(tt.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+			got := WithVersionKeys(test.args.keys...)
+			obj := new(T)
+			got(obj)
+			if err := test.checkFunc(test.want, obj); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithVersionFlagDefault(t *testing.T) {
-	type T = interface{}
+	type T = parser
 	type args struct {
 		flag bool
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got error = %v, want %v", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.c)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T) error {
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got = %v, want %v", obj, w.obj)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           flag: false,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           flag: false,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set success when flag is true",
+			args: args{
+				flag: true,
+			},
+			want: want{
+				obj: &T{
+					version: struct {
+						keys        []string
+						defaultFlag bool
+						description string
+					}{
+						defaultFlag: true,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -559,112 +355,66 @@ func TestWithVersionFlagDefault(t *testing.T) {
 				defer test.afterFunc(test.args)
 			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithVersionFlagDefault(test.args.flag)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithVersionFlagDefault(test.args.flag)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(tt.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+			got := WithVersionFlagDefault(test.args.flag)
+			obj := new(T)
+			got(obj)
+			if err := test.checkFunc(test.want, obj); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithVersionDescription(t *testing.T) {
-	type T = interface{}
+	type T = parser
 	type args struct {
 		desc string
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got error = %v, want %v", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.c)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T) error {
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got = %v, want %v", obj, w.obj)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           desc: "",
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           desc: "",
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set success when desc is true",
+			args: args{
+				desc: "desc",
+			},
+			want: want{
+				obj: &T{
+					version: struct {
+						keys        []string
+						defaultFlag bool
+						description string
+					}{
+						description: "desc",
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -672,31 +422,15 @@ func TestWithVersionDescription(t *testing.T) {
 				defer test.afterFunc(test.args)
 			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithVersionDescription(test.args.desc)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithVersionDescription(test.args.desc)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(tt.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+			got := WithVersionDescription(test.args.desc)
+			obj := new(T)
+			got(obj)
+			if err := test.checkFunc(test.want, obj); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }

--- a/internal/params/params.go
+++ b/internal/params/params.go
@@ -58,8 +58,7 @@ func New(opts ...Option) *parser {
 	return p
 }
 
-// Parse parses command-line argument and returns parsed data.
-// If parse fails, returns an error but when there is help option, returns nil and true.
+// Parse parses command-line argument and returns parsed data and whether there is a help option or not and error.
 func (p *parser) Parse() (Data, bool, error) {
 	f := flag.NewFlagSet(filepath.Base(os.Args[0]), flag.ContinueOnError)
 

--- a/internal/params/params.go
+++ b/internal/params/params.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vdaas/vald/internal/errors"
 )
 
+// Data is an interface to get the configuration path and flag.
 type Data interface {
 	ConfigFilePath() string
 	ShowVersion() bool
@@ -48,6 +49,7 @@ type parser struct {
 	}
 }
 
+// New returns parser object.
 func New(opts ...Option) *parser {
 	p := new(parser)
 	for _, opt := range append(defaultOpts, opts...) {
@@ -56,6 +58,7 @@ func New(opts ...Option) *parser {
 	return p
 }
 
+// Parse parses command-line argument and returns parsed data.
 func (p *parser) Parse() (Data, bool, error) {
 	f := flag.NewFlagSet(filepath.Base(os.Args[0]), flag.ContinueOnError)
 
@@ -94,10 +97,12 @@ func (p *parser) Parse() (Data, bool, error) {
 	return d, false, nil
 }
 
+// ConfigFilePath returns configFilePath.
 func (d *data) ConfigFilePath() string {
 	return d.configFilePath
 }
 
+// ShowVersion returns showVersion.
 func (d *data) ShowVersion() bool {
 	return d.showVersion
 }

--- a/internal/params/params.go
+++ b/internal/params/params.go
@@ -59,6 +59,7 @@ func New(opts ...Option) *parser {
 }
 
 // Parse parses command-line argument and returns parsed data.
+// If parse fails, returns an error but when there is help option, returns nil and true.
 func (p *parser) Parse() (Data, bool, error) {
 	f := flag.NewFlagSet(filepath.Base(os.Args[0]), flag.ContinueOnError)
 

--- a/internal/params/params_test.go
+++ b/internal/params/params_test.go
@@ -190,7 +190,7 @@ func Test_parser_Parse(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "returns (d, false, nil) when parse succeeds",
+			name: "returns (d, false, nil) when parse succeed",
 			fields: fields{
 				filePath: struct {
 					keys        []string
@@ -286,8 +286,6 @@ func Test_parser_Parse(t *testing.T) {
 			},
 		},
 	}
-
-	type h = syscall.Errno
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {

--- a/internal/params/params_test.go
+++ b/internal/params/params_test.go
@@ -200,7 +200,7 @@ func Test_parser_Parse(t *testing.T) {
 					keys: []string{
 						"path", "p",
 					},
-					defaultPath: "./test_datas/config.yml",
+					defaultPath: "./params.go",
 					description: "sets file path",
 				},
 				version: struct {
@@ -217,13 +217,13 @@ func Test_parser_Parse(t *testing.T) {
 			},
 			beforeFunc: func() {
 				os.Args = []string{
-					"test", "--path=./test_datas/config.yml", "--version=false",
+					"test", "--path=./params.go", "--version=false",
 				}
 			},
 			afterFunc: func() { os.Args = nil },
 			want: want{
 				want: &data{
-					configFilePath: "./test_datas/config.yml",
+					configFilePath: "./params.go",
 					showVersion:    false,
 				},
 			},


### PR DESCRIPTION
Signed-off-by: hlts2 <hiroto.funakoshi.hiroto@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

I added `internal/params` pacakge test.
this test' coverage is 100%.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.3
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.11.5

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
