### PR TITLE
add internal/compress/lz4_option test

### DIFF
--- a/internal/compress/lz4_option.go
+++ b/internal/compress/lz4_option.go
@@ -17,8 +17,11 @@
 // Package compress provides compress functions
 package compress
 
-import "github.com/vdaas/vald/internal/errors"
+import (
+	"github.com/vdaas/vald/internal/errors"
+)
 
+// LZ4Option represents the functional option for lz4Compressor.
 type LZ4Option func(c *lz4Compressor) error
 
 var (
@@ -28,6 +31,7 @@ var (
 	}
 )
 
+// WithLZ4Gob returns the option to set gobc for lz4Compressor.
 func WithLZ4Gob(opts ...GobOption) LZ4Option {
 	return func(c *lz4Compressor) error {
 		gobc, err := NewGob(opts...)
@@ -39,6 +43,7 @@ func WithLZ4Gob(opts ...GobOption) LZ4Option {
 	}
 }
 
+// WithLZ4CompressionLevel returns the option to set compressionLevel for lz4Compressor.
 func WithLZ4CompressionLevel(level int) LZ4Option {
 	return func(c *lz4Compressor) error {
 		if level > 0 {

--- a/internal/compress/lz4_option_test.go
+++ b/internal/compress/lz4_option_test.go
@@ -144,6 +144,7 @@ func TestWithLZ4CompressionLevel(t *testing.T) {
 				level: 1,
 			},
 			want: want{
+				obj: new(T),
 				err: errors.ErrInvalidCompressionLevel(1),
 			},
 		},

--- a/internal/compress/lz4_option_test.go
+++ b/internal/compress/lz4_option_test.go
@@ -18,196 +18,142 @@
 package compress
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/vdaas/vald/internal/errors"
 	"go.uber.org/goleak"
 )
 
 func TestWithLZ4Gob(t *testing.T) {
-	type T = interface{}
+	type T = lz4Compressor
 	type args struct {
 		opts []GobOption
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got error = %v, want %v", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.c)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got error = %v, want %v", err, w.err)
+		}
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got = %v, want %v", obj, w.obj)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           opts: nil,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           opts: nil,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		func() test {
+			gobc, _ := NewGob()
+			return test{
+				name: "set success when opts is not nil.",
+				args: args{
+					opts: nil,
+				},
+				want: want{
+					obj: &T{
+						gobc: gobc,
+					},
+				},
+			}
+		}(),
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithLZ4Gob(test.args.opts...)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithLZ4Gob(test.args.opts...)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(tt.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithLZ4Gob(test.args.opts...)
+			obj := new(T)
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithLZ4CompressionLevel(t *testing.T) {
-	type T = interface{}
+	type T = lz4Compressor
 	type args struct {
 		level int
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got error = %v, want %v", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got = %v, want %v", obj, w.c)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got error = %v, want %v", err, w.err)
+		}
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got = %v, want %v", obj, w.obj)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           level: 0,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           level: 0,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		func() test {
+			return test{
+				name: "set success when level is less than 0.",
+				args: args{
+					level: -1,
+				},
+				want: want{
+					obj: &T{
+						compressionLevel: -1,
+					},
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "set success when level is nil.",
+				want: want{
+					obj: new(T),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "return error when level is more than 1.",
+				args: args{
+					level: 1,
+				},
+				want: want{
+					obj: new(T),
+					err: errors.ErrInvalidCompressionLevel(1),
+				},
+			}
+		}(),
 	}
 
 	for _, test := range tests {
@@ -220,31 +166,15 @@ func TestWithLZ4CompressionLevel(t *testing.T) {
 				defer test.afterFunc(test.args)
 			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			   got := WithLZ4CompressionLevel(test.args.level)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithLZ4CompressionLevel(test.args.level)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(tt.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithLZ4CompressionLevel(test.args.level)
+			obj := new(T)
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }

--- a/internal/compress/lz4_option_test.go
+++ b/internal/compress/lz4_option_test.go
@@ -144,7 +144,6 @@ func TestWithLZ4CompressionLevel(t *testing.T) {
 				level: 1,
 			},
 			want: want{
-				obj: new(T),
 				err: errors.ErrInvalidCompressionLevel(1),
 			},
 		},

--- a/internal/compress/lz4_option_test.go
+++ b/internal/compress/lz4_option_test.go
@@ -121,39 +121,33 @@ func TestWithLZ4CompressionLevel(t *testing.T) {
 	}
 
 	tests := []test{
-		func() test {
-			return test{
-				name: "set success when level is less than 0.",
-				args: args{
-					level: -1,
+		{
+			name: "set success when level is less than 0.",
+			args: args{
+				level: -1,
+			},
+			want: want{
+				obj: &T{
+					compressionLevel: -1,
 				},
-				want: want{
-					obj: &T{
-						compressionLevel: -1,
-					},
-				},
-			}
-		}(),
-		func() test {
-			return test{
-				name: "set success when level is nil.",
-				want: want{
-					obj: new(T),
-				},
-			}
-		}(),
-		func() test {
-			return test{
-				name: "return error when level is more than 1.",
-				args: args{
-					level: 1,
-				},
-				want: want{
-					obj: new(T),
-					err: errors.ErrInvalidCompressionLevel(1),
-				},
-			}
-		}(),
+			},
+		},
+		{
+			name: "set success when level is nil.",
+			want: want{
+				obj: new(T),
+			},
+		},
+		{
+			name: "return error when level is more than 1.",
+			args: args{
+				level: 1,
+			},
+			want: want{
+				obj: new(T),
+				err: errors.ErrInvalidCompressionLevel(1),
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Signed-off-by: vankichi <kyukawa315@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
- Add test for `internal/compress/lz4_option`
- Update comments for each external func/method/var in `internal/compress/lz4_option`

- Note: I could not cover the error pattern test in `WithLZ4Gob`, because `gobCompressor` is an empty struct and has no `options`.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.4
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.0

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
