### PR TITLE
create internal/worker/queue test

### DIFF
--- a/internal/worker/queue.go
+++ b/internal/worker/queue.go
@@ -64,6 +64,7 @@ func NewQueue(opts ...QueueOption) (Queue, error) {
 	return q, nil
 }
 
+// Start starts queue and returns (<-chan error, error).
 func (q *queue) Start(ctx context.Context) (<-chan error, error) {
 	if q.isRunning() {
 		return nil, errors.ErrQueueIsAlreadyRunning()
@@ -104,10 +105,13 @@ func (q *queue) Start(ctx context.Context) (<-chan error, error) {
 	return ech, nil
 }
 
+// isRunning returns true when queue is already running or false when queue is not running.
 func (q *queue) isRunning() bool {
 	return q.running.Load().(bool)
 }
 
+// Push sends JobFunc to q.inCh when JobFunc is not nil and queue is running.
+// If JobFunc is nil or queue is not running, Push returns error.
 func (q *queue) Push(ctx context.Context, job JobFunc) error {
 	if job == nil {
 		return errors.ErrJobFuncIsNil()
@@ -125,6 +129,8 @@ func (q *queue) Push(ctx context.Context, job JobFunc) error {
 	}
 }
 
+// Pop returns (JobFunc, nil) if q.outCh contains JobFunc.
+// If pop returns error, Pos returns (nil, error)
 func (q *queue) Pop(ctx context.Context) (JobFunc, error) {
 	return q.pop(ctx, q.Len())
 }
@@ -151,6 +157,7 @@ func (q *queue) pop(ctx context.Context, retry uint64) (JobFunc, error) {
 	return q.pop(ctx, retry)
 }
 
+// Len returns qLen.
 func (q *queue) Len() uint64 {
 	return q.qLen.Load().(uint64)
 }

--- a/internal/worker/queue.go
+++ b/internal/worker/queue.go
@@ -64,7 +64,9 @@ func NewQueue(opts ...QueueOption) (Queue, error) {
 	return q, nil
 }
 
-// Start starts queue and returns (<-chan error, error).
+// Start starts execute queueing if queue is not runnnig.
+// If queue is already reunning, it returns error.
+// It returns the error channel that the queueing job return.
 func (q *queue) Start(ctx context.Context) (<-chan error, error) {
 	if q.isRunning() {
 		return nil, errors.ErrQueueIsAlreadyRunning()
@@ -110,7 +112,7 @@ func (q *queue) isRunning() bool {
 	return q.running.Load().(bool)
 }
 
-// Push sends JobFunc to q.inCh when JobFunc is not nil and queue is running.
+// Push sends JobFunc to channel, which will be used for stock JobFunc, when JobFunc is not nil and queue is running.
 // If JobFunc is nil or queue is not running, Push returns error.
 func (q *queue) Push(ctx context.Context, job JobFunc) error {
 	if job == nil {
@@ -129,7 +131,7 @@ func (q *queue) Push(ctx context.Context, job JobFunc) error {
 	}
 }
 
-// Pop returns (JobFunc, nil) if q.outCh contains JobFunc.
+// Pop returns (JobFunc, nil) if the channnel, which will be used for queuing job, contains JobFunc.
 // If pop returns error, Pos returns (nil, error)
 func (q *queue) Pop(ctx context.Context) (JobFunc, error) {
 	return q.pop(ctx, q.Len())
@@ -157,7 +159,7 @@ func (q *queue) pop(ctx context.Context, retry uint64) (JobFunc, error) {
 	return q.pop(ctx, retry)
 }
 
-// Len returns qLen.
+// Len returns the length of queue.
 func (q *queue) Len() uint64 {
 	return q.qLen.Load().(uint64)
 }

--- a/internal/worker/queue.go
+++ b/internal/worker/queue.go
@@ -74,6 +74,7 @@ func (q *queue) Start(ctx context.Context) (<-chan error, error) {
 
 	ech := make(chan error, 1)
 	q.eg.Go(safety.RecoverFunc(func() (err error) {
+		defer close(ech)
 		defer close(q.outCh)
 		defer close(q.inCh)
 		defer q.running.Store(false)

--- a/internal/worker/queue.go
+++ b/internal/worker/queue.go
@@ -46,7 +46,7 @@ type queue struct {
 	running atomic.Value
 }
 
-// NewQueue returns Queue if no error is occured.
+// NewQueue returns Queue if no error is occurred.
 func NewQueue(opts ...QueueOption) (Queue, error) {
 	q := new(queue)
 	for _, opt := range append(defaultQueueOpts, opts...) {

--- a/internal/worker/queue.go
+++ b/internal/worker/queue.go
@@ -133,7 +133,7 @@ func (q *queue) Push(ctx context.Context, job JobFunc) error {
 }
 
 // Pop returns (JobFunc, nil) if the channnel, which will be used for queuing job, contains JobFunc.
-// If pop returns error, Pos returns (nil, error)
+// It returns (nil ,error) if it failed to pop from the job queue.
 func (q *queue) Pop(ctx context.Context) (JobFunc, error) {
 	return q.pop(ctx, q.Len())
 }

--- a/internal/worker/queue.go
+++ b/internal/worker/queue.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vdaas/vald/internal/safety"
 )
 
+// Queue represents the interface of queue.
 type Queue interface {
 	Start(ctx context.Context) (<-chan error, error)
 	Push(ctx context.Context, job JobFunc) error
@@ -45,6 +46,7 @@ type queue struct {
 	running atomic.Value
 }
 
+// NewQueue returns Queue if no error is occured.
 func NewQueue(opts ...QueueOption) (Queue, error) {
 	q := new(queue)
 	for _, opt := range append(defaultQueueOpts, opts...) {

--- a/internal/worker/queue_test.go
+++ b/internal/worker/queue_test.go
@@ -806,7 +806,7 @@ func Test_queue_pop(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			return test{
-				name: "return (JobFunc, error) when context canceld.",
+				name: "return (JobFunc, error) when context canceled.",
 				args: args{
 					ctx:   ctx,
 					retry: 0,

--- a/internal/worker/queue_test.go
+++ b/internal/worker/queue_test.go
@@ -63,6 +63,10 @@ func TestNewQueue(t *testing.T) {
 			return nil
 		}
 
+		if (w.want == nil && got != nil) || (w.want != nil && got == nil) {
+			return errors.Errorf("got = %v, want %v", got, w.want)
+		}
+
 		egComparator := func(want, got errgroup.Group) bool {
 			return reflect.DeepEqual(want, got)
 		}
@@ -78,7 +82,7 @@ func TestNewQueue(t *testing.T) {
 			}),
 		}
 		if diff := cmp.Diff(w.want, got, opts...); diff != "" {
-			return errors.Errorf("got = %v, want %v", got, w.want)
+			return errors.Errorf("diff = %s", diff)
 		}
 		return nil
 	}

--- a/internal/worker/queue_test.go
+++ b/internal/worker/queue_test.go
@@ -532,7 +532,7 @@ func Test_queue_Push(t *testing.T) {
 					eg:     errgroup.Get(),
 					qcdur:  100 * time.Microsecond,
 					inCh:   make(chan JobFunc, 1),
-					outCh:  make(chan JobFunc, 0),
+					outCh:  make(chan JobFunc),
 					qLen: func() atomic.Value {
 						v := new(atomic.Value)
 						v.Store(uint64(0))
@@ -842,7 +842,7 @@ func Test_queue_pop(t *testing.T) {
 					eg:     errgroup.Get(),
 					qcdur:  100 * time.Microsecond,
 					inCh:   make(chan JobFunc, 10),
-					outCh:  make(chan JobFunc, 0),
+					outCh:  make(chan JobFunc),
 					qLen: func() atomic.Value {
 						v := new(atomic.Value)
 						v.Store(uint64(0))


### PR DESCRIPTION
Signed-off-by: vankichi <kyukawa315@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
There are 2 changes:
  - create test of `internal/worker/queue`.
  - update comments for each function of `internal/worker/queue`
And 1 bug fix:
  - add `close(ech)` in `func(q) Starts() (<-chan error, error)`

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.4
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.0

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
