### PR TITLE
Fix singleflight logic and test case

### DIFF
--- a/internal/singleflight/singleflight.go
+++ b/internal/singleflight/singleflight.go
@@ -41,10 +41,7 @@ type group struct {
 }
 
 // New returns Group imple
-func New(size int) Group {
-	if size < 1 {
-		size = 1
-	}
+func New() Group {
 	return new(group)
 }
 

--- a/internal/singleflight/singleflight_test.go
+++ b/internal/singleflight/singleflight_test.go
@@ -130,7 +130,6 @@ func Test_group_Do(t *testing.T) {
 		want       want
 		checkFunc  func(want, interface{}, bool, error) error
 		beforeFunc func(Group, args)
-		execFunc   func(*testing.T, Group)
 		afterFunc  func(args)
 	}
 	defaultCheckFunc := func(w want, gotV interface{}, gotShared bool, err error) error {

--- a/internal/singleflight/singleflight_test.go
+++ b/internal/singleflight/singleflight_test.go
@@ -30,81 +30,56 @@ import (
 	"go.uber.org/goleak"
 )
 
-// func TestNew(t *testing.T) {
-// 	type args struct {
-// 		size int
-// 	}
-// 	type want struct {
-// 		want Group
-// 	}
-// 	type test struct {
-// 		name       string
-// 		args       args
-// 		want       want
-// 		checkFunc  func(want, Group) error
-// 		beforeFunc func(args)
-// 		afterFunc  func(args)
-// 	}
-// 	defaultCheckFunc := func(w want, got Group) error {
-// 		if !reflect.DeepEqual(got, w.want) {
-// 			return errors.Errorf("got = %v, want %v", got, w.want)
-// 		}
-// 		return nil
-// 	}
-// 	tests := []test{
-// 		{
-// 			name: "returns Group when size is 0",
-// 			want: want{
-// 				want: &group{
-// 					m: make(map[string]*call, 1),
-// 				},
-// 			},
-// 		},
-// 		{
-// 			name: "returns Group when size is 1",
-// 			args: args{
-// 				size: 1,
-// 			},
-// 			want: want{
-// 				want: &group{
-// 					m: make(map[string]*call, 1),
-// 				},
-// 			},
-// 		},
-// 		{
-// 			name: "returns Group when size is over than 1",
-// 			args: args{
-// 				size: 2,
-// 			},
-// 			want: want{
-// 				want: &group{
-// 					m: make(map[string]*call, 2),
-// 				},
-// 			},
-// 		},
-// 	}
-//
-// 	for _, test := range tests {
-// 		t.Run(test.name, func(tt *testing.T) {
-// 			defer goleak.VerifyNone(t)
-// 			if test.beforeFunc != nil {
-// 				test.beforeFunc(test.args)
-// 			}
-// 			if test.afterFunc != nil {
-// 				defer test.afterFunc(test.args)
-// 			}
-// 			if test.checkFunc == nil {
-// 				test.checkFunc = defaultCheckFunc
-// 			}
-//
-// 			got := New(test.args.size)
-// 			if err := test.checkFunc(test.want, got); err != nil {
-// 				tt.Errorf("error = %v", err)
-// 			}
-//
-// 		})
-// 	}
-// }
+func TestNew(t *testing.T) {
+	type args struct {
+	}
+	type want struct {
+		want Group
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, Group) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got Group) error {
+		if !reflect.DeepEqual(got, w.want) {
+			return errors.Errorf("got = %v, want %v", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "returns Group",
+			want: want{
+				want: new(group),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			defer goleak.VerifyNone(t)
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := New()
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+
+		})
+	}
+}
 
 func Test_group_Do(t *testing.T) {
 	type args struct {

--- a/internal/singleflight/singleflight_test.go
+++ b/internal/singleflight/singleflight_test.go
@@ -19,8 +19,8 @@ package singleflight
 
 import (
 	"context"
-	"fmt"
 	"reflect"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -30,81 +30,81 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestNew(t *testing.T) {
-	type args struct {
-		size int
-	}
-	type want struct {
-		want Group
-	}
-	type test struct {
-		name       string
-		args       args
-		want       want
-		checkFunc  func(want, Group) error
-		beforeFunc func(args)
-		afterFunc  func(args)
-	}
-	defaultCheckFunc := func(w want, got Group) error {
-		if !reflect.DeepEqual(got, w.want) {
-			return errors.Errorf("got = %v, want %v", got, w.want)
-		}
-		return nil
-	}
-	tests := []test{
-		{
-			name: "returns Group when size is 0",
-			want: want{
-				want: &group{
-					m: make(map[string]*call, 1),
-				},
-			},
-		},
-		{
-			name: "returns Group when size is 1",
-			args: args{
-				size: 1,
-			},
-			want: want{
-				want: &group{
-					m: make(map[string]*call, 1),
-				},
-			},
-		},
-		{
-			name: "returns Group when size is over than 1",
-			args: args{
-				size: 2,
-			},
-			want: want{
-				want: &group{
-					m: make(map[string]*call, 2),
-				},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
-			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
-			}
-			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
-			}
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
-
-			got := New(test.args.size)
-			if err := test.checkFunc(test.want, got); err != nil {
-				tt.Errorf("error = %v", err)
-			}
-
-		})
-	}
-}
+// func TestNew(t *testing.T) {
+// 	type args struct {
+// 		size int
+// 	}
+// 	type want struct {
+// 		want Group
+// 	}
+// 	type test struct {
+// 		name       string
+// 		args       args
+// 		want       want
+// 		checkFunc  func(want, Group) error
+// 		beforeFunc func(args)
+// 		afterFunc  func(args)
+// 	}
+// 	defaultCheckFunc := func(w want, got Group) error {
+// 		if !reflect.DeepEqual(got, w.want) {
+// 			return errors.Errorf("got = %v, want %v", got, w.want)
+// 		}
+// 		return nil
+// 	}
+// 	tests := []test{
+// 		{
+// 			name: "returns Group when size is 0",
+// 			want: want{
+// 				want: &group{
+// 					m: make(map[string]*call, 1),
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name: "returns Group when size is 1",
+// 			args: args{
+// 				size: 1,
+// 			},
+// 			want: want{
+// 				want: &group{
+// 					m: make(map[string]*call, 1),
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name: "returns Group when size is over than 1",
+// 			args: args{
+// 				size: 2,
+// 			},
+// 			want: want{
+// 				want: &group{
+// 					m: make(map[string]*call, 2),
+// 				},
+// 			},
+// 		},
+// 	}
+//
+// 	for _, test := range tests {
+// 		t.Run(test.name, func(tt *testing.T) {
+// 			defer goleak.VerifyNone(t)
+// 			if test.beforeFunc != nil {
+// 				test.beforeFunc(test.args)
+// 			}
+// 			if test.afterFunc != nil {
+// 				defer test.afterFunc(test.args)
+// 			}
+// 			if test.checkFunc == nil {
+// 				test.checkFunc = defaultCheckFunc
+// 			}
+//
+// 			got := New(test.args.size)
+// 			if err := test.checkFunc(test.want, got); err != nil {
+// 				tt.Errorf("error = %v", err)
+// 			}
+//
+// 		})
+// 	}
+// }
 
 func Test_group_Do(t *testing.T) {
 	type args struct {
@@ -112,8 +112,11 @@ func Test_group_Do(t *testing.T) {
 		key string
 		fn  func() (interface{}, error)
 	}
-	type fields struct {
-		m map[string]*call
+	type util struct {
+		mu         *sync.Mutex
+		wg         *sync.WaitGroup
+		cond       *sync.Cond
+		condWaitFn func()
 	}
 	type want struct {
 		wantV      interface{}
@@ -123,13 +126,11 @@ func Test_group_Do(t *testing.T) {
 	type test struct {
 		name       string
 		args       args
-		fields     fields
+		util       util
 		want       want
-		cond       *sync.Cond
-		mu         *sync.Mutex
-		wg         *sync.WaitGroup
 		checkFunc  func(want, interface{}, bool, error) error
 		beforeFunc func(Group, args)
+		execFunc   func(*testing.T, Group)
 		afterFunc  func(args)
 	}
 	defaultCheckFunc := func(w want, gotV interface{}, gotShared bool, err error) error {
@@ -145,44 +146,35 @@ func Test_group_Do(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           ctx: nil,
-		           key: "",
-		           fn: nil,
-		       },
-		       fields: fields {
-		           mu: sync.RWMutex{},
-		           m: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
 		func() test {
-			mu := new(sync.Mutex)
-			cond := sync.NewCond(mu)
-			cnt := uint32(0)
-			wg := new(sync.WaitGroup)
+			var calledCnt uint32
+
+			var (
+				mu         = new(sync.Mutex)
+				cond       = sync.NewCond(mu)
+				wg         = new(sync.WaitGroup)
+				condWaitFn = func() {
+					mu.Lock()
+					defer mu.Unlock()
+					cond.Wait()
+				}
+			)
+
 			return test{
-				mu:   mu,
-				cond: cond,
-				wg:   wg,
 				name: "returns (v, shared, nil) when Do is called with another key",
+				util: util{
+					mu:         mu,
+					cond:       cond,
+					wg:         wg,
+					condWaitFn: condWaitFn,
+				},
 				args: args{
-					ctx: context.Background(),
 					key: "req_1",
+					ctx: context.Background(),
 					fn: func() (interface{}, error) {
-						atomic.AddUint32(&cnt, 1)
+						atomic.AddUint32(&calledCnt, 1)
 						return "res_1", nil
 					},
-				},
-				fields: fields{
-					m: make(map[string]*call, 2),
 				},
 				want: want{
 					wantV:      "res_1",
@@ -190,47 +182,71 @@ func Test_group_Do(t *testing.T) {
 					err:        nil,
 				},
 				beforeFunc: func(g Group, args args) {
-					wg.Add(1)
-					go func() {
-						mu.Lock()
-						defer mu.Unlock()
-						cond.Wait()
-						g.Do(context.Background(), "req_2", func() (interface{}, error) {
+					gcnt := 10
+					ch := make(chan struct{}, gcnt)
+
+					for i := 0; i < gcnt; i++ {
+						wg.Add(1)
+						go func(i int) {
+							ch <- struct{}{}
 							defer wg.Done()
-							atomic.AddUint32(&cnt, 1)
-							return "res_2", nil
-						})
-					}()
+							condWaitFn()
+
+							g.Do(context.Background(), strconv.Itoa(i), func() (interface{}, error) {
+								time.Sleep(time.Nanosecond * 100)
+								atomic.AddUint32(&calledCnt, 1)
+								return "vdaas/vald", nil
+							})
+						}(i)
+					}
+
+					for i := 0; i < gcnt; i++ {
+						<-ch
+					}
+					close(ch)
 				},
-				checkFunc: func(want, interface{}, bool, error) error {
-					if got, want := int(atomic.LoadUint32(&cnt)), 2; got != want {
-						return errors.Errorf("cnt got = %d, want = %d", got, want)
+				checkFunc: func(w want, gotV interface{}, gotShared bool, err error) error {
+					if got, want := int(atomic.LoadUint32(&calledCnt)), 11; got != want {
+						return errors.Errorf("calledCnt got = %d, want = %d", got, want)
+					}
+
+					if err := defaultCheckFunc(w, gotV, gotShared, err); err != nil {
+						return err
 					}
 					return nil
 				},
 			}
 		}(),
+
 		func() test {
-			mu := new(sync.Mutex)
-			cond := sync.NewCond(mu)
-			cnt := uint32(0)
-			wg := new(sync.WaitGroup)
+			var calledCnt uint32
+
+			var (
+				mu         = new(sync.Mutex)
+				cond       = sync.NewCond(mu)
+				wg         = new(sync.WaitGroup)
+				condWaitFn = func() {
+					mu.Lock()
+					defer mu.Unlock()
+					cond.Wait()
+				}
+			)
+
 			return test{
 				name: "returns (v, shared, nil) when Do is called with same key",
-				mu:   mu,
-				cond: cond,
-				wg:   wg,
+				util: util{
+					mu:         mu,
+					cond:       cond,
+					wg:         wg,
+					condWaitFn: condWaitFn,
+				},
 				args: args{
-					ctx: context.Background(),
 					key: "req_1",
+					ctx: context.Background(),
 					fn: func() (interface{}, error) {
-						fmt.Println("args")
-						atomic.AddUint32(&cnt, 1)
+						atomic.AddUint32(&calledCnt, 1)
 						return "res_1", nil
 					},
-				},
-				fields: fields{
-					m: make(map[string]*call, 2),
 				},
 				want: want{
 					wantV:      "res_1",
@@ -239,35 +255,43 @@ func Test_group_Do(t *testing.T) {
 				},
 				beforeFunc: func(g Group, args args) {
 					wg.Add(1)
-					ch := make(chan struct{})
 					go func() {
-						g.Do(context.Background(), "req_1", func() (interface{}, error) {
-							ch <- struct{}{}
-							fmt.Println("test")
-							defer wg.Done()
-							time.Sleep(time.Second * 10)
-							return "res_1", nil
+						defer wg.Done()
+						g.Do(context.Background(), args.key, func() (interface{}, error) {
+							time.Sleep(3 * time.Second)
+							return args.fn()
 						})
 					}()
-					<- ch
-					for i := 0; i < 10; i++ {
+
+					gcnt := 10
+					ch := make(chan struct{}, gcnt)
+
+					for i := 0; i < gcnt; i++ {
 						wg.Add(1)
-						go func(i int) {
-							mu.Lock()
-							defer mu.Unlock()
-							cond.Wait()
+						go func() {
+							ch <- struct{}{}
 							defer wg.Done()
-							fmt.Println(i)
-							g.Do(context.Background(), "req_1", func() (interface{}, error) {
-								atomic.AddUint32(&cnt, 1)
-								return "res_1", nil
+							condWaitFn()
+
+							g.Do(context.Background(), args.key, func() (interface{}, error) {
+								atomic.AddUint32(&calledCnt, 1)
+								return "vdaas/vald", nil
 							})
-						}(i)
+						}()
 					}
+
+					for i := 0; i < gcnt; i++ {
+						<-ch
+					}
+					close(ch)
 				},
-				checkFunc: func(want, interface{}, bool, error) error {
-					if got, want := int(atomic.LoadUint32(&cnt)), 1; got != want {
-						return errors.Errorf("cnt got = %d, want = %d", got, want)
+				checkFunc: func(w want, gotV interface{}, gotShared bool, err error) error {
+					if got, want := int(atomic.LoadUint32(&calledCnt)), 1; got != want {
+						return errors.Errorf("calledCnt got = %d, want = %d", got, want)
+					}
+
+					if err := defaultCheckFunc(w, gotV, gotShared, err); err != nil {
+						return err
 					}
 					return nil
 				},
@@ -284,32 +308,31 @@ func Test_group_Do(t *testing.T) {
 			if test.checkFunc == nil {
 				test.checkFunc = defaultCheckFunc
 			}
-			g := &group{
-				m: test.fields.m,
-			}
+
+			g := new(group)
 
 			if test.beforeFunc != nil {
 				test.beforeFunc(g, test.args)
 			}
 
-			var gotV interface{}
-			var gotShared bool
-			var err error
-			test.wg.Add(1)
+			var (
+				gotV      interface{}
+				gotShared bool
+				err       error
+			)
+
+			test.util.wg.Add(1)
 			go func() {
-				test.mu.Lock()
-				defer test.mu.Unlock()
-				test.cond.Wait()
-				defer test.wg.Done()
-				gotV, gotShared, err = g.Do(test.args.ctx, test.args.key, test.args.fn)
+				defer test.util.wg.Done()
+				gotV, gotShared, err = g.Do(context.Background(), test.args.key, test.args.fn)
 			}()
-			time.Sleep(time.Second)
-			test.cond.Broadcast()
-			test.wg.Wait()
+
+			test.util.cond.Broadcast()
+			test.util.wg.Wait()
+
 			if err := test.checkFunc(test.want, gotV, gotShared, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }

--- a/pkg/discoverer/k8s/handler/grpc/handler.go
+++ b/pkg/discoverer/k8s/handler/grpc/handler.go
@@ -59,7 +59,7 @@ func New(opts ...Option) (ds DiscovererServer, err error) {
 		}
 	}
 
-	s.group = singleflight.New(10)
+	s.group = singleflight.New()
 
 	return s, nil
 }


### PR DESCRIPTION
Signed-off-by: hlts2 <hiroto.funakoshi.hiroto@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

I fixed singleflight logic and added test case.
Before `internal/singleflight` use a normal map to store object, but it was changed to use `sync.Map` to store the object.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.3
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.11.5

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [x] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [x] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
