### PR TITLE
[bugfix] fix agent sidecar behavior when index files are updated

### DIFF
--- a/pkg/agent/sidecar/service/observer/observer.go
+++ b/pkg/agent/sidecar/service/observer/observer.go
@@ -318,7 +318,11 @@ func (o *observer) onWrite(ctx context.Context, name string) error {
 		}
 	}()
 
-	ok, err := o.isValidMetadata(name)
+	if name != o.metadataPath {
+		return nil
+	}
+
+	ok, err := o.isValidMetadata()
 	if err != nil {
 		return err
 	}
@@ -338,7 +342,11 @@ func (o *observer) onCreate(ctx context.Context, name string) error {
 		}
 	}()
 
-	ok, err := o.isValidMetadata(name)
+	if name != o.metadataPath {
+		return nil
+	}
+
+	ok, err := o.isValidMetadata()
 	if err != nil {
 		return err
 	}
@@ -350,11 +358,7 @@ func (o *observer) onCreate(ctx context.Context, name string) error {
 	return o.terminate()
 }
 
-func (o *observer) isValidMetadata(name string) (bool, error) {
-	if name != o.metadataPath {
-		return false, nil
-	}
-
+func (o *observer) isValidMetadata() (bool, error) {
 	metadata, err := metadata.Load(o.metadataPath)
 	if err != nil {
 		return false, err

--- a/pkg/agent/sidecar/service/observer/observer_test.go
+++ b/pkg/agent/sidecar/service/observer/observer_test.go
@@ -845,7 +845,6 @@ func Test_observer_onCreate(t *testing.T) {
 
 func Test_observer_isValidMetadata(t *testing.T) {
 	type args struct {
-		name string
 	}
 	type fields struct {
 		w               watch.Watcher
@@ -887,7 +886,6 @@ func Test_observer_isValidMetadata(t *testing.T) {
 		   {
 		       name: "test_case_1",
 		       args: args {
-		           name: "",
 		       },
 		       fields: fields {
 		           w: nil,
@@ -912,7 +910,6 @@ func Test_observer_isValidMetadata(t *testing.T) {
 		       return test {
 		           name: "test_case_2",
 		           args: args {
-		           name: "",
 		           },
 		           fields: fields {
 		           w: nil,
@@ -958,7 +955,7 @@ func Test_observer_isValidMetadata(t *testing.T) {
 				ch:              test.fields.ch,
 			}
 
-			got, err := o.isValidMetadata(test.args.name)
+			got, err := o.isValidMetadata()
 			if err := test.checkFunc(test.want, got, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}


### PR DESCRIPTION
Signed-off-by: Rintaro Okamura <rintaro.okamura@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
Current version v0.0.48, when agent-sidecar detects the changes in index files, it terminates itself immediately because the implementation is wrong.
In this PR, i've fixed it.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
nothing.

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
nothing.

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.4
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.0

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
