### PR TITLE
Add internal/net test

### DIFF
--- a/internal/errors/net.go
+++ b/internal/errors/net.go
@@ -31,6 +31,6 @@ var (
 
 	// net
 
-	// ErrNoPortAvailiable defines no port availiable error
-	ErrNoPortAvailiable = New("no port availiable")
+	// ErrNoPortAvailiable defines no port available error
+	ErrNoPortAvailable = New("no port available")
 )

--- a/internal/errors/net.go
+++ b/internal/errors/net.go
@@ -28,4 +28,9 @@ var (
 	ErrInvalidDNSConfig = func(dnsRefreshDur, dnsCacheExp time.Duration) error {
 		return Errorf("dnsRefreshDuration  > dnsCacheExp, %s, %s", dnsRefreshDur, dnsCacheExp)
 	}
+
+	// net
+
+	// ErrNoPortAvailiable defines no port availiable error
+	ErrNoPortAvailiable = New("no port availiable")
 )

--- a/internal/net/net.go
+++ b/internal/net/net.go
@@ -142,6 +142,7 @@ func ScanPorts(ctx context.Context, start, end uint16, host string) (ports []uin
 	eg.Limitation(int(rl.Max) / 2)
 
 	var mu sync.Mutex
+
 	for i := start; i >= start && i <= end; i++ {
 		port := i
 		eg.Go(func() error {

--- a/internal/net/net.go
+++ b/internal/net/net.go
@@ -39,14 +39,24 @@ const (
 )
 
 type (
-	Conn         = net.Conn
-	Dialer       = net.Dialer
+	// Conn is an alias of net.Conn
+	Conn = net.Conn
+
+	// Dialer is an alias of net.Dialer
+	Dialer = net.Dialer
+
+	// ListenConfig is an alias of net.ListenConfig
 	ListenConfig = net.ListenConfig
-	Listener     = net.Listener
-	Resolver     = net.Resolver
+
+	// Listener is an alias of net.Listener
+	Listener = net.Listener
+
+	// Resolver is an alias of net.Resolver
+	Resolver = net.Resolver
 )
 
 var (
+	// DefaultResolver is an alias of net.DefaultResolver
 	DefaultResolver = net.DefaultResolver
 )
 

--- a/internal/net/net.go
+++ b/internal/net/net.go
@@ -94,7 +94,7 @@ func IsIPv4(addr string) bool {
 func SplitHostPort(hostport string) (host string, port uint16, err error) {
 	switch {
 	case strings.HasPrefix(hostport, "::"):
-		hostport = localIPv6 + hostport[2:]
+		hostport = localIPv6 + hostport
 	case strings.HasPrefix(hostport, ":"):
 		hostport = localIPv4 + hostport
 	}

--- a/internal/net/net.go
+++ b/internal/net/net.go
@@ -63,7 +63,7 @@ func IsLocal(host string) bool {
 }
 
 // Dial is a wrapper function of the net.Dial function.
-func Dial(network string, addr string) (conn Conn, err error) {
+func Dial(network, addr string) (conn Conn, err error) {
 	return net.Dial(network, addr)
 }
 

--- a/internal/net/net.go
+++ b/internal/net/net.go
@@ -91,10 +91,14 @@ func IsIPv4(addr string) bool {
 
 // SplitHostPort splits the address, and return the host/IP address and the port number,
 // and any error occurred.
+// If it is the loopback address, it will return the loopback address and corresponding port number.
+// IPv6 loopback address is not supported yet. For more information, please read https://github.com/vdaas/vald/projects/3#card-43504189
 func SplitHostPort(hostport string) (host string, port uint16, err error) {
 	switch {
+	/* TODO: IPv6 loopback address support
 	case strings.HasPrefix(hostport, "::"):
 		hostport = localIPv6 + hostport
+	*/
 	case strings.HasPrefix(hostport, ":"):
 		hostport = localIPv4 + hostport
 	}

--- a/internal/net/net.go
+++ b/internal/net/net.go
@@ -92,7 +92,8 @@ func IsIPv4(addr string) bool {
 // SplitHostPort splits the address, and return the host/IP address and the port number,
 // and any error occurred.
 // If it is the loopback address, it will return the loopback address and corresponding port number.
-// IPv6 loopback address is not supported yet. For more information, please read https://github.com/vdaas/vald/projects/3#card-43504189
+// IPv6 loopback address is not supported yet.
+// For more information, please read https://github.com/vdaas/vald/projects/3#card-43504189
 func SplitHostPort(hostport string) (host string, port uint16, err error) {
 	switch {
 	/* TODO: IPv6 loopback address support

--- a/internal/net/net.go
+++ b/internal/net/net.go
@@ -161,7 +161,7 @@ func ScanPorts(ctx context.Context, start, end uint16, host string) (ports []uin
 	}
 
 	if len(ports) == 0 {
-		return nil, errors.ErrNoPortAvailiable
+		return nil, errors.ErrNoPortAvailable
 	}
 
 	return ports, nil

--- a/internal/net/net_test.go
+++ b/internal/net/net_test.go
@@ -443,7 +443,7 @@ func TestIsIPv6(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return true if it is IPv6 adress",
+			name: "return true if it is IPv6 address",
 			args: args{
 				addr: "2001:db8::1",
 			},
@@ -452,7 +452,7 @@ func TestIsIPv6(t *testing.T) {
 			},
 		},
 		{
-			name: "return false if it is not IPv6 adress",
+			name: "return false if it is not IPv6 address",
 			args: args{
 				addr: "localhost",
 			},
@@ -507,7 +507,7 @@ func TestIsIPv4(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return true if it is IPv4 adress",
+			name: "return true if it is IPv4 address",
 			args: args{
 				addr: "192.168.1.1",
 			},
@@ -516,7 +516,7 @@ func TestIsIPv4(t *testing.T) {
 			},
 		},
 		{
-			name: "return false if it is not IPv4 adress",
+			name: "return false if it is not IPv4 address",
 			args: args{
 				addr: "localhost",
 			},
@@ -649,17 +649,6 @@ func TestSplitHostPort(t *testing.T) {
 			want: want{
 				wantHost: "127.0.0.1",
 				wantPort: uint16(8080),
-			},
-		},
-		{
-			name: "parse success with default IPv6 address",
-			args: args{
-				hostport: "::",
-			},
-			want: want{
-				wantHost: "::1",
-				wantPort: uint16(80),
-				err:      &strconv.NumError{"Atoi", "", strconv.ErrSyntax},
 			},
 		},
 	}
@@ -858,7 +847,7 @@ func TestScanPorts(t *testing.T) {
 			}
 		}(),
 		{
-			name: "return no port availiable if no port is scanned",
+			name: "return no port available if no port is scanned",
 			args: args{
 				ctx:   context.Background(),
 				host:  "localhost",
@@ -866,7 +855,7 @@ func TestScanPorts(t *testing.T) {
 				end:   65535,
 			},
 			want: want{
-				err: errors.ErrNoPortAvailiable,
+				err: errors.ErrNoPortAvailable,
 			},
 		},
 	}

--- a/internal/net/net_test.go
+++ b/internal/net/net_test.go
@@ -369,7 +369,11 @@ func TestParse(t *testing.T) {
 			want: want{
 				wantHost: "dummy",
 				wantPort: uint16(80),
-				err:      &strconv.NumError{"Atoi", "", strconv.ErrSyntax},
+				err: &strconv.NumError{
+					Func: "Atoi",
+					Num:  "",
+					Err:  strconv.ErrSyntax,
+				},
 			},
 		},
 		{
@@ -381,7 +385,11 @@ func TestParse(t *testing.T) {
 				wantHost: "192.168.1.1",
 				wantPort: uint16(80),
 				wantIsIP: true,
-				err:      &strconv.NumError{"Atoi", "", strconv.ErrSyntax},
+				err: &strconv.NumError{
+					Func: "Atoi",
+					Num:  "",
+					Err:  strconv.ErrSyntax,
+				},
 			},
 		},
 		{
@@ -393,7 +401,11 @@ func TestParse(t *testing.T) {
 				wantHost: "2001:db8::1",
 				wantPort: uint16(80),
 				wantIsIP: true,
-				err:      &strconv.NumError{"Atoi", "", strconv.ErrSyntax},
+				err: &strconv.NumError{
+					Func: "Atoi",
+					Num:  "",
+					Err:  strconv.ErrSyntax,
+				},
 			},
 		},
 	}

--- a/internal/net/net_test.go
+++ b/internal/net/net_test.go
@@ -19,12 +19,34 @@ package net
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/vdaas/vald/internal/errors"
+	"github.com/vdaas/vald/internal/log"
 	"go.uber.org/goleak"
 )
+
+var (
+	// Goroutine leak is detected by `fastime`, but it should be ignored in the test because it is an external package.
+	goleakIgnoreOptions = []goleak.Option{
+		goleak.IgnoreTopFunction("github.com/kpango/fastime.(*Fastime).StartTimerD.func1"),
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
+	}
+)
+
+func TestMain(m *testing.M) {
+	log.Init()
+	os.Exit(m.Run())
+}
 
 func TestListen(t *testing.T) {
 	type args struct {
@@ -53,38 +75,29 @@ func TestListen(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           network: "",
-		           address: "",
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
+		{
+			name: "listener is created successfully",
+			args: args{
+				network: "tcp",
+				address: ":0",
+			},
+			checkFunc: func(w want, got Listener, err error) error {
+				if !errors.Is(err, w.err) {
+					return errors.Errorf("got error = %v, want %v", err, w.err)
+				}
 
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           network: "",
-		           address: "",
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+				if err := got.Close(); err != nil {
+					return err
+				}
+
+				return nil
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -126,36 +139,56 @@ func TestIsLocal(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           host: "",
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           host: "",
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return true if it is host is `localhost`",
+			args: args{
+				host: "localhost",
+			},
+			want: want{
+				want: true,
+			},
+		},
+		{
+			name: "return true if it is host is local IPv4 address",
+			args: args{
+				host: "127.0.0.1",
+			},
+			want: want{
+				want: true,
+			},
+		},
+		{
+			name: "return true if it is host is local IPv6 address",
+			args: args{
+				host: "::1",
+			},
+			want: want{
+				want: true,
+			},
+		},
+		{
+			name: "return false if the host is not an address",
+			args: args{
+				host: "dummy",
+			},
+			want: want{
+				want: false,
+			},
+		},
+		{
+			name: "return false if the host is empty",
+			args: args{
+				host: "",
+			},
+			want: want{
+				want: false,
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -202,38 +235,46 @@ func TestDial(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           network: "",
-		           addr: "",
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
+		func() test {
+			srvContent := "test"
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, srvContent)
+				w.WriteHeader(200)
+			})
+			testSrv := httptest.NewServer(handler)
 
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           network: "",
-		           addr: "",
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+			return test{
+				name: "dial return server content",
+				args: args{
+					network: "tcp",
+					addr:    testSrv.URL[len("http://"):],
+				},
+				checkFunc: func(w want, gotConn Conn, err error) error {
+					if !errors.Is(err, w.err) {
+						return errors.Errorf("got error = %v, want %v", err, w.err)
+					}
+
+					// read the output from the server and check if it is equals to the count
+					fmt.Fprintf(gotConn, "GET / HTTP/1.0\r\n\r\n")
+					buf, _ := ioutil.ReadAll(gotConn)
+					content := strings.Split(string(buf), "\n")[5] // skip HTTP header
+					if content != srvContent {
+						return errors.Errorf("invalid content, got: %v, want: %v", content, srvContent)
+					}
+
+					return nil
+				},
+				afterFunc: func(args) {
+					testSrv.CloseClientConnections()
+					testSrv.Close()
+				},
+			}
+		}(),
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -272,7 +313,7 @@ func TestParse(t *testing.T) {
 		afterFunc  func(args)
 	}
 	defaultCheckFunc := func(w want, gotHost string, gotPort uint16, gotIsIP bool, err error) error {
-		if !errors.Is(err, w.err) {
+		if (w.err == nil && err != nil) || (w.err != nil && err == nil) || (err != nil && err.Error() != w.err.Error()) {
 			return errors.Errorf("got error = %v, want %v", err, w.err)
 		}
 		if !reflect.DeepEqual(gotHost, w.wantHost) {
@@ -287,36 +328,79 @@ func TestParse(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           addr: "",
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           addr: "",
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "parse success with IPv4 address",
+			args: args{
+				addr: "192.168.1.1:8080",
+			},
+			want: want{
+				wantHost: "192.168.1.1",
+				wantPort: uint16(8080),
+				wantIsIP: true,
+			},
+		},
+		{
+			name: "parse success with IPv6 address",
+			args: args{
+				addr: "[2001:db8::1]:8080",
+			},
+			want: want{
+				wantHost: "2001:db8::1",
+				wantPort: uint16(8080),
+				wantIsIP: true,
+			},
+		},
+		{
+			name: "parse success with hostname",
+			args: args{
+				addr: "google.com:8080",
+			},
+			want: want{
+				wantHost: "google.com",
+				wantPort: uint16(8080),
+				wantIsIP: false,
+			},
+		},
+		{
+			name: "return default port when parse failed if it is not an address",
+			args: args{
+				addr: "dummy",
+			},
+			want: want{
+				wantHost: "dummy",
+				wantPort: uint16(80),
+				err:      &strconv.NumError{"Atoi", "", strconv.ErrSyntax},
+			},
+		},
+		{
+			name: "return default port when parse failed if port number missing in IPv4 address",
+			args: args{
+				addr: "192.168.1.1",
+			},
+			want: want{
+				wantHost: "192.168.1.1",
+				wantPort: uint16(80),
+				wantIsIP: true,
+				err:      &strconv.NumError{"Atoi", "", strconv.ErrSyntax},
+			},
+		},
+		{
+			name: "return default port when parse failed if port number missing in IPv6 address",
+			args: args{
+				addr: "2001:db8::1",
+			},
+			want: want{
+				wantHost: "2001:db8::1",
+				wantPort: uint16(80),
+				wantIsIP: true,
+				err:      &strconv.NumError{"Atoi", "", strconv.ErrSyntax},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -358,36 +442,29 @@ func TestIsIPv6(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           addr: "",
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           addr: "",
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return true if it is IPv6 adress",
+			args: args{
+				addr: "2001:db8::1",
+			},
+			want: want{
+				want: true,
+			},
+		},
+		{
+			name: "return false if it is not IPv6 adress",
+			args: args{
+				addr: "localhost",
+			},
+			want: want{
+				want: false,
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -429,36 +506,29 @@ func TestIsIPv4(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           addr: "",
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           addr: "",
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return true if it is IPv4 adress",
+			args: args{
+				addr: "192.168.1.1",
+			},
+			want: want{
+				want: true,
+			},
+		},
+		{
+			name: "return false if it is not IPv4 adress",
+			args: args{
+				addr: "localhost",
+			},
+			want: want{
+				want: false,
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -496,7 +566,7 @@ func TestSplitHostPort(t *testing.T) {
 		afterFunc  func(args)
 	}
 	defaultCheckFunc := func(w want, gotHost string, gotPort uint16, err error) error {
-		if !errors.Is(err, w.err) {
+		if (w.err == nil && err != nil) || (w.err != nil && err == nil) || (err != nil && err.Error() != w.err.Error()) {
 			return errors.Errorf("got error = %v, want %v", err, w.err)
 		}
 		if !reflect.DeepEqual(gotHost, w.wantHost) {
@@ -508,36 +578,95 @@ func TestSplitHostPort(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           hostport: "",
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           hostport: "",
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "parse success with IPv4 address",
+			args: args{
+				hostport: "192.168.1.1:8080",
+			},
+			want: want{
+				wantHost: "192.168.1.1",
+				wantPort: uint16(8080),
+			},
+		},
+		{
+			name: "parse success with IPv6 address",
+			args: args{
+				hostport: "[2001:db8::1]:8080",
+			},
+			want: want{
+				wantHost: "2001:db8::1",
+				wantPort: uint16(8080),
+			},
+		},
+		{
+			name: "parse success with hostname",
+			args: args{
+				hostport: "google.com:8080",
+			},
+			want: want{
+				wantHost: "google.com",
+				wantPort: uint16(8080),
+			},
+		},
+		{
+			name: "return default port when parse failed if it is not an address",
+			args: args{
+				hostport: "dummy",
+			},
+			want: want{
+				wantHost: "dummy",
+				wantPort: uint16(80),
+				err:      &strconv.NumError{"Atoi", "", strconv.ErrSyntax},
+			},
+		},
+		{
+			name: "return default port when parse failed if port number missing in IPv4 address",
+			args: args{
+				hostport: "192.168.1.1",
+			},
+			want: want{
+				wantHost: "192.168.1.1",
+				wantPort: uint16(80),
+				err:      &strconv.NumError{"Atoi", "", strconv.ErrSyntax},
+			},
+		},
+		{
+			name: "return default port when parse failed if port number missing in IPv6 address",
+			args: args{
+				hostport: "2001:db8::1",
+			},
+			want: want{
+				wantHost: "2001:db8::1",
+				wantPort: uint16(80),
+				err:      &strconv.NumError{"Atoi", "", strconv.ErrSyntax},
+			},
+		},
+		{
+			name: "parse success with default IPv4 address",
+			args: args{
+				hostport: ":8080",
+			},
+			want: want{
+				wantHost: "127.0.0.1",
+				wantPort: uint16(8080),
+			},
+		},
+		{
+			name: "parse success with default IPv6 address",
+			args: args{
+				hostport: "::",
+			},
+			want: want{
+				wantHost: "::1",
+				wantPort: uint16(80),
+				err:      &strconv.NumError{"Atoi", "", strconv.ErrSyntax},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -580,53 +709,173 @@ func TestScanPorts(t *testing.T) {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got error = %v, want %v", err, w.err)
 		}
-		if !reflect.DeepEqual(gotPorts, w.wantPorts) {
+
+		// count how want want ports exists in got ports
+		cnt := 0
+		for _, wp := range w.wantPorts {
+			for _, gp := range gotPorts {
+				if wp == gp {
+					cnt++
+					break
+				}
+			}
+		}
+
+		if cnt != len(w.wantPorts) {
 			return errors.Errorf("got = %v, want %v", gotPorts, w.wantPorts)
 		}
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           ctx: nil,
-		           start: 0,
-		           end: 0,
-		           host: "",
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
+		func() test {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(200)
+			})
+			testSrv := httptest.NewServer(handler)
 
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           ctx: nil,
-		           start: 0,
-		           end: 0,
-		           host: "",
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+			s := strings.Split(testSrv.URL, ":")
+			p, _ := strconv.Atoi(s[len(s)-1])
+			srvPort := uint16(p)
+
+			return test{
+				name: "return test server port number in given range",
+				args: args{
+					ctx:   context.Background(),
+					host:  "localhost",
+					start: srvPort - 5,
+					end:   srvPort + 5,
+				},
+				want: want{
+					wantPorts: []uint16{
+						srvPort,
+					},
+				},
+				afterFunc: func(args) {
+					testSrv.Close()
+				},
+			}
+		}(),
+		func() test {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(200)
+			})
+			testSrv := httptest.NewServer(handler)
+
+			s := strings.Split(testSrv.URL, ":")
+			p, _ := strconv.Atoi(s[len(s)-1])
+			srvPort := uint16(p)
+
+			return test{
+				name: "return test server port number when start = end",
+				args: args{
+					ctx:   context.Background(),
+					host:  "localhost",
+					start: srvPort,
+					end:   srvPort,
+				},
+				want: want{
+					wantPorts: []uint16{
+						srvPort,
+					},
+				},
+				afterFunc: func(args) {
+					testSrv.Close()
+				},
+			}
+		}(),
+		func() test {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(200)
+			})
+			testSrv := httptest.NewServer(handler)
+
+			s := strings.Split(testSrv.URL, ":")
+			p, _ := strconv.Atoi(s[len(s)-1])
+			srvPort := uint16(p)
+
+			return test{
+				name: "return test server port number when start > end",
+				args: args{
+					ctx:   context.Background(),
+					host:  "localhost",
+					start: srvPort + 10,
+					end:   srvPort - 10,
+				},
+				want: want{
+					wantPorts: []uint16{
+						srvPort,
+					},
+				},
+				afterFunc: func(args) {
+					testSrv.Close()
+				},
+			}
+		}(),
+		func() test {
+			srvNum := 20
+
+			srvs := make([]*httptest.Server, 0, srvNum)
+			ports := make([]uint16, 0, srvNum)
+			minPort := uint16(math.MaxUint16)
+			maxPort := uint16(0)
+
+			for i := 0; i < srvNum; i++ {
+				handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(200)
+				})
+				srv := httptest.NewServer(handler)
+				srvs = append(srvs, srv)
+
+				s := strings.Split(srv.URL, ":")
+				p, _ := strconv.Atoi(s[len(s)-1])
+				port := uint16(p)
+				ports = append(ports, port)
+
+				if port < minPort {
+					minPort = port
+				}
+				if port > maxPort {
+					maxPort = port
+				}
+			}
+
+			return test{
+				name: "return multiple test server port number",
+				args: args{
+					ctx:   context.Background(),
+					host:  "localhost",
+					start: minPort - 5,
+					end:   maxPort + 5,
+				},
+				want: want{
+					wantPorts: ports,
+				},
+				afterFunc: func(args) {
+					for _, s := range srvs {
+						s.Close()
+					}
+				},
+			}
+		}(),
+		{
+			name: "return no port availiable if no port is scanned",
+			args: args{
+				ctx:   context.Background(),
+				host:  "localhost",
+				start: 65534,
+				end:   65535,
+			},
+			want: want{
+				err: errors.ErrNoPortAvailiable,
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
-			}
-			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
 			}
 			if test.checkFunc == nil {
 				test.checkFunc = defaultCheckFunc
@@ -637,6 +886,9 @@ func TestScanPorts(t *testing.T) {
 				tt.Errorf("error = %v", err)
 			}
 
+			if test.afterFunc != nil {
+				test.afterFunc(test.args)
+			}
 		})
 	}
 }

--- a/internal/net/net_test.go
+++ b/internal/net/net_test.go
@@ -86,11 +86,7 @@ func TestListen(t *testing.T) {
 					return errors.Errorf("got error = %v, want %v", err, w.err)
 				}
 
-				if err := got.Close(); err != nil {
-					return err
-				}
-
-				return nil
+				return got.Close()
 			},
 		},
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Author review required.
### Description:

This PR implements test case for internal/net/net.go. 
This PR also include the following changes:

Bug fix:
- In ScanPorts(), when `start > end`, unexpected ports will be scanned
   Fix: https://github.com/vdaas/vald/pull/615/files#diff-111853981bfa0f81d6c8945300daf97bR122-R124

- In ScanPorts(), when `end` is 65535, the `ScanPorts()` will never return due to golang bug or behavior
   Fix: https://github.com/vdaas/vald/pull/615/files#diff-111853981bfa0f81d6c8945300daf97bR134
   Ref: https://github.com/vdaas/vald/pull/615#discussion_r469117449

- In ScanPorts(), scanning ports in range, with some ports are failed but some success, the error will be returned instead of returning succeed ports 
   Fix: https://github.com/vdaas/vald/pull/615/files#diff-111853981bfa0f81d6c8945300daf97bR143-R144
          https://github.com/vdaas/vald/pull/615/files#diff-111853981bfa0f81d6c8945300daf97bR163-R165

Refactor:
- In ScanPorts(), do not return connection close error.
   Ref: https://github.com/vdaas/vald/pull/615/files#diff-111853981bfa0f81d6c8945300daf97bR151-R153

- In SplitHostPort(), commented out the `::` support due to invalid implementation, which always return error.
   To support loopback IPv6 address please read the function comment.
   Ref: https://github.com/vdaas/vald/pull/615/files#diff-111853981bfa0f81d6c8945300daf97bR98-R101

<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.4
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.0

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
