### PR TITLE
added internal/config/log test

### DIFF
--- a/.github/codeql/codeql-config.yaml
+++ b/.github/codeql/codeql-config.yaml
@@ -4,7 +4,7 @@ queries:
   # - uses: github/codeql-go/ql/src@lgtm.com
 
 paths:
-  - '/cmd'
-  - '/hack'
-  - '/internal'
-  - '/pkg'
+  - "/cmd"
+  - "/hack"
+  - "/internal"
+  - "/pkg"

--- a/internal/config/log.go
+++ b/internal/config/log.go
@@ -17,12 +17,14 @@
 // Package config providers configuration type and load configuration logic
 package config
 
+// Logging represents Logging configuration.
 type Logging struct {
 	Logger string `json:"logger" yaml:"logger"`
 	Level  string `json:"level" yaml:"level"`
 	Format string `json:"format" yaml:"format"`
 }
 
+// Bind returns Logging object whose every value is field value or envirionment value.
 func (l *Logging) Bind() *Logging {
 	l.Logger = GetActualValue(l.Logger)
 	l.Level = GetActualValue(l.Level)

--- a/internal/config/log_test.go
+++ b/internal/config/log_test.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -48,35 +49,52 @@ func TestLogging_Bind(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           Logger: "",
-		           Level: "",
-		           Format: "",
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           Logger: "",
-		           Level: "",
-		           Format: "",
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return Logging when all fields contain no prefix/suffix symbol",
+			fields: fields{
+				Logger: "logger",
+				Level:  "info",
+				Format: "json",
+			},
+			want: want{
+				want: &Logging{
+					Logger: "logger",
+					Level:  "info",
+					Format: "json",
+				},
+			},
+		},
+		{
+			name: "return Logging when all fields contain has prefix/suffix symbol",
+			fields: fields{
+				Logger: "_logger_",
+				Level:  "_level_",
+				Format: "_format_",
+			},
+			beforeFunc: func() {
+				os.Setenv("logger", "glg")
+				os.Setenv("level", "info")
+				os.Setenv("format", "json")
+			},
+			afterFunc: func() {
+				os.Unsetenv("logger")
+				os.Unsetenv("level")
+				os.Unsetenv("format")
+			},
+			want: want{
+				want: &Logging{
+					Logger: "glg",
+					Level:  "info",
+					Format: "json",
+				},
+			},
+		},
+		{
+			name: "return Logging when all fields are empty",
+			want: want{
+				want: new(Logging),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/config/log_test.go
+++ b/internal/config/log_test.go
@@ -65,7 +65,7 @@ func TestLogging_Bind(t *testing.T) {
 			},
 		},
 		{
-			name: "returns Logging when all fields contain has prefix/suffix symbol",
+			name: "returns Logging with environment variable when it contains `_` prefix and suffix",
 			fields: fields{
 				Logger: "_logger_",
 				Level:  "_level_",

--- a/internal/config/log_test.go
+++ b/internal/config/log_test.go
@@ -50,7 +50,7 @@ func TestLogging_Bind(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return Logging when all fields contain no prefix/suffix symbol",
+			name: "returns Logging when all fields contain no prefix/suffix symbol",
 			fields: fields{
 				Logger: "logger",
 				Level:  "info",
@@ -65,7 +65,7 @@ func TestLogging_Bind(t *testing.T) {
 			},
 		},
 		{
-			name: "return Logging when all fields contain has prefix/suffix symbol",
+			name: "returns Logging when all fields contain has prefix/suffix symbol",
 			fields: fields{
 				Logger: "_logger_",
 				Level:  "_level_",
@@ -90,7 +90,7 @@ func TestLogging_Bind(t *testing.T) {
 			},
 		},
 		{
-			name: "return Logging when all fields are empty",
+			name: "returns Logging when all fields are empty",
 			want: want{
 				want: new(Logging),
 			},

--- a/internal/config/log_test.go
+++ b/internal/config/log_test.go
@@ -72,14 +72,14 @@ func TestLogging_Bind(t *testing.T) {
 				Format: "_format_",
 			},
 			beforeFunc: func() {
-				os.Setenv("logger", "glg")
-				os.Setenv("level", "info")
-				os.Setenv("format", "json")
+				_ = os.Setenv("logger", "glg")
+				_ = os.Setenv("level", "info")
+				_ = os.Setenv("format", "json")
 			},
 			afterFunc: func() {
-				os.Unsetenv("logger")
-				os.Unsetenv("level")
-				os.Unsetenv("format")
+				_ = os.Unsetenv("logger")
+				_ = os.Unsetenv("level")
+				_ = os.Unsetenv("format")
 			},
 			want: want{
 				want: &Logging{


### PR DESCRIPTION
Signed-off-by: vankichi <kyukawa315@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

I added test of `internal/config/log.go`
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.3
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.11.5

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
