### PR TITLE
Add internal/worker/worker test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ GO_SOURCES = $(eval GO_SOURCES := $(shell find \
 		./pkg \
 		-not -path './cmd/cli/*' \
 		-not -path './internal/core/ngt/*' \
+		-not -path './internal/test/*' \
 		-not -path './hack/benchmark/internal/client/ngtd/*' \
 		-not -path './hack/benchmark/internal/starter/agent/*' \
 		-not -path './hack/benchmark/internal/starter/external/*' \
@@ -130,6 +131,7 @@ GO_OPTION_SOURCES = $(eval GO_OPTION_SOURCES := $(shell find \
 		./pkg \
 		-not -path './cmd/cli/*' \
 		-not -path './internal/core/ngt/*' \
+		-not -path './internal/test/*' \
 		-not -path './hack/benchmark/internal/client/ngtd/*' \
 		-not -path './hack/benchmark/internal/starter/agent/*' \
 		-not -path './hack/benchmark/internal/starter/external/*' \

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ GO_SOURCES = $(eval GO_SOURCES := $(shell find \
 		./pkg \
 		-not -path './cmd/cli/*' \
 		-not -path './internal/core/ngt/*' \
-		-not -path './internal/test/*' \
+		-not -path './internal/test/comparator/*' \
 		-not -path './hack/benchmark/internal/client/ngtd/*' \
 		-not -path './hack/benchmark/internal/starter/agent/*' \
 		-not -path './hack/benchmark/internal/starter/external/*' \
@@ -131,7 +131,7 @@ GO_OPTION_SOURCES = $(eval GO_OPTION_SOURCES := $(shell find \
 		./pkg \
 		-not -path './cmd/cli/*' \
 		-not -path './internal/core/ngt/*' \
-		-not -path './internal/test/*' \
+		-not -path './internal/test/comparator/*' \
 		-not -path './hack/benchmark/internal/client/ngtd/*' \
 		-not -path './hack/benchmark/internal/starter/agent/*' \
 		-not -path './hack/benchmark/internal/starter/external/*' \

--- a/internal/test/comparator/standard.go
+++ b/internal/test/comparator/standard.go
@@ -10,7 +10,15 @@ import (
 type (
 	atomicValue = atomic.Value
 	errorGroup  = errgroup.Group
-	Option      = cmp.Option
+
+	Option = cmp.Option
+)
+
+var (
+	AllowUnexported = cmp.AllowUnexported
+	Comparer        = cmp.Comparer
+	Diff            = cmp.Diff
+	Equal           = cmp.Equal
 )
 
 /*

--- a/internal/test/comparator/standard.go
+++ b/internal/test/comparator/standard.go
@@ -1,0 +1,47 @@
+package comparator
+
+import (
+	"reflect"
+	"sync/atomic"
+
+	"github.com/vdaas/vald/internal/errgroup"
+)
+
+type (
+	atomicValue = atomic.Value
+	errorGroup  = errgroup.Group
+)
+
+var (
+	AtomicValue = func(x, y atomicValue) bool {
+		return reflect.DeepEqual(x.Load(), y.Load())
+	}
+
+	ErrorGroup = func(x, y errorGroup) bool {
+		return reflect.DeepEqual(x, y)
+	}
+
+	// channel comparator
+
+	ErrorChannel = func(x, y <-chan error) bool {
+		if x == nil && y == nil {
+			return true
+		}
+		if x == nil || y == nil {
+			return false
+		}
+
+		chanToSlice := func(c <-chan error) []error {
+			s := make([]error, 0)
+			for v := range c {
+				s = append(s, v)
+			}
+			return s
+		}
+
+		s1 := chanToSlice(x)
+		s2 := chanToSlice(y)
+
+		return reflect.DeepEqual(s1, s2)
+	}
+)

--- a/internal/test/comparator/standard.go
+++ b/internal/test/comparator/standard.go
@@ -1,7 +1,6 @@
 package comparator
 
 import (
-	"reflect"
 	"sync/atomic"
 
 	"github.com/vdaas/vald/internal/errgroup"
@@ -12,6 +11,7 @@ type (
 	errorGroup  = errgroup.Group
 )
 
+/*
 var (
 	AtomicValue = func(x, y atomicValue) bool {
 		return reflect.DeepEqual(x.Load(), y.Load())
@@ -23,25 +23,20 @@ var (
 
 	// channel comparator
 
-	ErrorChannel = func(x, y <-chan error) bool {
-		if x == nil && y == nil {
+		ErrChannel := func(x, y <-chan error) bool {
+			if x == nil && y == nil {
+				return true
+			}
+			if x == nil || y == nil || len(x) != len(y) {
+				return false
+			}
+
+			for e := range x {
+				if e1 := <-y; !errors.Is(e, e1) {
+					return false
+				}
+			}
 			return true
 		}
-		if x == nil || y == nil {
-			return false
-		}
-
-		chanToSlice := func(c <-chan error) []error {
-			s := make([]error, 0)
-			for v := range c {
-				s = append(s, v)
-			}
-			return s
-		}
-
-		s1 := chanToSlice(x)
-		s2 := chanToSlice(y)
-
-		return reflect.DeepEqual(s1, s2)
-	}
 )
+*/

--- a/internal/test/comparator/standard.go
+++ b/internal/test/comparator/standard.go
@@ -3,12 +3,14 @@ package comparator
 import (
 	"sync/atomic"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/vdaas/vald/internal/errgroup"
 )
 
 type (
 	atomicValue = atomic.Value
 	errorGroup  = errgroup.Group
+	Option      = cmp.Option
 )
 
 /*

--- a/internal/test/comparator/standard.go
+++ b/internal/test/comparator/standard.go
@@ -1,3 +1,18 @@
+//
+// Copyright (C) 2019-2020 Vdaas.org Vald team ( kpango, rinx, kmrmt )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package comparator
 
 import (

--- a/internal/worker/queue_mock_test.go
+++ b/internal/worker/queue_mock_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright (C) 2019-2020 Vdaas.org Vald team ( kpango, rinx, kmrmt )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package worker
 
 import "context"

--- a/internal/worker/queue_mock_test.go
+++ b/internal/worker/queue_mock_test.go
@@ -1,0 +1,50 @@
+package worker
+
+import "context"
+
+var (
+	DefaultStartFunc = func(context.Context) (<-chan error, error) {
+		return nil, nil
+	}
+	DefaultPushFunc = func(context.Context, JobFunc) error {
+		return nil
+	}
+	DefaultPopFunc = func(context.Context) (JobFunc, error) {
+		return nil, nil
+	}
+	DefaultLenFunc = func() uint64 {
+		return uint64(0)
+	}
+)
+
+type QueueMock struct {
+	StartFunc func(context.Context) (<-chan error, error)
+	PushFunc  func(context.Context, JobFunc) error
+	PopFunc   func(context.Context) (JobFunc, error)
+	LenFunc   func() uint64
+}
+
+func NewQueueMock() Queue {
+	return &QueueMock{
+		StartFunc: DefaultStartFunc,
+		PushFunc:  DefaultPushFunc,
+		PopFunc:   DefaultPopFunc,
+		LenFunc:   DefaultLenFunc,
+	}
+}
+
+func (q *QueueMock) Start(ctx context.Context) (<-chan error, error) {
+	return q.StartFunc(ctx)
+}
+
+func (q *QueueMock) Push(ctx context.Context, job JobFunc) error {
+	return q.PushFunc(ctx, job)
+}
+
+func (q *QueueMock) Pop(ctx context.Context) (JobFunc, error) {
+	return q.PopFunc(ctx)
+}
+
+func (q *QueueMock) Len() uint64 {
+	return q.LenFunc()
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -81,7 +81,8 @@ func New(opts ...WorkerOption) (Worker, error) {
 	return w, nil
 }
 
-// Start starts execute jobs in the worker queue. It returns the error channel that the job return, and the error if start failed.
+// Start starts execute jobs in the worker queue.
+// It returns the error channel that the job return, and the error if start failed.
 func (w *worker) Start(ctx context.Context) (<-chan error, error) {
 	if w.IsRunning() {
 		return nil, errors.ErrWorkerIsAlreadyRunning(w.Name())

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -184,12 +184,12 @@ func (w *worker) startJobLoop(ctx context.Context) <-chan error {
 	return ech
 }
 
-// Pause pause the execution of the worker.
+// Pause stop allowing new job to be dispatched to the worker.
 func (w *worker) Pause() {
 	w.running.Store(false)
 }
 
-// Resume resume the execution of the worker.
+// Resume resume to allow new job to be dispatched to the worker.
 func (w *worker) Resume() {
 	w.running.Store(true)
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -29,10 +29,10 @@ import (
 	"github.com/vdaas/vald/internal/safety"
 )
 
-// JobFunc represent the function of a job that work in the worker.
+// JobFunc represents the function of a job that works in the worker.
 type JobFunc func(context.Context) error
 
-// Worker represent the worker interface to execute jobs.
+// Worker represents the worker interface to execute jobs.
 type Worker interface {
 	Start(ctx context.Context) (<-chan error, error)
 	Pause()
@@ -56,7 +56,7 @@ type worker struct {
 	completedCount uint64
 }
 
-// New initialize and return the worker, or return initialization error if occurred.
+// New initializes and return the worker, or return initialization error if occurred.
 func New(opts ...WorkerOption) (Worker, error) {
 	w := new(worker)
 	for _, opt := range append(defaultWorkerOpts, opts...) {
@@ -81,7 +81,7 @@ func New(opts ...WorkerOption) (Worker, error) {
 	return w, nil
 }
 
-// Start start execute jobs in the worker queue. It returns the error channel that the job return, and the error if start failed.
+// Start starts execute jobs in the worker queue. It returns the error channel that the job return, and the error if start failed.
 func (w *worker) Start(ctx context.Context) (<-chan error, error) {
 	if w.IsRunning() {
 		return nil, errors.ErrWorkerIsAlreadyRunning(w.Name())
@@ -184,44 +184,44 @@ func (w *worker) startJobLoop(ctx context.Context) <-chan error {
 	return ech
 }
 
-// Pause stop allowing new job to be dispatched to the worker.
+// Pause stops allowing new job to be dispatched to the worker.
 func (w *worker) Pause() {
 	w.running.Store(false)
 }
 
-// Resume resume to allow new job to be dispatched to the worker.
+// Resume resumes to allow new jobs to be dispatched to the worker.
 func (w *worker) Resume() {
 	w.running.Store(true)
 }
 
-// IsRunning return if the worker is running or not.
+// IsRunning returns if the worker is running or not.
 func (w *worker) IsRunning() bool {
 	return w.running.Load().(bool)
 }
 
-// Name return the worker name.
+// Name returns the worker name.
 func (w *worker) Name() string {
 	return w.name
 }
 
-// Len return the length of the worker queue.
+// Len returns the length of the worker queue.
 func (w *worker) Len() uint64 {
 	return w.queue.Len()
 }
 
-// TotalRequested return the number of job that dispatched to the worker.
+// TotalRequested returns the number of jobs that dispatched to the worker.
 func (w *worker) TotalRequested() uint64 {
 	return atomic.LoadUint64(&w.requestedCount)
 }
 
-// TotalCompleted return the number of completed job.
+// TotalCompleted returns the number of completed job.
 func (w *worker) TotalCompleted() uint64 {
 	return atomic.LoadUint64(&w.completedCount)
 }
 
-// Dispatch dispatch the job to the worker and waiting for worker to process it.
-// The job error is push to the error channel that Start() return.
-// This function will return error if the job cannot be dispatch to the worker queue, or the worker is not running.
+// Dispatch dispatches the job to the worker and waiting for the worker to process it.
+// The job error is pushed to the error channel that Start() return.
+// This function will return an error if the job cannot be dispatch to the worker queue, or the worker is not running.
 func (w *worker) Dispatch(ctx context.Context, f JobFunc) error {
 	ctx, span := trace.StartSpan(ctx, "vald/internal/worker/Worker.Dispatch")
 	defer func() {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -24,10 +24,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/vdaas/vald/internal/errgroup"
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/log"
+	"github.com/vdaas/vald/internal/test/comparator"
+
 	"go.uber.org/goleak"
 )
 
@@ -67,23 +68,23 @@ func TestNew(t *testing.T) {
 		}
 		want := w.want.(*worker)
 
-		queueOpts := []cmp.Option{
-			cmp.AllowUnexported(*(want.queue.(*queue))),
-			cmp.Comparer(func(x, y chan JobFunc) bool {
+		queueOpts := []comparator.Option{
+			comparator.AllowUnexported(*(want.queue.(*queue))),
+			comparator.Comparer(func(x, y chan JobFunc) bool {
 				return len(x) == len(y)
 			}),
-			cmp.Comparer(egComparator),
-			cmp.Comparer(atomicValueComparator),
+			comparator.Comparer(egComparator),
+			comparator.Comparer(atomicValueComparator),
 		}
-		opts := []cmp.Option{
-			cmp.AllowUnexported(*want),
-			cmp.Comparer(func(x, y Queue) bool {
-				return cmp.Equal(x, y, queueOpts...)
+		opts := []comparator.Option{
+			comparator.AllowUnexported(*want),
+			comparator.Comparer(func(x, y Queue) bool {
+				return comparator.Equal(x, y, queueOpts...)
 			}),
-			cmp.Comparer(egComparator),
-			cmp.Comparer(atomicValueComparator),
+			comparator.Comparer(egComparator),
+			comparator.Comparer(atomicValueComparator),
 		}
-		if diff := cmp.Diff(want, got, opts...); diff != "" {
+		if diff := comparator.Diff(want, got, opts...); diff != "" {
 			return errors.New(diff)
 		}
 		return nil

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -97,24 +97,21 @@ func TestNew(t *testing.T) {
 					name:       "worker",
 					limitation: 10,
 					eg:         errgroup.Get(),
-					running: func() atomic.Value {
-						v := new(atomic.Value)
+					running: func() (v atomic.Value) {
 						v.Store(false)
-						return *v
+						return v
 					}(),
 					queue: &queue{
 						buffer: 10,
 						eg:     errgroup.Get(),
 						qcdur:  200 * time.Millisecond,
-						qLen: func() atomic.Value {
-							v := new(atomic.Value)
+						qLen: func() (v atomic.Value) {
 							v.Store(uint64(0))
-							return *v
+							return v
 						}(),
-						running: func() atomic.Value {
-							v := new(atomic.Value)
+						running: func() (v atomic.Value) {
 							v.Store(false)
-							return *v
+							return v
 						}(),
 						inCh:  make(chan JobFunc, 10),
 						outCh: make(chan JobFunc, 1),
@@ -133,25 +130,22 @@ func TestNew(t *testing.T) {
 				want: &worker{
 					name:       "test1",
 					limitation: 10,
-					running: func() atomic.Value {
-						v := new(atomic.Value)
+					running: func() (v atomic.Value) {
 						v.Store(false)
-						return *v
+						return v
 					}(),
 					eg: errgroup.Get(),
 					queue: &queue{
 						buffer: 10,
 						eg:     errgroup.Get(),
 						qcdur:  200 * time.Millisecond,
-						qLen: func() atomic.Value {
-							v := new(atomic.Value)
+						qLen: func() (v atomic.Value) {
 							v.Store(uint64(0))
-							return *v
+							return v
 						}(),
-						running: func() atomic.Value {
-							v := new(atomic.Value)
+						running: func() (v atomic.Value) {
 							v.Store(false)
-							return *v
+							return v
 						}(),
 						inCh:  make(chan JobFunc, 10),
 						outCh: make(chan JobFunc, 1),
@@ -242,10 +236,9 @@ func Test_worker_Start(t *testing.T) {
 					name:       "worker",
 					limitation: 10,
 					eg:         errgroup.Get(),
-					running: func() atomic.Value {
-						v := new(atomic.Value)
+					running: func() (v atomic.Value) {
 						v.Store(false)
-						return *v
+						return v
 					}(),
 					queue: NewQueueMock(),
 				},
@@ -267,10 +260,9 @@ func Test_worker_Start(t *testing.T) {
 			args: args{},
 			fields: fields{
 				name: "test",
-				running: func() atomic.Value {
-					v := new(atomic.Value)
+				running: func() (v atomic.Value) {
 					v.Store(true)
-					return *v
+					return v
 				}(),
 			},
 			want: want{
@@ -286,10 +278,9 @@ func Test_worker_Start(t *testing.T) {
 				name:       "worker",
 				limitation: 10,
 				eg:         errgroup.Get(),
-				running: func() atomic.Value {
-					v := new(atomic.Value)
+				running: func() (v atomic.Value) {
 					v.Store(false)
-					return *v
+					return v
 				}(),
 				queue: &QueueMock{
 					StartFunc: func(context.Context) (<-chan error, error) {
@@ -622,10 +613,9 @@ func Test_worker_Pause(t *testing.T) {
 		{
 			name: "Pause success",
 			fields: fields{
-				running: func() atomic.Value {
-					v := &atomic.Value{}
+				running: func() (v atomic.Value) {
 					v.Store(true)
-					return *v
+					return v
 				}(),
 			},
 			checkFunc: func(w want, worker *worker) error {
@@ -696,10 +686,9 @@ func Test_worker_Resume(t *testing.T) {
 		{
 			name: "Resume success",
 			fields: fields{
-				running: func() atomic.Value {
-					v := &atomic.Value{}
+				running: func() (v atomic.Value) {
 					v.Store(false)
-					return *v
+					return v
 				}(),
 			},
 			checkFunc: func(w want, worker *worker) error {
@@ -774,10 +763,9 @@ func Test_worker_IsRunning(t *testing.T) {
 		{
 			name: "return true if it is running",
 			fields: fields{
-				running: func() atomic.Value {
-					v := &atomic.Value{}
+				running: func() (v atomic.Value) {
 					v.Store(true)
-					return *v
+					return v
 				}(),
 			},
 			want: want{
@@ -787,10 +775,9 @@ func Test_worker_IsRunning(t *testing.T) {
 		{
 			name: "return false if it is not running",
 			fields: fields{
-				running: func() atomic.Value {
-					v := &atomic.Value{}
+				running: func() (v atomic.Value) {
 					v.Store(false)
-					return *v
+					return v
 				}(),
 			},
 			want: want{
@@ -1164,10 +1151,9 @@ func Test_worker_Dispatch(t *testing.T) {
 			},
 			fields: fields{
 				name: "test",
-				running: func() atomic.Value {
-					v := &atomic.Value{}
+				running: func() (v atomic.Value) {
 					v.Store(false)
-					return *v
+					return v
 				}(),
 			},
 			want: want{
@@ -1184,10 +1170,9 @@ func Test_worker_Dispatch(t *testing.T) {
 			},
 			fields: fields{
 				name: "test",
-				running: func() atomic.Value {
-					v := &atomic.Value{}
+				running: func() (v atomic.Value) {
 					v.Store(true)
-					return *v
+					return v
 				}(),
 				queue: &QueueMock{
 					PushFunc: func(context.Context, JobFunc) error {
@@ -1207,10 +1192,9 @@ func Test_worker_Dispatch(t *testing.T) {
 			},
 			fields: fields{
 				name: "test",
-				running: func() atomic.Value {
-					v := &atomic.Value{}
+				running: func() (v atomic.Value) {
 					v.Store(true)
-					return *v
+					return v
 				}(),
 				queue: &QueueMock{},
 			},
@@ -1226,10 +1210,9 @@ func Test_worker_Dispatch(t *testing.T) {
 			},
 			fields: fields{
 				name: "test",
-				running: func() atomic.Value {
-					v := &atomic.Value{}
+				running: func() (v atomic.Value) {
 					v.Store(true)
-					return *v
+					return v
 				}(),
 				queue: &QueueMock{
 					PushFunc: func(context.Context, JobFunc) error {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/vdaas/vald/internal/errgroup"
 	"github.com/vdaas/vald/internal/errors"
+	"github.com/vdaas/vald/internal/log"
 	"github.com/vdaas/vald/internal/test/comparator"
 	"go.uber.org/goleak"
 )
@@ -235,23 +236,7 @@ func Test_worker_Start(t *testing.T) {
 						v.Store(false)
 						return *v
 					}(),
-					queue: &queue{
-						buffer: 10,
-						eg:     errgroup.Get(),
-						qcdur:  200 * time.Millisecond,
-						qLen: func() atomic.Value {
-							v := new(atomic.Value)
-							v.Store(uint64(0))
-							return *v
-						}(),
-						running: func() atomic.Value {
-							v := new(atomic.Value)
-							v.Store(false)
-							return *v
-						}(),
-						inCh:  make(chan JobFunc, 10),
-						outCh: make(chan JobFunc, 1),
-					},
+					queue: NewQueueMock(),
 				},
 				want: want{
 					want: func() <-chan error {
@@ -279,6 +264,30 @@ func Test_worker_Start(t *testing.T) {
 			},
 			want: want{
 				err: errors.ErrWorkerIsAlreadyRunning("test"),
+			},
+		},
+		{
+			name: "return queue start error",
+			args: args{
+				ctx: context.Background(),
+			},
+			fields: fields{
+				name:       "worker",
+				limitation: 10,
+				eg:         errgroup.Get(),
+				running: func() atomic.Value {
+					v := new(atomic.Value)
+					v.Store(false)
+					return *v
+				}(),
+				queue: &QueueMock{
+					StartFunc: func(context.Context) (<-chan error, error) {
+						return nil, errors.New("error")
+					},
+				},
+			},
+			want: want{
+				err: errors.New("error"),
 			},
 		},
 	}
@@ -342,62 +351,200 @@ func Test_worker_startJobLoop(t *testing.T) {
 		afterFunc  func(args)
 	}
 	defaultCheckFunc := func(w want, got <-chan error) error {
-		if !reflect.DeepEqual(got, w.want) {
-			return errors.Errorf("got = %v, want %v", got, w.want)
+		if !comparator.ErrorChannel(w.want, got) {
+			return errors.New("error")
 		}
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           ctx: nil,
-		       },
-		       fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			return test{
+				name: "start job loop with empty job list",
+				args: args{
+					ctx: ctx,
+				},
+				fields: fields{
+					name:           "test",
+					limitation:     1,
+					running:        atomic.Value{},
+					eg:             errgroup.Get(),
+					queue:          NewQueueMock(),
+					requestedCount: 0,
+					completedCount: 0,
+				},
+				want: want{
+					want: func() <-chan error {
+						ch := make(chan error, 1)
+						close(ch)
+						return ch
+					}(),
+				},
+				checkFunc: func(w want, got <-chan error) error {
+					time.Sleep(time.Millisecond * 200)
+					cancel()
+					time.Sleep(time.Millisecond * 200)
 
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           ctx: nil,
-		           },
-		           fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+					return defaultCheckFunc(w, got)
+				},
+			}
+		}(),
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := errors.New("error")
+			return test{
+				name: "start job loop with queue pop error",
+				args: args{
+					ctx: ctx,
+				},
+				fields: fields{
+					name:       "test",
+					limitation: 1,
+					running:    atomic.Value{},
+					eg:         errgroup.Get(),
+					queue: &QueueMock{
+						StartFunc: DefaultStartFunc,
+						PopFunc: func(context.Context) (JobFunc, error) {
+							return nil, err
+						},
+					},
+					requestedCount: 0,
+					completedCount: 0,
+				},
+				checkFunc: func(w want, got <-chan error) error {
+					time.Sleep(time.Millisecond * 200)
+					cancel()
+					time.Sleep(time.Millisecond * 200)
+
+					if len(got) == 0 {
+						return errors.New("got chan len 0")
+					}
+					for e := range got {
+						if e != err {
+							return errors.New("invalid error")
+						}
+					}
+					return nil
+				},
+			}
+		}(),
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			return test{
+				name: "start job loop with a job",
+				args: args{
+					ctx: ctx,
+				},
+				fields: fields{
+					name:       "test",
+					limitation: 1,
+					running:    atomic.Value{},
+					eg:         errgroup.Get(),
+					queue: &QueueMock{
+						StartFunc: DefaultStartFunc,
+						PopFunc: func(context.Context) (JobFunc, error) {
+							f := JobFunc(func(context.Context) error {
+								return nil
+							})
+							return f, nil
+						},
+					},
+					requestedCount: 0,
+					completedCount: 0,
+				},
+				checkFunc: func(w want, got <-chan error) error {
+					time.Sleep(time.Millisecond * 200)
+					cancel()
+					time.Sleep(time.Millisecond * 200)
+
+					if len(got) != 0 {
+						return errors.New("error returned")
+					}
+					return nil
+				},
+			}
+		}(),
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := errors.New("error")
+			return test{
+				name: "start job loop with a job which return error",
+				args: args{
+					ctx: ctx,
+				},
+				fields: fields{
+					name:       "test",
+					limitation: 1,
+					running:    atomic.Value{},
+					eg:         errgroup.Get(),
+					queue: &QueueMock{
+						StartFunc: DefaultStartFunc,
+						PopFunc: func(context.Context) (JobFunc, error) {
+							f := JobFunc(func(context.Context) error {
+								return err
+							})
+							return f, nil
+						},
+					},
+					requestedCount: 0,
+					completedCount: 0,
+				},
+				checkFunc: func(w want, got <-chan error) error {
+					time.Sleep(time.Millisecond * 200)
+					cancel()
+					time.Sleep(time.Millisecond * 200)
+
+					if len(got) == 0 {
+						return errors.New("got chan len 0")
+					}
+					for e := range got {
+						if e != err {
+							return errors.New("invalid error")
+						}
+					}
+					return nil
+				},
+			}
+		}(),
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			return test{
+				name: "start job loop with queue pop a nil job without error",
+				args: args{
+					ctx: ctx,
+				},
+				fields: fields{
+					name:       "test",
+					limitation: 1,
+					running:    atomic.Value{},
+					eg:         errgroup.Get(),
+					queue: &QueueMock{
+						StartFunc: DefaultStartFunc,
+						PopFunc: func(context.Context) (JobFunc, error) {
+							return nil, nil
+						},
+					},
+					requestedCount: 0,
+					completedCount: 0,
+				},
+				checkFunc: func(w want, got <-chan error) error {
+					time.Sleep(time.Millisecond * 200)
+					cancel()
+					time.Sleep(time.Millisecond * 200)
+
+					if len(got) != 0 {
+						return errors.New("got error")
+					}
+					return nil
+				},
+			}
+		}(),
 	}
 
+	log.Init()
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -444,58 +591,35 @@ func Test_worker_Pause(t *testing.T) {
 		name       string
 		fields     fields
 		want       want
-		checkFunc  func(want) error
+		checkFunc  func(want, *worker) error
 		beforeFunc func()
 		afterFunc  func()
 	}
-	defaultCheckFunc := func(w want) error {
+	defaultCheckFunc := func(w want, worker *worker) error {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "Pause success",
+			fields: fields{
+				running: func() atomic.Value {
+					v := &atomic.Value{}
+					v.Store(true)
+					return *v
+				}(),
+			},
+			checkFunc: func(w want, worker *worker) error {
+				if worker.running.Load().(bool) != false {
+					return errors.New("running is not false")
+				}
+				return nil
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -517,7 +641,7 @@ func Test_worker_Pause(t *testing.T) {
 			}
 
 			w.Pause()
-			if err := test.checkFunc(test.want); err != nil {
+			if err := test.checkFunc(test.want, w); err != nil {
 				tt.Errorf("error = %v", err)
 			}
 		})
@@ -541,58 +665,35 @@ func Test_worker_Resume(t *testing.T) {
 		name       string
 		fields     fields
 		want       want
-		checkFunc  func(want) error
+		checkFunc  func(want, *worker) error
 		beforeFunc func()
 		afterFunc  func()
 	}
-	defaultCheckFunc := func(w want) error {
+	defaultCheckFunc := func(w want, worker *worker) error {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "Resume success",
+			fields: fields{
+				running: func() atomic.Value {
+					v := &atomic.Value{}
+					v.Store(false)
+					return *v
+				}(),
+			},
+			checkFunc: func(w want, worker *worker) error {
+				if worker.running.Load().(bool) != true {
+					return errors.New("running is not false")
+				}
+				return nil
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -614,7 +715,7 @@ func Test_worker_Resume(t *testing.T) {
 			}
 
 			w.Resume()
-			if err := test.checkFunc(test.want); err != nil {
+			if err := test.checkFunc(test.want, w); err != nil {
 				tt.Errorf("error = %v", err)
 			}
 		})
@@ -650,50 +751,37 @@ func Test_worker_IsRunning(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return true if it is running",
+			fields: fields{
+				running: func() atomic.Value {
+					v := &atomic.Value{}
+					v.Store(true)
+					return *v
+				}(),
+			},
+			want: want{
+				want: true,
+			},
+		},
+		{
+			name: "return false if it is not running",
+			fields: fields{
+				running: func() atomic.Value {
+					v := &atomic.Value{}
+					v.Store(false)
+					return *v
+				}(),
+			},
+			want: want{
+				want: false,
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -752,50 +840,20 @@ func Test_worker_Name(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return name",
+			fields: fields{
+				name: "testname",
+			},
+			want: want{
+				want: "testname",
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -854,50 +912,24 @@ func Test_worker_Len(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return queue length",
+			fields: fields{
+				queue: &QueueMock{
+					LenFunc: func() uint64 {
+						return uint64(100)
+					},
+				},
+			},
+			want: want{
+				want: uint64(100),
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -956,50 +988,20 @@ func Test_worker_TotalRequested(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return total count",
+			fields: fields{
+				requestedCount: 1000,
+			},
+			want: want{
+				want: 1000,
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -1058,50 +1060,20 @@ func Test_worker_TotalCompleted(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return total count",
+			fields: fields{
+				completedCount: 1000,
+			},
+			want: want{
+				want: 1000,
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -1154,69 +1126,111 @@ func Test_worker_Dispatch(t *testing.T) {
 		args       args
 		fields     fields
 		want       want
-		checkFunc  func(want, error) error
+		checkFunc  func(*worker, want, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
-	defaultCheckFunc := func(w want, err error) error {
+	defaultCheckFunc := func(worker *worker, w want, err error) error {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got error = %v, want %v", err, w.err)
 		}
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           ctx: nil,
-		           f: nil,
-		       },
-		       fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           ctx: nil,
-		           f: nil,
-		           },
-		           fields: fields {
-		           name: "",
-		           limitation: 0,
-		           running: nil,
-		           eg: nil,
-		           queue: nil,
-		           qopts: nil,
-		           requestedCount: 0,
-		           completedCount: 0,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return error if the worker is not started yet",
+			args: args{
+				ctx: context.Background(),
+			},
+			fields: fields{
+				name: "test",
+				running: func() atomic.Value {
+					v := &atomic.Value{}
+					v.Store(false)
+					return *v
+				}(),
+			},
+			want: want{
+				err: errors.ErrWorkerIsNotRunning("test"),
+			},
+		},
+		{
+			name: "return error if the job is failed to push to worker queue",
+			args: args{
+				ctx: context.Background(),
+				f: JobFunc(func(context.Context) error {
+					return nil
+				}),
+			},
+			fields: fields{
+				name: "test",
+				running: func() atomic.Value {
+					v := &atomic.Value{}
+					v.Store(true)
+					return *v
+				}(),
+				queue: &QueueMock{
+					PushFunc: func(context.Context, JobFunc) error {
+						return errors.New("queue push error")
+					},
+				},
+			},
+			want: want{
+				err: errors.New("queue push error"),
+			},
+		},
+		{
+			name: "return nil if the job is nil",
+			args: args{
+				ctx: context.Background(),
+				f:   nil,
+			},
+			fields: fields{
+				name: "test",
+				running: func() atomic.Value {
+					v := &atomic.Value{}
+					v.Store(true)
+					return *v
+				}(),
+				queue: &QueueMock{},
+			},
+			want: want{},
+		},
+		{
+			name: "request count is incremented if the job is pushed",
+			args: args{
+				ctx: context.Background(),
+				f: JobFunc(func(context.Context) error {
+					return nil
+				}),
+			},
+			fields: fields{
+				name: "test",
+				running: func() atomic.Value {
+					v := &atomic.Value{}
+					v.Store(true)
+					return *v
+				}(),
+				queue: &QueueMock{
+					PushFunc: func(context.Context, JobFunc) error {
+						return nil
+					},
+				},
+				requestedCount: uint64(999),
+			},
+			want: want{},
+			checkFunc: func(worker *worker, w want, err error) error {
+				if worker.requestedCount != uint64(1000) {
+					return errors.New("requestedCount is not incremented")
+				}
+				return defaultCheckFunc(worker, w, err)
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -1238,7 +1252,7 @@ func Test_worker_Dispatch(t *testing.T) {
 			}
 
 			err := w.Dispatch(test.args.ctx, test.args.f)
-			if err := test.checkFunc(test.want, err); err != nil {
+			if err := test.checkFunc(w, test.want, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -215,25 +215,19 @@ func Test_worker_Start(t *testing.T) {
 			return errors.Errorf("got error = %v, want %v", err, w.err)
 		}
 
-		ecComparator := func(x, y <-chan error) bool {
-			if x == nil && y == nil {
-				return true
-			}
-			if x == nil || y == nil || len(x) != len(y) {
-				return false
-			}
-
-			for e := range x {
-				if e1 := <-y; !errors.Is(e, e1) {
-					return false
-				}
-			}
-			return true
+		if w.want == nil && got == nil {
+			return nil
+		}
+		if w.want == nil || got == nil || len(w.want) != len(got) {
+			return errors.New("want is not equal to got")
 		}
 
-		if !ecComparator(w.want, got) {
-			return errors.New("error")
+		for e := range w.want {
+			if e1 := <-got; !errors.Is(e, e1) {
+				return errors.New("want is not equal to got")
+			}
 		}
+
 		return nil
 	}
 	tests := []test{
@@ -368,24 +362,17 @@ func Test_worker_startJobLoop(t *testing.T) {
 		afterFunc  func(args)
 	}
 	defaultCheckFunc := func(w want, got <-chan error) error {
-		ecComparator := func(x, y <-chan error) bool {
-			if x == nil && y == nil {
-				return true
-			}
-			if x == nil || y == nil || len(x) != len(y) {
-				return false
-			}
-
-			for e := range x {
-				if e1 := <-y; !errors.Is(e, e1) {
-					return false
-				}
-			}
-			return true
+		if w.want == nil && got == nil {
+			return nil
+		}
+		if w.want == nil || got == nil || len(w.want) != len(got) {
+			return errors.New("want is not equal to got")
 		}
 
-		if !ecComparator(w.want, got) {
-			return errors.New("error")
+		for e := range w.want {
+			if e1 := <-got; !errors.Is(e, e1) {
+				return errors.New("want is not equal to got")
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Author review required.

### Description:

This PR includes the following changes:
- implements internal/worker test code
- create test/comparator package and implement go-cmp comparator
- missing `close(ech)` in `startJobLoop()`
 
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.4
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.0

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
