### PR TITLE
[patch] Revise S3 reader/writer: compatible with IBM Cloud Object Storage

### DIFF
--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -1442,6 +1442,9 @@ agent:
           # @schema {"name": "agent.sidecar.config.blob_storage.s3.max_part_size", "type": "string", "pattern": "^[0-9]+(kb|mb|gb)$"}
           # agent.sidecar.config.blob_storage.s3.max_part_size -- s3 multipart upload max part size
           max_part_size: 64mb
+          # @schema {"name": "agent.sidecar.config.blob_storage.s3.max_chunk_size", "type": "string", "pattern": "^[0-9]+(kb|mb|gb)$"}
+          # agent.sidecar.config.blob_storage.s3.max_chunk_size -- s3 download max chunk size
+          max_chunk_size: 64mb
       # @schema {"name": "agent.sidecar.config.compress", "type": "object"}
       compress:
         # @schema {"name": "agent.sidecar.config.compress.compress_algorithm", "type": "string", "enum": ["gob", "gzip", "lz4", "zstd"]}
@@ -1536,6 +1539,8 @@ agent:
             retry_count: 100
             # agent.sidecar.config.client.transport.backoff.enable_error_log -- backoff error log enabled
             enable_error_log: true
+      # agent.sidecar.config.restore_backoff_enabled -- restore backoff enabled
+      restore_backoff_enabled: false
       # @schema {"name": "agent.sidecar.config.restore_backoff", "alias": "backoff"}
       restore_backoff:
         # agent.sidecar.config.restore_backoff.initial_duration -- restore backoff initial duration

--- a/internal/config/blob.go
+++ b/internal/config/blob.go
@@ -71,7 +71,8 @@ type S3Config struct {
 	EnableEndpointDiscovery    bool `json:"enable_endpoint_discovery" yaml:"enable_endpoint_discovery"`
 	EnableEndpointHostPrefix   bool `json:"enable_endpoint_host_prefix" yaml:"enable_endpoint_host_prefix"`
 
-	MaxPartSize string `json:"max_part_size" yaml:"max_part_size"`
+	MaxPartSize  string `json:"max_part_size" yaml:"max_part_size"`
+	MaxChunkSize string `json:"max_chunk_size" yaml:"max_chunk_size"`
 }
 
 func (b *Blob) Bind() *Blob {
@@ -94,6 +95,7 @@ func (s *S3Config) Bind() *S3Config {
 	s.SecretAccessKey = GetActualValue(s.SecretAccessKey)
 	s.Token = GetActualValue(s.Token)
 	s.MaxPartSize = GetActualValue(s.MaxPartSize)
+	s.MaxChunkSize = GetActualValue(s.MaxChunkSize)
 
 	return s
 }

--- a/internal/config/sidecar.go
+++ b/internal/config/sidecar.go
@@ -42,6 +42,9 @@ type AgentSidecar struct {
 	// Compress represent compression configurations
 	Compress *CompressCore `yaml:"compress" json:"compress"`
 
+	// RestoreBackoffEnabled represent backoff enabled or not
+	RestoreBackoffEnabled bool `yaml:"restore_backoff_enabled" json:"restore_backoff_enabled"`
+
 	// RestoreBackoff represent backoff configurations for restoring process
 	RestoreBackoff *Backoff `yaml:"restore_backoff" json:"restore_backoff"`
 

--- a/internal/db/storage/blob/s3/option.go
+++ b/internal/db/storage/blob/s3/option.go
@@ -19,6 +19,7 @@ package s3
 import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/vdaas/vald/internal/backoff"
 	"github.com/vdaas/vald/internal/errgroup"
 	"github.com/vdaas/vald/internal/unit"
 )
@@ -81,6 +82,25 @@ func WithMaxChunkSize(size string) Option {
 		if int64(b) >= s3manager.MinUploadPartSize {
 			c.maxChunkSize = int64(b)
 		}
+
+		return nil
+	}
+}
+
+func WithReaderBackoff(enabled bool) Option {
+	return func(c *client) error {
+		c.readerBackoffEnabled = enabled
+		return nil
+	}
+}
+
+func WithReaderBackoffOpts(opts ...backoff.Option) Option {
+	return func(c *client) error {
+		if c.readerBackoffOpts == nil {
+			c.readerBackoffOpts = opts
+		}
+
+		c.readerBackoffOpts = append(c.readerBackoffOpts, opts...)
 
 		return nil
 	}

--- a/internal/db/storage/blob/s3/option.go
+++ b/internal/db/storage/blob/s3/option.go
@@ -70,3 +70,18 @@ func WithMaxPartSize(size string) Option {
 		return nil
 	}
 }
