### PR TITLE
[agent-sidecar] Add cancel hook for file watcher

### DIFF
--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -1374,7 +1374,7 @@ agent:
       auto_backup_duration: 10m
       # @schema {"name": "agent.sidecar.config.post_stop_timeout", "type": "string"}
       # agent.sidecar.config.post_stop_timeout -- timeout duration for file changing during post stop
-      post_stop_timeout: 10s
+      post_stop_timeout: 20s
       # @schema {"name": "agent.sidecar.config.filename", "type": "string"}
       # agent.sidecar.config.filename -- backup filename
       filename: _MY_POD_NAME_

--- a/pkg/agent/sidecar/service/observer/observer.go
+++ b/pkg/agent/sidecar/service/observer/observer.go
@@ -159,10 +159,19 @@ func (o *observer) PostStop(ctx context.Context) (err error) {
 		return err
 	}
 
-	_, err = o.w.Start(ctx)
+	wctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	_, err = o.w.Start(wctx)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		e := o.w.Stop(wctx)
+		if e != nil {
+			log.Error("an error occurred when watcher stopped:", e)
+		}
+	}()
 
 	for {
 		select {

--- a/pkg/agent/sidecar/service/observer/option.go
+++ b/pkg/agent/sidecar/service/observer/option.go
@@ -29,7 +29,7 @@ var (
 	defaultOpts = []Option{
 		WithErrGroup(errgroup.Get()),
 		WithBackupDuration("10m"),
-		WithPostStopTimeout("10s"),
+		WithPostStopTimeout("20s"),
 	}
 )
 


### PR DESCRIPTION
Signed-off-by: Rintaro Okamura <rintaro.okamura@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
Added cancel hook for file watcher.
agent-sidecar does not stop correctly when it receives SIGTERM without it.

made the default post_stop_timeout longer.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
nothing.

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
nothing.

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.3
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.11.5

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
