### PR TITLE
Add internal roundtrip test code

### DIFF
--- a/internal/net/http/transport/roundtrip.go
+++ b/internal/net/http/transport/roundtrip.go
@@ -51,7 +51,7 @@ func (e *ert) RoundTrip(req *http.Request) (res *http.Response, err error) {
 		return e.roundTrip(req)
 	}
 
-	var fnerr error
+	var rterr error
 	_, err = e.bo.Do(req.Context(), func() (interface{}, error) {
 		r, e := e.roundTrip(req)
 		if e != nil {
@@ -60,7 +60,7 @@ func (e *ert) RoundTrip(req *http.Request) (res *http.Response, err error) {
 				return nil, e
 			}
 			// if the error is not retryable, return nil error to terminate the backoff execution
-			fnerr = e
+			rterr = e
 			return nil, nil
 		}
 		res = r
@@ -69,8 +69,8 @@ func (e *ert) RoundTrip(req *http.Request) (res *http.Response, err error) {
 	if err != nil {
 		return nil, err
 	}
-	if fnerr != nil {
-		return nil, fnerr
+	if rterr != nil {
+		return nil, rterr
 	}
 
 	return res, nil

--- a/internal/net/http/transport/roundtrip.go
+++ b/internal/net/http/transport/roundtrip.go
@@ -32,6 +32,7 @@ type ert struct {
 	bo        backoff.Backoff
 }
 
+// NewExpBackoff returns the backoff roundtripper implementation
 func NewExpBackoff(opts ...Option) http.RoundTripper {
 	e := new(ert)
 	for _, opt := range append(defaultOpts, opts...) {
@@ -41,6 +42,7 @@ func NewExpBackoff(opts ...Option) http.RoundTripper {
 	return e
 }
 
+// RoundTrip round trip the HTTP request and return the response
 func (e *ert) RoundTrip(req *http.Request) (res *http.Response, err error) {
 	if e.bo == nil {
 		return e.roundTrip(req)

--- a/internal/net/http/transport/roundtrip.go
+++ b/internal/net/http/transport/roundtrip.go
@@ -79,6 +79,7 @@ func (e *ert) RoundTrip(req *http.Request) (res *http.Response, err error) {
 func (e *ert) roundTrip(req *http.Request) (res *http.Response, err error) {
 	res, err = e.transport.RoundTrip(req)
 	if err != nil {
+		log.Error(err)
 		if res != nil { // just in case we check the response as it depends on RoundTrip impl.
 			closeBody(res.Body)
 			if retryableStatusCode(res.StatusCode) {

--- a/internal/net/http/transport/roundtrip.go
+++ b/internal/net/http/transport/roundtrip.go
@@ -51,7 +51,7 @@ func (e *ert) RoundTrip(req *http.Request) (res *http.Response, err error) {
 		return e.roundTrip(req)
 	}
 
-	var boerr error
+	var fnerr error
 	_, err = e.bo.Do(req.Context(), func() (interface{}, error) {
 		r, e := e.roundTrip(req)
 		if e != nil {
@@ -60,7 +60,7 @@ func (e *ert) RoundTrip(req *http.Request) (res *http.Response, err error) {
 				return nil, e
 			}
 			// if the error is not retryable, return nil error to terminate the backoff execution
-			boerr = e
+			fnerr = e
 			return nil, nil
 		}
 		res = r
@@ -69,8 +69,8 @@ func (e *ert) RoundTrip(req *http.Request) (res *http.Response, err error) {
 	if err != nil {
 		return nil, err
 	}
-	if boerr != nil {
-		return nil, boerr
+	if fnerr != nil {
+		return nil, fnerr
 	}
 
 	return res, nil

--- a/internal/net/http/transport/roundtrip.go
+++ b/internal/net/http/transport/roundtrip.go
@@ -53,14 +53,14 @@ func (e *ert) RoundTrip(req *http.Request) (res *http.Response, err error) {
 
 	var rterr error
 	_, err = e.bo.Do(req.Context(), func() (interface{}, error) {
-		r, e := e.roundTrip(req)
-		if e != nil {
+		r, reqerr := e.roundTrip(req)
+		if reqerr != nil {
 			// if the error is retryable, return the error and let backoff to retry.
-			if errors.Is(e, errors.ErrTransportRetryable) {
-				return nil, e
+			if errors.Is(reqerr, errors.ErrTransportRetryable) {
+				return nil, reqerr
 			}
 			// if the error is not retryable, return nil error to terminate the backoff execution
-			rterr = e
+			rterr = reqerr
 			return nil, nil
 		}
 		res = r

--- a/internal/net/http/transport/roundtrip.go
+++ b/internal/net/http/transport/roundtrip.go
@@ -51,7 +51,7 @@ func (e *ert) RoundTrip(req *http.Request) (res *http.Response, err error) {
 		return e.roundTrip(req)
 	}
 
-	var boErr error
+	var ferr error
 	r, err := e.bo.Do(req.Context(), func() (res interface{}, err error) {
 		res, err = e.roundTrip(req)
 		if err != nil {
@@ -59,8 +59,8 @@ func (e *ert) RoundTrip(req *http.Request) (res *http.Response, err error) {
 			if errors.Is(err, errors.ErrTransportRetryable) {
 				return nil, err
 			}
-			// if the error is not retryable, return nil error to backoff to terminate the backoff execution
-			boErr = err
+			// if the error is not retryable, return nil error to terminate the backoff execution
+			ferr = err
 			return nil, nil
 		}
 		return res, nil
@@ -68,8 +68,8 @@ func (e *ert) RoundTrip(req *http.Request) (res *http.Response, err error) {
 	if err != nil {
 		return nil, err
 	}
-	if boErr != nil {
-		return nil, boErr
+	if ferr != nil {
+		return nil, ferr
 	}
 
 	res, ok := r.(*http.Response)

--- a/internal/net/http/transport/roundtrip.go
+++ b/internal/net/http/transport/roundtrip.go
@@ -81,22 +81,22 @@ func (e *ert) roundTrip(req *http.Request) (res *http.Response, err error) {
 	if err != nil {
 		if res != nil { // just in case we check the response as it depends on RoundTrip impl.
 			closeBody(res.Body)
-			if retryable(res) {
+			if retryableStatusCode(res.StatusCode) {
 				return nil, errors.Wrap(errors.ErrTransportRetryable, err.Error())
 			}
 		}
 		return nil, err
 	}
 
-	if res != nil && retryable(res) {
+	if res != nil && retryableStatusCode(res.StatusCode) {
 		closeBody(res.Body)
 		return nil, errors.ErrTransportRetryable
 	}
 	return res, nil
 }
 
-func retryable(res *http.Response) bool {
-	switch res.StatusCode {
+func retryableStatusCode(status int) bool {
+	switch status {
 	case http.StatusTooManyRequests,
 		http.StatusInternalServerError,
 		http.StatusServiceUnavailable,

--- a/internal/net/http/transport/roundtrip_test.go
+++ b/internal/net/http/transport/roundtrip_test.go
@@ -448,9 +448,9 @@ func Test_ert_roundTrip(t *testing.T) {
 	}
 }
 
-func Test_retryable(t *testing.T) {
+func Test_retryableStatusCode(t *testing.T) {
 	type args struct {
-		res *http.Response
+		status int
 	}
 	type want struct {
 		want bool
@@ -473,9 +473,7 @@ func Test_retryable(t *testing.T) {
 		{
 			name: "return true when response status is retryable",
 			args: args{
-				res: &http.Response{
-					StatusCode: http.StatusTooManyRequests,
-				},
+				status: http.StatusTooManyRequests,
 			},
 			want: want{
 				want: true,
@@ -484,9 +482,7 @@ func Test_retryable(t *testing.T) {
 		{
 			name: "return false when response status is not retryable",
 			args: args{
-				res: &http.Response{
-					StatusCode: http.StatusOK,
-				},
+				status: http.StatusOK,
 			},
 			want: want{
 				want: false,
@@ -507,7 +503,7 @@ func Test_retryable(t *testing.T) {
 				test.checkFunc = defaultCheckFunc
 			}
 
-			got := retryable(test.args.res)
+			got := retryableStatusCode(test.args.status)
 			if err := test.checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/net/http/transport/roundtrip_test.go
+++ b/internal/net/http/transport/roundtrip_test.go
@@ -36,8 +36,7 @@ import (
 
 func TestMain(m *testing.M) {
 	log.Init()
-	code := m.Run()
-	os.Exit(code)
+	os.Exit(m.Run())
 }
 
 func TestNewExpBackoff(t *testing.T) {

--- a/internal/net/http/transport/roundtrip_test.go
+++ b/internal/net/http/transport/roundtrip_test.go
@@ -36,9 +36,7 @@ import (
 
 func TestMain(m *testing.M) {
 	log.Init()
-
 	code := m.Run()
-
 	os.Exit(code)
 }
 

--- a/internal/net/http/transport/roundtrip_test.go
+++ b/internal/net/http/transport/roundtrip_test.go
@@ -515,7 +515,7 @@ func Test_retryable(t *testing.T) {
 
 func Test_closeBody(t *testing.T) {
 	type args struct {
-		res *http.Response
+		rc io.ReadCloser
 	}
 	type want struct {
 	}
@@ -523,12 +523,12 @@ func Test_closeBody(t *testing.T) {
 		name       string
 		args       args
 		want       want
-		checkFunc  func(*http.Response, want) error
+		checkFunc  func(io.ReadCloser, want) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
-	defaultCheckFunc := func(res *http.Response, w want) error {
-		if i, err := res.Body.Read([]byte{}); i != 0 || err != io.EOF {
+	defaultCheckFunc := func(rc io.ReadCloser, w want) error {
+		if i, err := rc.Read([]byte{}); i != 0 || err != io.EOF {
 			return errors.Errorf("connection not closed, num: %d, err: %v", i, err)
 		}
 		return nil
@@ -542,7 +542,7 @@ func Test_closeBody(t *testing.T) {
 			return test{
 				name: "close response body",
 				args: args{
-					res: res,
+					rc: res.Body,
 				},
 			}
 		}(),
@@ -561,8 +561,8 @@ func Test_closeBody(t *testing.T) {
 				test.checkFunc = defaultCheckFunc
 			}
 
-			closeBody(test.args.res)
-			if err := test.checkFunc(test.args.res, test.want); err != nil {
+			closeBody(test.args.rc)
+			if err := test.checkFunc(test.args.rc, test.want); err != nil {
 				tt.Errorf("error = %v", err)
 			}
 		})

--- a/internal/net/http/transport/roundtrip_test.go
+++ b/internal/net/http/transport/roundtrip_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
 
@@ -33,8 +34,12 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestMain(t *testing.T) {
+func TestMain(m *testing.M) {
 	log.Init()
+
+	code := m.Run()
+
+	os.Exit(code)
 }
 
 func TestNewExpBackoff(t *testing.T) {

--- a/internal/net/http/transport/roundtrip_test.go
+++ b/internal/net/http/transport/roundtrip_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/vdaas/vald/internal/backoff"
 	"github.com/vdaas/vald/internal/errors"
-	"github.com/vdaas/vald/internal/log"
 	"go.uber.org/goleak"
 )
 
@@ -37,7 +36,6 @@ var (
 	// Goroutine leak is detected by `fastime`, but it should be ignored in the test because it is an external package.
 	goleakIgnoreOptions = []goleak.Option{
 		goleak.IgnoreTopFunction("github.com/kpango/fastime.(*Fastime).StartTimerD.func1"),
-		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
 	}
 )
 
@@ -550,7 +548,6 @@ func Test_closeBody(t *testing.T) {
 		}(),
 	}
 
-	log.Init()
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)

--- a/internal/net/http/transport/roundtrip_test.go
+++ b/internal/net/http/transport/roundtrip_test.go
@@ -32,13 +32,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-var (
-	// Goroutine leak is detected by `fastime`, but it should be ignored in the test because it is an external package.
-	goleakIgnoreOptions = []goleak.Option{
-		goleak.IgnoreTopFunction("github.com/kpango/fastime.(*Fastime).StartTimerD.func1"),
-	}
-)
-
 func TestNewExpBackoff(t *testing.T) {
 	type args struct {
 		opts []Option

--- a/internal/net/http/transport/roundtrip_test.go
+++ b/internal/net/http/transport/roundtrip_test.go
@@ -33,6 +33,10 @@ import (
 	"go.uber.org/goleak"
 )
 
+func TestMain(t *testing.T) {
+	log.Init()
+}
+
 func TestNewExpBackoff(t *testing.T) {
 	type args struct {
 		opts []Option
@@ -290,7 +294,6 @@ func Test_ert_RoundTrip(t *testing.T) {
 		},
 	}
 
-	log.Init()
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)

--- a/internal/net/http/transport/roundtrip_test.go
+++ b/internal/net/http/transport/roundtrip_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/vdaas/vald/internal/backoff"
 	"github.com/vdaas/vald/internal/errors"
+	"github.com/vdaas/vald/internal/log"
 	"go.uber.org/goleak"
 )
 
@@ -289,6 +290,7 @@ func Test_ert_RoundTrip(t *testing.T) {
 		},
 	}
 
+	log.Init()
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Author review required?

### Description:

This PR implements the roundtrip test case.
This PR also fix the bug that it did not return `errors.ErrTransportRetryable` when the roundtrip success and the request is retryable.
Also this PR update the roundtrip logic that making the request terminated if the request is not retryable.
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.4
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.0

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