+
+func WithMaxChunkSize(size string) Option {
+	return func(c *client) error {
+		b, err := unit.ParseBytes(size)
+		if err != nil {
+			return err
+		}
+
+		if int64(b) >= s3manager.MinUploadPartSize {
+			c.maxChunkSize = int64(b)
+		}
+
+		return nil
+	}
+}

--- a/internal/db/storage/blob/s3/reader/option.go
+++ b/internal/db/storage/blob/s3/reader/option.go
@@ -26,6 +26,7 @@ type Option func(r *reader)
 var (
 	defaultOpts = []Option{
 		WithErrGroup(errgroup.Get()),
+		WithMaxChunkSize(512 * 1024 * 1024),
 	}
 )
 
@@ -54,5 +55,11 @@ func WithBucket(bucket string) Option {
 func WithKey(key string) Option {
 	return func(r *reader) {
 		r.key = key
+	}
+}
+
+func WithMaxChunkSize(size int64) Option {
+	return func(r *reader) {
+		r.maxChunkSize = size
 	}
 }

--- a/internal/db/storage/blob/s3/reader/option.go
+++ b/internal/db/storage/blob/s3/reader/option.go
@@ -18,6 +18,7 @@ package reader
 
 import (
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/vdaas/vald/internal/backoff"
 	"github.com/vdaas/vald/internal/errgroup"
 )
 
@@ -27,6 +28,7 @@ var (
 	defaultOpts = []Option{
 		WithErrGroup(errgroup.Get()),
 		WithMaxChunkSize(512 * 1024 * 1024),
+		WithBackoff(false),
 	}
 )
 
@@ -61,5 +63,21 @@ func WithKey(key string) Option {
 func WithMaxChunkSize(size int64) Option {
 	return func(r *reader) {
 		r.maxChunkSize = size
+	}
+}
+
+func WithBackoff(enabled bool) Option {
+	return func(r *reader) {
+		r.backoffEnabled = enabled
+	}
+}
+
+func WithBackoffOpts(opts ...backoff.Option) Option {
+	return func(r *reader) {
+		if r.backoffOpts == nil {
+			r.backoffOpts = opts
+		}
+
+		r.backoffOpts = append(r.backoffOpts, opts...)
 	}
 }

--- a/internal/db/storage/blob/s3/reader/reader.go
+++ b/internal/db/storage/blob/s3/reader/reader.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/vdaas/vald/internal/errgroup"
 	"github.com/vdaas/vald/internal/errors"
+	ctxio "github.com/vdaas/vald/internal/io"
 	"github.com/vdaas/vald/internal/log"
 	"github.com/vdaas/vald/internal/safety"
 )
@@ -81,6 +82,11 @@ func (r *reader) Open(ctx context.Context) (err error) {
 
 			log.Debugf("loading %d bytes...", offset)
 			body, err := r.getObject(ctx, offset, r.maxChunkSize)
+			if err != nil {
+				return err
+			}
+
+			body, err = ctxio.NewReadCloserWithContext(ctx, body)
 			if err != nil {
 				return err
 			}

--- a/internal/db/storage/blob/s3/reader/reader.go
+++ b/internal/db/storage/blob/s3/reader/reader.go
@@ -171,14 +171,16 @@ func (r *reader) getObject(ctx context.Context, offset, length int64) (io.Reader
 
 	buf := new(bytes.Buffer)
 
+	defer func() {
+		e := res.Close()
+		if e != nil {
+			log.Warn(e)
+		}
+	}()
+
 	_, err = io.Copy(buf, res)
 	if err != nil {
 		return nil, err
-	}
-
-	err = res.Close()
-	if err != nil {
-		log.Warn(err)
 	}
 
 	return buf, nil

--- a/internal/db/storage/blob/s3/s3.go
+++ b/internal/db/storage/blob/s3/s3.go
@@ -36,7 +36,8 @@ type client struct {
 	service *s3.S3
 	bucket  string
 
-	maxPartSize int64
+	maxPartSize  int64
+	maxChunkSize int64
 }
 
 func New(opts ...Option) (blob.Bucket, error) {
@@ -66,6 +67,7 @@ func (c *client) Reader(ctx context.Context, key string) (io.ReadCloser, error) 
 		reader.WithService(c.service),
 		reader.WithBucket(c.bucket),
 		reader.WithKey(key),
+		reader.WithMaxChunkSize(c.maxChunkSize),
 	)
 
 	return r, r.Open(ctx)

--- a/internal/db/storage/blob/s3/s3.go
+++ b/internal/db/storage/blob/s3/s3.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/vdaas/vald/internal/backoff"
 	"github.com/vdaas/vald/internal/db/storage/blob"
 	"github.com/vdaas/vald/internal/db/storage/blob/s3/reader"
 	"github.com/vdaas/vald/internal/db/storage/blob/s3/writer"
@@ -38,6 +39,9 @@ type client struct {
 
 	maxPartSize  int64
 	maxChunkSize int64
+
+	readerBackoffEnabled bool
+	readerBackoffOpts    []backoff.Option
 }
 
 func New(opts ...Option) (blob.Bucket, error) {
@@ -68,6 +72,8 @@ func (c *client) Reader(ctx context.Context, key string) (io.ReadCloser, error) 
 		reader.WithBucket(c.bucket),
 		reader.WithKey(key),
 		reader.WithMaxChunkSize(c.maxChunkSize),
+		reader.WithBackoff(c.readerBackoffEnabled),
+		reader.WithBackoffOpts(c.readerBackoffOpts...),
 	)
 
 	return r, r.Open(ctx)

--- a/internal/db/storage/blob/s3/writer/option.go
+++ b/internal/db/storage/blob/s3/writer/option.go
@@ -26,6 +26,7 @@ type Option func(w *writer)
 var (
 	defaultOpts = []Option{
 		WithErrGroup(errgroup.Get()),
+		WithContentType("application/octet-stream"),
 		WithMaxPartSize(64 * 1024 * 1024),
 	}
 )
@@ -55,6 +56,14 @@ func WithBucket(bucket string) Option {
 func WithKey(key string) Option {
 	return func(w *writer) {
 		w.key = key
+	}
+}
+
+func WithContentType(ct string) Option {
+	return func(w *writer) {
+		if ct != "" {
+			w.contentType = ct
+		}
 	}
 }
 

--- a/internal/db/storage/blob/s3/writer/writer.go
+++ b/internal/db/storage/blob/s3/writer/writer.go
@@ -36,6 +36,7 @@ type writer struct {
 	bucket  string
 	key     string
 
+	contentType string
 	maxPartSize int64
 
 	pw io.WriteCloser
@@ -103,9 +104,10 @@ func (w *writer) upload(ctx context.Context, body io.Reader) (err error) {
 		},
 	)
 	input := &s3manager.UploadInput{
-		Bucket: aws.String(w.bucket),
-		Key:    aws.String(w.key),
-		Body:   body,
+		Bucket:      aws.String(w.bucket),
+		Key:         aws.String(w.key),
+		Body:        body,
+		ContentType: aws.String(w.contentType),
 	}
 
 	res, err := uploader.UploadWithContext(ctx, input)

--- a/internal/errors/io.go
+++ b/internal/errors/io.go
@@ -1,0 +1,33 @@
+//
+// Copyright (C) 2019-2020 Vdaas.org Vald team ( kpango, rinx, kmrmt )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package errors provides error types and function
+package errors
+
+var (
+	// io
+	NewErrContextNotProvided = func() error {
+		return New("context not provided")
+	}
+
+	NewErrReaderNotProvided = func() error {
+		return New("io.Reader not provided")
+	}
+
+	NewErrWriterNotProvided = func() error {
+		return New("io.Writer not provided")
+	}
+)

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -1,0 +1,141 @@
+//
+// Copyright (C) 2019-2020 Vdaas.org Vald team ( kpango, rinx, kmrmt )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package io provides io functions
+package io
+
+import (
+	"context"
+	"io"
+
+	"github.com/vdaas/vald/internal/errors"
+)
+
+type ctxReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func NewReaderWithContext(ctx context.Context, r io.Reader) (io.Reader, error) {
+	if ctx == nil {
+		return nil, errors.NewErrContextNotProvided()
+	}
+
+	if r == nil {
+		return nil, errors.NewErrReaderNotProvided()
+	}
+
+	return &ctxReader{
+		ctx: ctx,
+		r:   r,
+	}, nil
+}
+
+func NewReadCloserWithContext(ctx context.Context, r io.ReadCloser) (io.ReadCloser, error) {
+	if ctx == nil {
+		return nil, errors.NewErrContextNotProvided()
+	}
+
+	if r == nil {
+		return nil, errors.NewErrReaderNotProvided()
+	}
+
+	return &ctxReader{
+		ctx: ctx,
+		r:   r,
+	}, nil
+}
+
+func (r *ctxReader) Read(p []byte) (n int, err error) {
+	select {
+	case <-r.ctx.Done():
+		return 0, r.ctx.Err()
+	default:
+	}
+	return r.r.Read(p)
+}
+
+func (r *ctxReader) Close() error {
+	select {
+	case <-r.ctx.Done():
+		return r.ctx.Err()
+	default:
+	}
+
+	if c, ok := r.r.(io.Closer); ok {
+		return c.Close()
+	}
+
+	return nil
+}
+
+type ctxWriter struct {
+	ctx context.Context
+	w   io.Writer
+}
+
+func NewWriterWithContext(ctx context.Context, w io.Writer) (io.Writer, error) {
+	if ctx == nil {
+		return nil, errors.NewErrContextNotProvided()
+	}
+
+	if w == nil {
+		return nil, errors.NewErrWriterNotProvided()
+	}
+
+	return &ctxWriter{
+		ctx: ctx,
+		w:   w,
+	}, nil
+}
+
+func NewWriteCloserWithContext(ctx context.Context, w io.WriteCloser) (io.WriteCloser, error) {
+	if ctx == nil {
+		return nil, errors.NewErrContextNotProvided()
+	}
+
+	if w == nil {
+		return nil, errors.NewErrWriterNotProvided()
+	}
+
+	return &ctxWriter{
+		ctx: ctx,
+		w:   w,
+	}, nil
+}
+
+func (w *ctxWriter) Write(p []byte) (n int, err error) {
+	select {
+	case <-w.ctx.Done():
+		return 0, w.ctx.Err()
+	default:
+	}
+	return w.w.Write(p)
+}
+
+func (w *ctxWriter) Close() error {
+	select {
+	case <-w.ctx.Done():
+		return w.ctx.Err()
+	default:
+	}
+
+	if c, ok := w.w.(io.Closer); ok {
+		return c.Close()
+	}
+
+	return nil
+}

--- a/pkg/agent/sidecar/service/restorer/option.go
+++ b/pkg/agent/sidecar/service/restorer/option.go
@@ -28,6 +28,7 @@ type Option func(r *restorer) error
 var (
 	defaultOpts = []Option{
 		WithErrGroup(errgroup.Get()),
+		WithBackoff(false),
 	}
 )
 
@@ -57,6 +58,13 @@ func WithBlobStorage(storage storage.Storage) Option {
 		if storage != nil {
 			r.storage = storage
 		}
+		return nil
+	}
+}
+
+func WithBackoff(enabled bool) Option {
+	return func(r *restorer) error {
+		r.backoffEnabled = enabled
 		return nil
 	}
 }

--- a/pkg/agent/sidecar/service/restorer/restorer.go
+++ b/pkg/agent/sidecar/service/restorer/restorer.go
@@ -116,11 +116,6 @@ func (r *restorer) startRestore(ctx context.Context) (<-chan error, error) {
 		if err != nil {
 			log.Errorf("restoring failed: %s", err)
 
-			if errors.IsErrBlobNoSuchBucket(err) ||
-				errors.IsErrBlobNoSuchKey(err) {
-				return nil, nil
-			}
-
 			return nil, err
 		}
 

--- a/pkg/agent/sidecar/usecase/initcontainer/initcontainer.go
+++ b/pkg/agent/sidecar/usecase/initcontainer/initcontainer.go
@@ -120,6 +120,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		),
 		storage.WithS3Opts(
 			s3.WithMaxPartSize(cfg.AgentSidecar.BlobStorage.S3.MaxPartSize),
+			s3.WithMaxChunkSize(cfg.AgentSidecar.BlobStorage.S3.MaxChunkSize),
 		),
 		storage.WithCompressAlgorithm(cfg.AgentSidecar.Compress.CompressAlgorithm),
 		storage.WithCompressionLevel(cfg.AgentSidecar.Compress.CompressionLevel),
@@ -132,6 +133,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		restorer.WithErrGroup(eg),
 		restorer.WithDir(cfg.AgentSidecar.WatchDir),
 		restorer.WithBlobStorage(bs),
+		restorer.WithBackoff(cfg.AgentSidecar.RestoreBackoffEnabled),
 		restorer.WithBackoffOpts(cfg.AgentSidecar.RestoreBackoff.Opts()...),
 	)
 	if err != nil {

--- a/pkg/agent/sidecar/usecase/initcontainer/initcontainer.go
+++ b/pkg/agent/sidecar/usecase/initcontainer/initcontainer.go
@@ -121,6 +121,8 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		storage.WithS3Opts(
 			s3.WithMaxPartSize(cfg.AgentSidecar.BlobStorage.S3.MaxPartSize),
 			s3.WithMaxChunkSize(cfg.AgentSidecar.BlobStorage.S3.MaxChunkSize),
+			s3.WithReaderBackoff(cfg.AgentSidecar.RestoreBackoffEnabled),
+			s3.WithReaderBackoffOpts(cfg.AgentSidecar.RestoreBackoff.Opts()...),
 		),
 		storage.WithCompressAlgorithm(cfg.AgentSidecar.Compress.CompressAlgorithm),
 		storage.WithCompressionLevel(cfg.AgentSidecar.Compress.CompressionLevel),

--- a/pkg/agent/sidecar/usecase/sidecar/sidecar.go
+++ b/pkg/agent/sidecar/usecase/sidecar/sidecar.go
@@ -120,6 +120,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		),
 		storage.WithS3Opts(
 			s3.WithMaxPartSize(cfg.AgentSidecar.BlobStorage.S3.MaxPartSize),
+			s3.WithMaxChunkSize(cfg.AgentSidecar.BlobStorage.S3.MaxChunkSize),
 		),
 		storage.WithCompressAlgorithm(cfg.AgentSidecar.Compress.CompressAlgorithm),
 		storage.WithCompressionLevel(cfg.AgentSidecar.Compress.CompressionLevel),

--- a/pkg/agent/sidecar/usecase/sidecar/sidecar.go
+++ b/pkg/agent/sidecar/usecase/sidecar/sidecar.go
@@ -121,6 +121,8 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		storage.WithS3Opts(
 			s3.WithMaxPartSize(cfg.AgentSidecar.BlobStorage.S3.MaxPartSize),
 			s3.WithMaxChunkSize(cfg.AgentSidecar.BlobStorage.S3.MaxChunkSize),
+			s3.WithReaderBackoff(cfg.AgentSidecar.RestoreBackoffEnabled),
+			s3.WithReaderBackoffOpts(cfg.AgentSidecar.RestoreBackoff.Opts()...),
 		),
 		storage.WithCompressAlgorithm(cfg.AgentSidecar.Compress.CompressAlgorithm),
 		storage.WithCompressionLevel(cfg.AgentSidecar.Compress.CompressionLevel),


### PR DESCRIPTION
Signed-off-by: Rintaro Okamura <rintaro.okamura@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
- Add `max_chunk_size` option
- Add backoff option to S3 reader
- Add internal/io package

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Nothing.

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On GKE.

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.3
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.11.5

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [X] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
