### PR TITLE
Add cassandra option test (part 1)

### DIFF
--- a/internal/db/nosql/cassandra/cassandra.go
+++ b/internal/db/nosql/cassandra/cassandra.go
@@ -44,6 +44,12 @@ var (
 	ErrHostQueryFailed      = gocql.ErrHostQueryFailed
 )
 
+type Cassandra interface {
+	Open(ctx context.Context) error
+	Close(ctx context.Context) error
+	Query(stmt string, names []string) *Queryx
+}
+
 type (
 	Session       = gocql.Session
 	Cmp           = qb.Cmp
@@ -52,13 +58,9 @@ type (
 	DeleteBuilder = qb.DeleteBuilder
 	UpdateBuilder = qb.UpdateBuilder
 	Queryx        = gocqlx.Queryx
+)
 
-	Cassandra interface {
-		Open(ctx context.Context) error
-		Close(ctx context.Context) error
-		Query(stmt string, names []string) *Queryx
-	}
-
+type (
 	retryPolicy struct {
 		numRetries  int
 		minDuration time.Duration

--- a/internal/db/nosql/cassandra/cassandra.go
+++ b/internal/db/nosql/cassandra/cassandra.go
@@ -44,35 +44,22 @@ var (
 	ErrHostQueryFailed      = gocql.ErrHostQueryFailed
 )
 
-type Cassandra interface {
-	Open(ctx context.Context) error
-	Close(ctx context.Context) error
-	Query(stmt string, names []string) *Queryx
-}
+type (
+	Session       = gocql.Session
+	Cmp           = qb.Cmp
+	BatchBuilder  = qb.BatchBuilder
+	InsertBuilder = qb.InsertBuilder
+	DeleteBuilder = qb.DeleteBuilder
+	UpdateBuilder = qb.UpdateBuilder
+	Queryx        = gocqlx.Queryx
 
-type Session = gocql.Session
-type Cmp = qb.Cmp
-type BatchBuilder = qb.BatchBuilder
-type InsertBuilder = qb.InsertBuilder
-type DeleteBuilder = qb.DeleteBuilder
-type UpdateBuilder = qb.UpdateBuilder
-type Queryx = gocqlx.Queryx
+	Cassandra interface {
+		Open(ctx context.Context) error
+		Close(ctx context.Context) error
+		Query(stmt string, names []string) *Queryx
+	}
 
-type client struct {
-	hosts          []string
-	cqlVersion     string
-	protoVersion   int
-	timeout        time.Duration
-	connectTimeout time.Duration
-	port           int
-	keyspace       string
-	numConns       int
-	consistency    gocql.Consistency
-	compressor     gocql.Compressor
-	username       string
-	password       string
-	authProvider   func(h *gocql.HostInfo) (gocql.Authenticator, error)
-	retryPolicy    struct {
+	retryPolicy struct {
 		numRetries  int
 		minDuration time.Duration
 		maxDuration time.Duration
@@ -93,36 +80,55 @@ type client struct {
 		dcHost    string
 		whiteList []string
 	}
-	socketKeepalive          time.Duration
-	maxPreparedStmts         int
-	maxRoutingKeyInfo        int
-	pageSize                 int
-	serialConsistency        gocql.SerialConsistency
-	tls                      *tls.Config
-	tlsCertPath              string
-	tlsKeyPath               string
-	tlsCAPath                string
-	enableHostVerification   bool
-	defaultTimestamp         bool
-	reconnectInterval        time.Duration
-	maxWaitSchemaAgreement   time.Duration
-	ignorePeerAddr           bool
-	disableInitialHostLookup bool
-	disableNodeStatusEvents  bool
-	disableTopologyEvents    bool
-	disableSchemaEvents      bool
-	disableSkipMetadata      bool
-	queryObserver            QueryObserver
-	batchObserver            BatchObserver
-	connectObserver          ConnectObserver
-	frameHeaderObserver      FrameHeaderObserver
-	defaultIdempotence       bool
-	dialer                   gocql.Dialer
-	writeCoalesceWaitTime    time.Duration
+	client struct {
+		hosts                    []string
+		cqlVersion               string
+		protoVersion             int
+		timeout                  time.Duration
+		connectTimeout           time.Duration
+		port                     int
+		keyspace                 string
+		numConns                 int
+		consistency              gocql.Consistency
+		compressor               gocql.Compressor
+		username                 string
+		password                 string
+		authProvider             func(h *gocql.HostInfo) (gocql.Authenticator, error)
+		retryPolicy              retryPolicy
+		reconnectionPolicy       reconnectionPolicy
+		poolConfig               poolConfig
+		hostFilter               hostFilter
+		socketKeepalive          time.Duration
+		maxPreparedStmts         int
+		maxRoutingKeyInfo        int
+		pageSize                 int
+		serialConsistency        gocql.SerialConsistency
+		tls                      *tls.Config
+		tlsCertPath              string
+		tlsKeyPath               string
+		tlsCAPath                string
+		enableHostVerification   bool
+		defaultTimestamp         bool
+		reconnectInterval        time.Duration
+		maxWaitSchemaAgreement   time.Duration
+		ignorePeerAddr           bool
+		disableInitialHostLookup bool
+		disableNodeStatusEvents  bool
+		disableTopologyEvents    bool
+		disableSchemaEvents      bool
+		disableSkipMetadata      bool
+		queryObserver            QueryObserver
+		batchObserver            BatchObserver
+		connectObserver          ConnectObserver
+		frameHeaderObserver      FrameHeaderObserver
+		defaultIdempotence       bool
+		dialer                   gocql.Dialer
+		writeCoalesceWaitTime    time.Duration
 
-	cluster *gocql.ClusterConfig
-	session *gocql.Session
-}
+		cluster *gocql.ClusterConfig
+		session *gocql.Session
+	}
+)
 
 func New(opts ...Option) (Cassandra, error) {
 	c := new(client)

--- a/internal/db/nosql/cassandra/cassandra_mock_test.go
+++ b/internal/db/nosql/cassandra/cassandra_mock_test.go
@@ -1,0 +1,14 @@
+package cassandra
+
+import (
+	"context"
+	"net"
+)
+
+type DialerMock struct {
+	DialContextFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
+func (dm *DialerMock) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	return dm.DialContextFunc(ctx, network, addr)
+}

--- a/internal/db/nosql/cassandra/option.go
+++ b/internal/db/nosql/cassandra/option.go
@@ -27,6 +27,10 @@ import (
 	"github.com/vdaas/vald/internal/timeutil"
 )
 
+// Option represents the functional option for client.
+// It wraps the gocql.ClusterConfig to the function option implementation.
+// Please refer to the following link for more information.
+// https://pkg.go.dev/github.com/gocql/gocql?tab=doc#ClusterConfig
 type Option func(*client) error
 
 var (
@@ -60,6 +64,7 @@ var (
 	}
 )
 
+// WithHosts returns the option to set the hosts
 func WithHosts(hosts ...string) Option {
 	return func(c *client) error {
 		if len(hosts) == 0 {
@@ -74,6 +79,7 @@ func WithHosts(hosts ...string) Option {
 	}
 }
 
+// WithDialer returns the option to set the dialer
 func WithDialer(der gocql.Dialer) Option {
 	return func(c *client) error {
 		if der != nil {
@@ -83,6 +89,7 @@ func WithDialer(der gocql.Dialer) Option {
 	}
 }
 
+// WithCQLVersion returns the option to set the CQL version
 func WithCQLVersion(version string) Option {
 	return func(c *client) error {
 		c.cqlVersion = version
@@ -90,6 +97,7 @@ func WithCQLVersion(version string) Option {
 	}
 }
 
+// WithProtoVersion returns the option to set the proto version
 func WithProtoVersion(version int) Option {
 	return func(c *client) error {
 		c.protoVersion = version
@@ -97,6 +105,7 @@ func WithProtoVersion(version int) Option {
 	}
 }
 
+// WithTimeout returns the option to set the cassandra connect timeout time
 func WithTimeout(dur string) Option {
 	return func(c *client) error {
 		if dur == "" {
@@ -111,6 +120,7 @@ func WithTimeout(dur string) Option {
 	}
 }
 
+// WithConnectTimeout returns the option to set the cassandra initial connection timeout
 func WithConnectTimeout(dur string) Option {
 	return func(c *client) error {
 		if dur == "" {
@@ -125,6 +135,7 @@ func WithConnectTimeout(dur string) Option {
 	}
 }
 
+// WithPort returns the option to set the port number
 func WithPort(port int) Option {
 	return func(c *client) error {
 		c.port = port
@@ -132,6 +143,7 @@ func WithPort(port int) Option {
 	}
 }
 
+// WithKeyspace returns the option to set the keyspace
 func WithKeyspace(keyspace string) Option {
 	return func(c *client) error {
 		c.keyspace = keyspace
@@ -139,6 +151,7 @@ func WithKeyspace(keyspace string) Option {
 	}
 }
 
+// WithNumConns returns the option to set the number of connection per host
 func WithNumConns(numConns int) Option {
 	return func(c *client) error {
 		c.numConns = numConns

--- a/internal/db/nosql/cassandra/option_test.go
+++ b/internal/db/nosql/cassandra/option_test.go
@@ -37,7 +37,7 @@ var (
 	}
 
 	// default comparator option for client
-	clientOpts = []comparator.Option{
+	clientComparatorOpts = []comparator.Option{
 		comparator.AllowUnexported(client{}),
 		comparator.Comparer(func(x, y retryPolicy) bool {
 			return reflect.DeepEqual(x, y)
@@ -76,7 +76,7 @@ func TestWithHosts(t *testing.T) {
 			return errors.Errorf("got error = %v, want %v", err, w.err)
 		}
 
-		if diff := comparator.Diff(obj, w.obj, clientOpts...); diff != "" {
+		if diff := comparator.Diff(obj, w.obj, clientComparatorOpts...); diff != "" {
 			return errors.New(diff)
 		}
 		return nil
@@ -183,7 +183,7 @@ func TestWithDialer(t *testing.T) {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got error = %v, want %v", err, w.err)
 		}
-		if diff := comparator.Diff(obj, w.obj, clientOpts...); diff != "" {
+		if diff := comparator.Diff(obj, w.obj, clientComparatorOpts...); diff != "" {
 			return errors.New(diff)
 		}
 		return nil
@@ -258,7 +258,7 @@ func TestWithCQLVersion(t *testing.T) {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got error = %v, want %v", err, w.err)
 		}
-		if diff := comparator.Diff(obj, w.obj, clientOpts...); diff != "" {
+		if diff := comparator.Diff(obj, w.obj, clientComparatorOpts...); diff != "" {
 			return errors.New(diff)
 		}
 		return nil
@@ -321,7 +321,7 @@ func TestWithProtoVersion(t *testing.T) {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got error = %v, want %v", err, w.err)
 		}
-		if diff := comparator.Diff(obj, w.obj, clientOpts...); diff != "" {
+		if diff := comparator.Diff(obj, w.obj, clientComparatorOpts...); diff != "" {
 			return errors.New(diff)
 		}
 		return nil
@@ -384,7 +384,7 @@ func TestWithTimeout(t *testing.T) {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got error = %v, want %v", err, w.err)
 		}
-		if diff := comparator.Diff(obj, w.obj, clientOpts...); diff != "" {
+		if diff := comparator.Diff(obj, w.obj, clientComparatorOpts...); diff != "" {
 			return errors.New(diff)
 		}
 		return nil
@@ -414,7 +414,7 @@ func TestWithTimeout(t *testing.T) {
 			},
 		},
 		{
-			name: "set timeout success if the time is nil",
+			name: "set timeout success if the time is empty",
 			args: args{
 				dur: "",
 			},
@@ -469,7 +469,7 @@ func TestWithConnectTimeout(t *testing.T) {
 			err != nil && w.err.Error() != err.Error() {
 			return errors.Errorf("got error = %v, want %v", err, w.err)
 		}
-		if diff := comparator.Diff(obj, w.obj, clientOpts...); diff != "" {
+		if diff := comparator.Diff(obj, w.obj, clientComparatorOpts...); diff != "" {
 			return errors.New(diff)
 		}
 		return nil
@@ -552,7 +552,7 @@ func TestWithPort(t *testing.T) {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got error = %v, want %v", err, w.err)
 		}
-		if diff := comparator.Diff(obj, w.obj, clientOpts...); diff != "" {
+		if diff := comparator.Diff(obj, w.obj, clientComparatorOpts...); diff != "" {
 			return errors.New(diff)
 		}
 		return nil
@@ -615,7 +615,7 @@ func TestWithKeyspace(t *testing.T) {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got error = %v, want %v", err, w.err)
 		}
-		if diff := comparator.Diff(obj, w.obj, clientOpts...); diff != "" {
+		if diff := comparator.Diff(obj, w.obj, clientComparatorOpts...); diff != "" {
 			return errors.New(diff)
 		}
 		return nil
@@ -678,7 +678,7 @@ func TestWithNumConns(t *testing.T) {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got error = %v, want %v", err, w.err)
 		}
-		if diff := comparator.Diff(obj, w.obj, clientOpts...); diff != "" {
+		if diff := comparator.Diff(obj, w.obj, clientComparatorOpts...); diff != "" {
 			return errors.New(diff)
 		}
 		return nil

--- a/internal/db/nosql/cassandra/option_test.go
+++ b/internal/db/nosql/cassandra/option_test.go
@@ -721,32 +721,48 @@ func TestWithNumConns(t *testing.T) {
 }
 
 func TestWithConsistency(t *testing.T) {
-	type T = client
+	type T = interface{}
 	type args struct {
 		consistency string
 	}
 	type want struct {
 		obj *T
-		err error
+		// Uncomment this line if the option returns an error, otherwise delete it
+		// err error
 	}
 	type test struct {
-		name       string
-		args       args
-		want       want
-		checkFunc  func(want, *T, error) error
+		name string
+		args args
+		want want
+		// Use the first line if the option returns an error. otherwise use the second line
+		// checkFunc  func(want, *T, error) error
+		// checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	defaultCheckFunc := func(w want, obj *T, err error) error {
-		if !errors.Is(err, w.err) {
-			return errors.Errorf("got error = %v, want %v", err, w.err)
-		}
-		if !reflect.DeepEqual(obj, w.obj) {
-			return errors.Errorf("got = %v, want %v", obj, w.obj)
-		}
-		return nil
-	}
+	// Uncomment this block if the option returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T, err error) error {
+	       if !errors.Is(err, w.err) {
+	           return errors.Errorf("got error = %v, want %v", err, w.err)
+	       }
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.obj)
+	       }
+	       return nil
+	   }
+	*/
+
+	// Uncomment this block if the option do not returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T) error {
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.c)
+	       }
+	       return nil
+	   }
+	*/
 
 	tests := []test{
 		// TODO test cases
@@ -780,53 +796,86 @@ func TestWithConsistency(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(t)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
 
-			got := WithConsistency(test.args.consistency)
-			obj := new(T)
-			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-				tt.Errorf("error = %v", err)
-			}
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+
+			   got := WithConsistency(test.args.consistency)
+			   obj := new(T)
+			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
+
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+			   got := WithConsistency(test.args.consistency)
+			   obj := new(T)
+			   got(obj)
+			   if err := test.checkFunc(tt.want, obj); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
 		})
 	}
 }
 
 func TestWithCompressor(t *testing.T) {
-	type T = client
+	type T = interface{}
 	type args struct {
 		compressor gocql.Compressor
 	}
 	type want struct {
 		obj *T
-		err error
+		// Uncomment this line if the option returns an error, otherwise delete it
+		// err error
 	}
 	type test struct {
-		name       string
-		args       args
-		want       want
-		checkFunc  func(want, *T, error) error
+		name string
+		args args
+		want want
+		// Use the first line if the option returns an error. otherwise use the second line
+		// checkFunc  func(want, *T, error) error
+		// checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	defaultCheckFunc := func(w want, obj *T, err error) error {
-		if !errors.Is(err, w.err) {
-			return errors.Errorf("got error = %v, want %v", err, w.err)
-		}
-		if !reflect.DeepEqual(obj, w.obj) {
-			return errors.Errorf("got = %v, want %v", obj, w.obj)
-		}
-		return nil
-	}
+	// Uncomment this block if the option returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T, err error) error {
+	       if !errors.Is(err, w.err) {
+	           return errors.Errorf("got error = %v, want %v", err, w.err)
+	       }
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.obj)
+	       }
+	       return nil
+	   }
+	*/
+
+	// Uncomment this block if the option do not returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T) error {
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.c)
+	       }
+	       return nil
+	   }
+	*/
 
 	tests := []test{
 		// TODO test cases
@@ -860,53 +909,86 @@ func TestWithCompressor(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(t)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
 
-			got := WithCompressor(test.args.compressor)
-			obj := new(T)
-			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-				tt.Errorf("error = %v", err)
-			}
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+
+			   got := WithCompressor(test.args.compressor)
+			   obj := new(T)
+			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
+
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+			   got := WithCompressor(test.args.compressor)
+			   obj := new(T)
+			   got(obj)
+			   if err := test.checkFunc(tt.want, obj); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
 		})
 	}
 }
 
 func TestWithUsername(t *testing.T) {
-	type T = client
+	type T = interface{}
 	type args struct {
 		username string
 	}
 	type want struct {
 		obj *T
-		err error
+		// Uncomment this line if the option returns an error, otherwise delete it
+		// err error
 	}
 	type test struct {
-		name       string
-		args       args
-		want       want
-		checkFunc  func(want, *T, error) error
+		name string
+		args args
+		want want
+		// Use the first line if the option returns an error. otherwise use the second line
+		// checkFunc  func(want, *T, error) error
+		// checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	defaultCheckFunc := func(w want, obj *T, err error) error {
-		if !errors.Is(err, w.err) {
-			return errors.Errorf("got error = %v, want %v", err, w.err)
-		}
-		if !reflect.DeepEqual(obj, w.obj) {
-			return errors.Errorf("got = %v, want %v", obj, w.obj)
-		}
-		return nil
-	}
+	// Uncomment this block if the option returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T, err error) error {
+	       if !errors.Is(err, w.err) {
+	           return errors.Errorf("got error = %v, want %v", err, w.err)
+	       }
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.obj)
+	       }
+	       return nil
+	   }
+	*/
+
+	// Uncomment this block if the option do not returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T) error {
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.c)
+	       }
+	       return nil
+	   }
+	*/
 
 	tests := []test{
 		// TODO test cases
@@ -940,53 +1022,86 @@ func TestWithUsername(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(t)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
 
-			got := WithUsername(test.args.username)
-			obj := new(T)
-			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-				tt.Errorf("error = %v", err)
-			}
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+
+			   got := WithUsername(test.args.username)
+			   obj := new(T)
+			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
+
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+			   got := WithUsername(test.args.username)
+			   obj := new(T)
+			   got(obj)
+			   if err := test.checkFunc(tt.want, obj); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
 		})
 	}
 }
 
 func TestWithPassword(t *testing.T) {
-	type T = client
+	type T = interface{}
 	type args struct {
 		password string
 	}
 	type want struct {
 		obj *T
-		err error
+		// Uncomment this line if the option returns an error, otherwise delete it
+		// err error
 	}
 	type test struct {
-		name       string
-		args       args
-		want       want
-		checkFunc  func(want, *T, error) error
+		name string
+		args args
+		want want
+		// Use the first line if the option returns an error. otherwise use the second line
+		// checkFunc  func(want, *T, error) error
+		// checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	defaultCheckFunc := func(w want, obj *T, err error) error {
-		if !errors.Is(err, w.err) {
-			return errors.Errorf("got error = %v, want %v", err, w.err)
-		}
-		if !reflect.DeepEqual(obj, w.obj) {
-			return errors.Errorf("got = %v, want %v", obj, w.obj)
-		}
-		return nil
-	}
+	// Uncomment this block if the option returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T, err error) error {
+	       if !errors.Is(err, w.err) {
+	           return errors.Errorf("got error = %v, want %v", err, w.err)
+	       }
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.obj)
+	       }
+	       return nil
+	   }
+	*/
+
+	// Uncomment this block if the option do not returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T) error {
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.c)
+	       }
+	       return nil
+	   }
+	*/
 
 	tests := []test{
 		// TODO test cases
@@ -1020,53 +1135,86 @@ func TestWithPassword(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(t)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
 
-			got := WithPassword(test.args.password)
-			obj := new(T)
-			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-				tt.Errorf("error = %v", err)
-			}
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+
+			   got := WithPassword(test.args.password)
+			   obj := new(T)
+			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
+
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+			   got := WithPassword(test.args.password)
+			   obj := new(T)
+			   got(obj)
+			   if err := test.checkFunc(tt.want, obj); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
 		})
 	}
 }
 
 func TestWithAuthProvider(t *testing.T) {
-	type T = client
+	type T = interface{}
 	type args struct {
 		authProvider func(h *gocql.HostInfo) (gocql.Authenticator, error)
 	}
 	type want struct {
 		obj *T
-		err error
+		// Uncomment this line if the option returns an error, otherwise delete it
+		// err error
 	}
 	type test struct {
-		name       string
-		args       args
-		want       want
-		checkFunc  func(want, *T, error) error
+		name string
+		args args
+		want want
+		// Use the first line if the option returns an error. otherwise use the second line
+		// checkFunc  func(want, *T, error) error
+		// checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	defaultCheckFunc := func(w want, obj *T, err error) error {
-		if !errors.Is(err, w.err) {
-			return errors.Errorf("got error = %v, want %v", err, w.err)
-		}
-		if !reflect.DeepEqual(obj, w.obj) {
-			return errors.Errorf("got = %v, want %v", obj, w.obj)
-		}
-		return nil
-	}
+	// Uncomment this block if the option returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T, err error) error {
+	       if !errors.Is(err, w.err) {
+	           return errors.Errorf("got error = %v, want %v", err, w.err)
+	       }
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.obj)
+	       }
+	       return nil
+	   }
+	*/
+
+	// Uncomment this block if the option do not returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T) error {
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.c)
+	       }
+	       return nil
+	   }
+	*/
 
 	tests := []test{
 		// TODO test cases
@@ -1100,53 +1248,86 @@ func TestWithAuthProvider(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(t)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
 
-			got := WithAuthProvider(test.args.authProvider)
-			obj := new(T)
-			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-				tt.Errorf("error = %v", err)
-			}
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+
+			   got := WithAuthProvider(test.args.authProvider)
+			   obj := new(T)
+			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
+
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+			   got := WithAuthProvider(test.args.authProvider)
+			   obj := new(T)
+			   got(obj)
+			   if err := test.checkFunc(tt.want, obj); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
 		})
 	}
 }
 
 func TestWithRetryPolicyNumRetries(t *testing.T) {
-	type T = client
+	type T = interface{}
 	type args struct {
 		n int
 	}
 	type want struct {
 		obj *T
-		err error
+		// Uncomment this line if the option returns an error, otherwise delete it
+		// err error
 	}
 	type test struct {
-		name       string
-		args       args
-		want       want
-		checkFunc  func(want, *T, error) error
+		name string
+		args args
+		want want
+		// Use the first line if the option returns an error. otherwise use the second line
+		// checkFunc  func(want, *T, error) error
+		// checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	defaultCheckFunc := func(w want, obj *T, err error) error {
-		if !errors.Is(err, w.err) {
-			return errors.Errorf("got error = %v, want %v", err, w.err)
-		}
-		if !reflect.DeepEqual(obj, w.obj) {
-			return errors.Errorf("got = %v, want %v", obj, w.obj)
-		}
-		return nil
-	}
+	// Uncomment this block if the option returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T, err error) error {
+	       if !errors.Is(err, w.err) {
+	           return errors.Errorf("got error = %v, want %v", err, w.err)
+	       }
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.obj)
+	       }
+	       return nil
+	   }
+	*/
+
+	// Uncomment this block if the option do not returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T) error {
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.c)
+	       }
+	       return nil
+	   }
+	*/
 
 	tests := []test{
 		// TODO test cases
@@ -1180,7 +1361,7 @@ func TestWithRetryPolicyNumRetries(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(t)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -1188,46 +1369,78 @@ func TestWithRetryPolicyNumRetries(t *testing.T) {
 				defer test.afterFunc(test.args)
 			}
 
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
 
-			got := WithRetryPolicyNumRetries(test.args.n)
-			obj := new(T)
-			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-				tt.Errorf("error = %v", err)
-			}
+			   got := WithRetryPolicyNumRetries(test.args.n)
+			   obj := new(T)
+			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
+
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+			   got := WithRetryPolicyNumRetries(test.args.n)
+			   obj := new(T)
+			   got(obj)
+			   if err := test.checkFunc(tt.want, obj); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
 		})
 	}
 }
 
 func TestWithRetryPolicyMinDuration(t *testing.T) {
-	type T = client
+	type T = interface{}
 	type args struct {
 		minDuration string
 	}
 	type want struct {
 		obj *T
-		err error
+		// Uncomment this line if the option returns an error, otherwise delete it
+		// err error
 	}
 	type test struct {
-		name       string
-		args       args
-		want       want
-		checkFunc  func(want, *T, error) error
+		name string
+		args args
+		want want
+		// Use the first line if the option returns an error. otherwise use the second line
+		// checkFunc  func(want, *T, error) error
+		// checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	defaultCheckFunc := func(w want, obj *T, err error) error {
-		if !errors.Is(err, w.err) {
-			return errors.Errorf("got error = %v, want %v", err, w.err)
-		}
-		if !reflect.DeepEqual(obj, w.obj) {
-			return errors.Errorf("got = %v, want %v", obj, w.obj)
-		}
-		return nil
-	}
+	// Uncomment this block if the option returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T, err error) error {
+	       if !errors.Is(err, w.err) {
+	           return errors.Errorf("got error = %v, want %v", err, w.err)
+	       }
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.obj)
+	       }
+	       return nil
+	   }
+	*/
+
+	// Uncomment this block if the option do not returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T) error {
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.c)
+	       }
+	       return nil
+	   }
+	*/
 
 	tests := []test{
 		// TODO test cases
@@ -1261,53 +1474,86 @@ func TestWithRetryPolicyMinDuration(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(t)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
 
-			got := WithRetryPolicyMinDuration(test.args.minDuration)
-			obj := new(T)
-			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-				tt.Errorf("error = %v", err)
-			}
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+
+			   got := WithRetryPolicyMinDuration(test.args.minDuration)
+			   obj := new(T)
+			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
+
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+			   got := WithRetryPolicyMinDuration(test.args.minDuration)
+			   obj := new(T)
+			   got(obj)
+			   if err := test.checkFunc(tt.want, obj); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
 		})
 	}
 }
 
 func TestWithRetryPolicyMaxDuration(t *testing.T) {
-	type T = client
+	type T = interface{}
 	type args struct {
 		maxDuration string
 	}
 	type want struct {
 		obj *T
-		err error
+		// Uncomment this line if the option returns an error, otherwise delete it
+		// err error
 	}
 	type test struct {
-		name       string
-		args       args
-		want       want
-		checkFunc  func(want, *T, error) error
+		name string
+		args args
+		want want
+		// Use the first line if the option returns an error. otherwise use the second line
+		// checkFunc  func(want, *T, error) error
+		// checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	defaultCheckFunc := func(w want, obj *T, err error) error {
-		if !errors.Is(err, w.err) {
-			return errors.Errorf("got error = %v, want %v", err, w.err)
-		}
-		if !reflect.DeepEqual(obj, w.obj) {
-			return errors.Errorf("got = %v, want %v", obj, w.obj)
-		}
-		return nil
-	}
+	// Uncomment this block if the option returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T, err error) error {
+	       if !errors.Is(err, w.err) {
+	           return errors.Errorf("got error = %v, want %v", err, w.err)
+	       }
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.obj)
+	       }
+	       return nil
+	   }
+	*/
+
+	// Uncomment this block if the option do not returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T) error {
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.c)
+	       }
+	       return nil
+	   }
+	*/
 
 	tests := []test{
 		// TODO test cases
@@ -1341,53 +1587,86 @@ func TestWithRetryPolicyMaxDuration(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(t)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
 
-			got := WithRetryPolicyMaxDuration(test.args.maxDuration)
-			obj := new(T)
-			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-				tt.Errorf("error = %v", err)
-			}
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+
+			   got := WithRetryPolicyMaxDuration(test.args.maxDuration)
+			   obj := new(T)
+			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
+
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+			   got := WithRetryPolicyMaxDuration(test.args.maxDuration)
+			   obj := new(T)
+			   got(obj)
+			   if err := test.checkFunc(tt.want, obj); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
 		})
 	}
 }
 
 func TestWithReconnectionPolicyInitialInterval(t *testing.T) {
-	type T = client
+	type T = interface{}
 	type args struct {
 		initialInterval string
 	}
 	type want struct {
 		obj *T
-		err error
+		// Uncomment this line if the option returns an error, otherwise delete it
+		// err error
 	}
 	type test struct {
-		name       string
-		args       args
-		want       want
-		checkFunc  func(want, *T, error) error
+		name string
+		args args
+		want want
+		// Use the first line if the option returns an error. otherwise use the second line
+		// checkFunc  func(want, *T, error) error
+		// checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	defaultCheckFunc := func(w want, obj *T, err error) error {
-		if !errors.Is(err, w.err) {
-			return errors.Errorf("got error = %v, want %v", err, w.err)
-		}
-		if !reflect.DeepEqual(obj, w.obj) {
-			return errors.Errorf("got = %v, want %v", obj, w.obj)
-		}
-		return nil
-	}
+	// Uncomment this block if the option returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T, err error) error {
+	       if !errors.Is(err, w.err) {
+	           return errors.Errorf("got error = %v, want %v", err, w.err)
+	       }
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.obj)
+	       }
+	       return nil
+	   }
+	*/
+
+	// Uncomment this block if the option do not returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T) error {
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.c)
+	       }
+	       return nil
+	   }
+	*/
 
 	tests := []test{
 		// TODO test cases
@@ -1421,53 +1700,86 @@ func TestWithReconnectionPolicyInitialInterval(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(t)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
 
-			got := WithReconnectionPolicyInitialInterval(test.args.initialInterval)
-			obj := new(T)
-			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-				tt.Errorf("error = %v", err)
-			}
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+
+			   got := WithReconnectionPolicyInitialInterval(test.args.initialInterval)
+			   obj := new(T)
+			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
+
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+			   got := WithReconnectionPolicyInitialInterval(test.args.initialInterval)
+			   obj := new(T)
+			   got(obj)
+			   if err := test.checkFunc(tt.want, obj); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
 		})
 	}
 }
 
 func TestWithReconnectionPolicyMaxRetries(t *testing.T) {
-	type T = client
+	type T = interface{}
 	type args struct {
 		maxRetries int
 	}
 	type want struct {
 		obj *T
-		err error
+		// Uncomment this line if the option returns an error, otherwise delete it
+		// err error
 	}
 	type test struct {
-		name       string
-		args       args
-		want       want
-		checkFunc  func(want, *T, error) error
+		name string
+		args args
+		want want
+		// Use the first line if the option returns an error. otherwise use the second line
+		// checkFunc  func(want, *T, error) error
+		// checkFunc  func(want, *T) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	defaultCheckFunc := func(w want, obj *T, err error) error {
-		if !errors.Is(err, w.err) {
-			return errors.Errorf("got error = %v, want %v", err, w.err)
-		}
-		if !reflect.DeepEqual(obj, w.obj) {
-			return errors.Errorf("got = %v, want %v", obj, w.obj)
-		}
-		return nil
-	}
+	// Uncomment this block if the option returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T, err error) error {
+	       if !errors.Is(err, w.err) {
+	           return errors.Errorf("got error = %v, want %v", err, w.err)
+	       }
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.obj)
+	       }
+	       return nil
+	   }
+	*/
+
+	// Uncomment this block if the option do not returns an error, otherwise delete it
+	/*
+	   defaultCheckFunc := func(w want, obj *T) error {
+	       if !reflect.DeepEqual(obj, w.obj) {
+	           return errors.Errorf("got = %v, want %v", obj, w.c)
+	       }
+	       return nil
+	   }
+	*/
 
 	tests := []test{
 		// TODO test cases
@@ -1501,22 +1813,39 @@ func TestWithReconnectionPolicyMaxRetries(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(t)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
 
-			got := WithReconnectionPolicyMaxRetries(test.args.maxRetries)
-			obj := new(T)
-			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-				tt.Errorf("error = %v", err)
-			}
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+
+			   got := WithReconnectionPolicyMaxRetries(test.args.maxRetries)
+			   obj := new(T)
+			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
+
+			// Uncomment this block if the option returns an error, otherwise delete it
+			/*
+			   if test.checkFunc == nil {
+			       test.checkFunc = defaultCheckFunc
+			   }
+			   got := WithReconnectionPolicyMaxRetries(test.args.maxRetries)
+			   obj := new(T)
+			   got(obj)
+			   if err := test.checkFunc(tt.want, obj); err != nil {
+			       tt.Errorf("error = %v", err)
+			   }
+			*/
 		})
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR includes the cassandra_option test code, and some refactoring for writing the test code.
It is only the part of the option test. 
This PR is merging against the [test/internal/db/cassandra_option](https://github.com/vdaas/vald/tree/test/internal/db/cassandra_option) branch. 
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.4
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.0

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
