### PR TITLE
add internal/compress/lz4 test

### DIFF
--- a/internal/compress/lz4.go
+++ b/internal/compress/lz4.go
@@ -122,7 +122,7 @@ func (l *lz4Reader) Read(p []byte) (n int, err error) {
 	return l.r.Read(p)
 }
 
-// Close closes src and r.
+// Close closes the reader.
 func (l *lz4Reader) Close() (err error) {
 	return l.src.Close()
 }

--- a/internal/compress/lz4.go
+++ b/internal/compress/lz4.go
@@ -138,7 +138,7 @@ func (l *lz4Writer) Write(p []byte) (n int, err error) {
 	return l.w.Write(p)
 }
 
-// Close closes dst and w.
+// Close closes the writer.
 func (l *lz4Writer) Close() (err error) {
 	err = l.w.Close()
 	if err != nil {

--- a/internal/compress/lz4_test.go
+++ b/internal/compress/lz4_test.go
@@ -70,6 +70,24 @@ func TestNewLZ4(t *testing.T) {
 			},
 		},
 		{
+			name: "returns (Compressor, nil) when option is not empty",
+			args: args{
+				opts: []LZ4Option{
+					WithLZ4CompressionLevel(-1),
+				},
+			},
+			want: want{
+				want: &lz4Compressor{
+					gobc: func() (gob Compressor) {
+						gob, _ = NewGob()
+						return
+					}(),
+					compressionLevel: -1,
+					lz4:              lz4.New(),
+				},
+			},
+		},
+		{
 			name: "returns (nil, error) when option apply fails",
 			args: args{
 				opts: []LZ4Option{

--- a/internal/compress/lz4_test.go
+++ b/internal/compress/lz4_test.go
@@ -22,48 +22,49 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/vdaas/vald/internal/compress/lz4"
 	"github.com/vdaas/vald/internal/errors"
 	"go.uber.org/goleak"
 )
 
-func TestLZ4CompressVector(t *testing.T) {
-	tests := []struct {
-		vector []float32
-	}{
-		{
-			vector: []float32{0.1, 0.2, 0.3},
-		},
-		{
-			vector: []float32{0.4, 0.2, 0.3, 0.1},
-		},
-		{
-			vector: []float32{0.1, 0.5, 0.12, 0.13, 1.0},
-		},
-	}
-
-	for _, tc := range tests {
-		lz4c, err := NewLZ4()
-		if err != nil {
-			t.Fatalf("initialize failed: %s", err)
-		}
-
-		compressed, err := lz4c.CompressVector(tc.vector)
-		if err != nil {
-			t.Fatalf("Compress failed: %s", err)
-		}
-
-		decompressed, err := lz4c.DecompressVector(compressed)
-		if err != nil {
-			t.Fatalf("Decompress failed: %s", err)
-		}
-		t.Logf("converted: origin %+v, compressed -> decompressed %+v", tc.vector, decompressed)
-		for i := range tc.vector {
-			if tc.vector[i] != decompressed[i] {
-				t.Fatalf("Invalid convert: origin %+v, compressed -> decompressed %+v", tc.vector, decompressed)
-			}
-		}
-	}
-}
+// func TestLZ4CompressVector(t *testing.T) {
+// 	tests := []struct {
+// 		vector []float32
+// 	}{
+// 		{
+// 			vector: []float32{0.1, 0.2, 0.3},
+// 		},
+// 		{
+// 			vector: []float32{0.4, 0.2, 0.3, 0.1},
+// 		},
+// 		{
+// 			vector: []float32{0.1, 0.5, 0.12, 0.13, 1.0},
+// 		},
+// 	}
+//
+// 	for _, tc := range tests {
+// 		lz4c, err := NewLZ4()
+// 		if err != nil {
+// 			t.Fatalf("initialize failed: %s", err)
+// 		}
+//
+// 		compressed, err := lz4c.CompressVector(tc.vector)
+// 		if err != nil {
+// 			t.Fatalf("Compress failed: %s", err)
+// 		}
+//
+// 		decompressed, err := lz4c.DecompressVector(compressed)
+// 		if err != nil {
+// 			t.Fatalf("Decompress failed: %s", err)
+// 		}
+// 		t.Logf("converted: origin %+v, compressed -> decompressed %+v", tc.vector, decompressed)
+// 		for i := range tc.vector {
+// 			if tc.vector[i] != decompressed[i] {
+// 				t.Fatalf("Invalid convert: origin %+v, compressed -> decompressed %+v", tc.vector, decompressed)
+// 			}
+// 		}
+// 	}
+// }
 
 func TestNewLZ4(t *testing.T) {
 	type args struct {
@@ -91,31 +92,36 @@ func TestNewLZ4(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           opts: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           opts: nil,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "returns (Compressor, nil) when option is empty",
+			args: args{
+				opts: nil,
+			},
+			want: want{
+				want: &lz4Compressor{
+					gobc: func() (gob Compressor) {
+						gob, _ = NewGob()
+						return
+					}(),
+					compressionLevel: 0,
+					lz4:              lz4.New(),
+				},
+			},
+		},
+		{
+			name: "returns (nil, error) when option apply fails",
+			args: args{
+				opts: []LZ4Option{
+					func(*lz4Compressor) error {
+						return errors.New("opts err")
+					},
+				},
+			},
+			want: want{
+				want: nil,
+				err:  errors.New("opts err"),
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -147,6 +153,7 @@ func Test_lz4Compressor_CompressVector(t *testing.T) {
 	type fields struct {
 		gobc             Compressor
 		compressionLevel int
+		lz4              lz4.LZ4
 	}
 	type want struct {
 		want []byte
@@ -171,39 +178,170 @@ func Test_lz4Compressor_CompressVector(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           vector: nil,
-		       },
-		       fields: fields {
-		           gobc: nil,
-		           compressionLevel: 0,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           vector: nil,
-		           },
-		           fields: fields {
-		           gobc: nil,
-		           compressionLevel: 0,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "returns ([]byte, nil) when no error occurs",
+			args: args{
+				vector: []float32{0.1, 0.2, 0.3},
+			},
+			fields: fields{
+				gobc: &MockCompressor{
+					CompressVectorFunc: func(vector []float32) (bytes []byte, err error) {
+						return []byte("vdaas/vald"), nil
+					},
+				},
+				compressionLevel: 0,
+				lz4: &lz4.MockLZ4{
+					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
+						return &lz4.MockWriter{
+							WriteFunc: func(p []byte) (n int, err error) {
+								return w.Write(p)
+							},
+							FlushFunc: func() error {
+								return nil
+							},
+							CloseFunc: func() error {
+								return nil
+							},
+						}
+					},
+				},
+			},
+			want: want{
+				want: []byte("vdaas/vald"),
+			},
+		},
+		{
+			name: "returns (nil, error) when compress vector fails",
+			args: args{
+				vector: []float32{0.1, 0.2, 0.3},
+			},
+			fields: fields{
+				gobc: &MockCompressor{
+					CompressVectorFunc: func(vector []float32) (bytes []byte, err error) {
+						return nil, errors.New("compress err")
+					},
+				},
+				compressionLevel: 0,
+				lz4: &lz4.MockLZ4{
+					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
+						return &lz4.MockWriter{
+							WriteFunc: func(p []byte) (n int, err error) {
+								return w.Write(p)
+							},
+							FlushFunc: func() error {
+								return nil
+							},
+							CloseFunc: func() error {
+								return nil
+							},
+						}
+					},
+				},
+			},
+			want: want{
+				want: nil,
+				err:  errors.New("compress err"),
+			},
+		},
+		{
+			name: "returns (nil, error) when Write fails",
+			args: args{
+				vector: []float32{0.1, 0.2, 0.3},
+			},
+			fields: fields{
+				gobc: &MockCompressor{
+					CompressVectorFunc: func(vector []float32) (bytes []byte, err error) {
+						return []byte("vdaas/vald"), nil
+					},
+				},
+				compressionLevel: 0,
+				lz4: &lz4.MockLZ4{
+					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
+						return &lz4.MockWriter{
+							WriteFunc: func(p []byte) (n int, err error) {
+								return 0, errors.New("write err")
+							},
+							FlushFunc: func() error {
+								return nil
+							},
+							CloseFunc: func() error {
+								return nil
+							},
+						}
+					},
+				},
+			},
+			want: want{
+				want: nil,
+				err:  errors.New("write err"),
+			},
+		},
+		{
+			name: "returns (nil, error) when Flush fails",
+			args: args{
+				vector: []float32{0.1, 0.2, 0.3},
+			},
+			fields: fields{
+				gobc: &MockCompressor{
+					CompressVectorFunc: func(vector []float32) (bytes []byte, err error) {
+						return []byte("vdaas/vald"), nil
+					},
+				},
+				compressionLevel: 0,
+				lz4: &lz4.MockLZ4{
+					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
+						return &lz4.MockWriter{
+							WriteFunc: func(p []byte) (n int, err error) {
+								return w.Write(p)
+							},
+							FlushFunc: func() error {
+								return errors.New("flush err")
+							},
+							CloseFunc: func() error {
+								return nil
+							},
+						}
+					},
+				},
+			},
+			want: want{
+				want: nil,
+				err:  errors.New("flush err"),
+			},
+		},
+		{
+			name: "returns (nil, error) when Close fails",
+			args: args{
+				vector: []float32{0.1, 0.2, 0.3},
+			},
+			fields: fields{
+				gobc: &MockCompressor{
+					CompressVectorFunc: func(vector []float32) (bytes []byte, err error) {
+						return []byte("vdaas/vald"), nil
+					},
+				},
+				compressionLevel: 0,
+				lz4: &lz4.MockLZ4{
+					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
+						return &lz4.MockWriter{
+							WriteFunc: func(p []byte) (n int, err error) {
+								return w.Write(p)
+							},
+							FlushFunc: func() error {
+								return nil
+							},
+							CloseFunc: func() error {
+								return errors.New("close err")
+							},
+						}
+					},
+				},
+			},
+			want: want{
+				want: nil,
+				err:  errors.New("close err"),
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -221,6 +359,7 @@ func Test_lz4Compressor_CompressVector(t *testing.T) {
 			l := &lz4Compressor{
 				gobc:             test.fields.gobc,
 				compressionLevel: test.fields.compressionLevel,
+				lz4:              test.fields.lz4,
 			}
 
 			got, err := l.CompressVector(test.args.vector)
@@ -239,6 +378,7 @@ func Test_lz4Compressor_DecompressVector(t *testing.T) {
 	type fields struct {
 		gobc             Compressor
 		compressionLevel int
+		lz4              lz4.LZ4
 	}
 	type want struct {
 		want []float32
@@ -263,39 +403,86 @@ func Test_lz4Compressor_DecompressVector(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           bs: nil,
-		       },
-		       fields: fields {
-		           gobc: nil,
-		           compressionLevel: 0,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           bs: nil,
-		           },
-		           fields: fields {
-		           gobc: nil,
-		           compressionLevel: 0,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "returns ([]float32, nil) when no error occurs",
+			args: args{
+				bs: []byte("vdaas/vald"),
+			},
+			fields: fields{
+				gobc: &MockCompressor{
+					DecompressVectorFunc: func(bytes []byte) (vector []float32, err error) {
+						return []float32{0.1, 0.2, 0.3}, nil
+					},
+				},
+				compressionLevel: 0,
+				lz4: &lz4.MockLZ4{
+					NewReaderFunc: func(r io.Reader) lz4.Reader {
+						return &lz4.MockReader{
+							ReadFunc: func(p []byte) (n int, err error) {
+								return r.Read(p)
+							},
+						}
+					},
+				},
+			},
+			want: want{
+				want: []float32{0.1, 0.2, 0.3},
+			},
+		},
+		{
+			name: "returns (nil, error) when Copy fails",
+			args: args{
+				bs: []byte("vdaas/vald"),
+			},
+			fields: fields{
+				gobc: &MockCompressor{
+					DecompressVectorFunc: func(bytes []byte) (vector []float32, err error) {
+						return []float32{0.1, 0.2, 0.3}, nil
+					},
+				},
+				compressionLevel: 0,
+				lz4: &lz4.MockLZ4{
+					NewReaderFunc: func(r io.Reader) lz4.Reader {
+						return &lz4.MockReader{
+							ReadFunc: func(p []byte) (n int, err error) {
+								return 0, errors.New("copy err")
+							},
+						}
+					},
+				},
+			},
+			want: want{
+				want: nil,
+				err:  errors.New("copy err"),
+			},
+		},
+		{
+			name: "returns (nil, error) when decompresse fails",
+			args: args{
+				bs: []byte("vdaas/vald"),
+			},
+			fields: fields{
+				gobc: &MockCompressor{
+					DecompressVectorFunc: func(bytes []byte) (vector []float32, err error) {
+						return nil, errors.New("decompresse err")
+					},
+				},
+				compressionLevel: 0,
+				lz4: &lz4.MockLZ4{
+					NewReaderFunc: func(r io.Reader) lz4.Reader {
+						return &lz4.MockReader{
+							ReadFunc: func(p []byte) (n int, err error) {
+								return r.Read(p)
+							},
+						}
+					},
+				},
+			},
+			want: want{
+				want: nil,
+				err:  errors.New("decompresse err"),
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -313,6 +500,7 @@ func Test_lz4Compressor_DecompressVector(t *testing.T) {
 			l := &lz4Compressor{
 				gobc:             test.fields.gobc,
 				compressionLevel: test.fields.compressionLevel,
+				lz4:              test.fields.lz4,
 			}
 
 			got, err := l.DecompressVector(test.args.bs)
@@ -331,6 +519,7 @@ func Test_lz4Compressor_Reader(t *testing.T) {
 	type fields struct {
 		gobc             Compressor
 		compressionLevel int
+		lz4              lz4.LZ4
 	}
 	type want struct {
 		want io.ReadCloser
@@ -355,39 +544,31 @@ func Test_lz4Compressor_Reader(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           src: nil,
-		       },
-		       fields: fields {
-		           gobc: nil,
-		           compressionLevel: 0,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           src: nil,
-		           },
-		           fields: fields {
-		           gobc: nil,
-		           compressionLevel: 0,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		func() test {
+			var (
+				src = new(lz4Reader)
+				r   = new(lz4Reader)
+			)
+			return test{
+				name: "returns (io.ReadCloser, nil) when no error occurs",
+				args: args{
+					src: src,
+				},
+				fields: fields{
+					lz4: &lz4.MockLZ4{
+						NewReaderFunc: func(io.Reader) lz4.Reader {
+							return r
+						},
+					},
+				},
+				want: want{
+					want: &lz4Reader{
+						src: src,
+						r:   r,
+					},
+				},
+			}
+		}(),
 	}
 
 	for _, test := range tests {
@@ -405,6 +586,7 @@ func Test_lz4Compressor_Reader(t *testing.T) {
 			l := &lz4Compressor{
 				gobc:             test.fields.gobc,
 				compressionLevel: test.fields.compressionLevel,
+				lz4:              test.fields.lz4,
 			}
 
 			got, err := l.Reader(test.args.src)
@@ -423,6 +605,7 @@ func Test_lz4Compressor_Writer(t *testing.T) {
 	type fields struct {
 		gobc             Compressor
 		compressionLevel int
+		lz4              lz4.LZ4
 	}
 	type want struct {
 		want io.WriteCloser
@@ -447,39 +630,31 @@ func Test_lz4Compressor_Writer(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           dst: nil,
-		       },
-		       fields: fields {
-		           gobc: nil,
-		           compressionLevel: 0,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           dst: nil,
-		           },
-		           fields: fields {
-		           gobc: nil,
-		           compressionLevel: 0,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		func() test {
+			var (
+				dst = new(lz4.MockWriter)
+				w   = new(lz4.MockWriter)
+			)
+			return test{
+				name: "returns (io.WriteCloser, nil) when no erro occurs",
+				args: args{
+					dst: dst,
+				},
+				fields: fields{
+					lz4: &lz4.MockLZ4{
+						NewWriterFunc: func(io.Writer) lz4.Writer {
+							return w
+						},
+					},
+				},
+				want: want{
+					want: &lz4Writer{
+						dst: dst,
+						w:   w,
+					},
+				},
+			}
+		}(),
 	}
 
 	for _, test := range tests {
@@ -497,6 +672,7 @@ func Test_lz4Compressor_Writer(t *testing.T) {
 			l := &lz4Compressor{
 				gobc:             test.fields.gobc,
 				compressionLevel: test.fields.compressionLevel,
+				lz4:              test.fields.lz4,
 			}
 
 			got, err := l.Writer(test.args.dst)
@@ -539,39 +715,23 @@ func Test_lz4Reader_Read(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           p: nil,
-		       },
-		       fields: fields {
-		           src: nil,
-		           r: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           p: nil,
-		           },
-		           fields: fields {
-		           src: nil,
-		           r: nil,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "returns (n, nil) when read success",
+			args: args{
+				p: []byte{},
+			},
+			fields: fields{
+				r: &MockReadCloser{
+					ReadFunc: func(p []byte) (n int, err error) {
+						return 10, nil
+					},
+				},
+			},
+			want: want{
+				wantN: 10,
+				err:   nil,
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -623,33 +783,24 @@ func Test_lz4Reader_Close(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           src: nil,
-		           r: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           src: nil,
-		           r: nil,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "returns nil when readClose success",
+			fields: fields{
+				src: &MockReadCloser{
+					CloseFunc: func() error {
+						return nil
+					},
+				},
+				r: &MockReadCloser{
+					CloseFunc: func() error {
+						return nil
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -709,39 +860,23 @@ func Test_lz4Writer_Write(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           p: nil,
-		       },
-		       fields: fields {
-		           dst: nil,
-		           w: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           p: nil,
-		           },
-		           fields: fields {
-		           dst: nil,
-		           w: nil,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "returns (n, nil) when write success",
+			args: args{
+				p: []byte{},
+			},
+			fields: fields{
+				w: &MockWriteCloser{
+					WriteFunc: func(p []byte) (n int, err error) {
+						return 10, nil
+					},
+				},
+			},
+			want: want{
+				wantN: 10,
+				err:   nil,
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -793,33 +928,42 @@ func Test_lz4Writer_Close(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           dst: nil,
-		           w: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           dst: nil,
-		           w: nil,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "returns nil when writeClose success",
+			fields: fields{
+				dst: &MockWriteCloser{
+					CloseFunc: func() error {
+						return nil
+					},
+				},
+				w: &MockWriteCloser{
+					CloseFunc: func() error {
+						return nil
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		{
+			name: "returns error when close fails",
+			fields: fields{
+				dst: &MockWriteCloser{
+					CloseFunc: func() error {
+						return nil
+					},
+				},
+				w: &MockWriteCloser{
+					CloseFunc: func() error {
+						return errors.New("close err")
+					},
+				},
+			},
+			want: want{
+				err: errors.New("close err"),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/compress/lz4_test.go
+++ b/internal/compress/lz4_test.go
@@ -154,7 +154,7 @@ func Test_lz4Compressor_CompressVector(t *testing.T) {
 				lz4: &lz4.MockLZ4{
 					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
 						return &lz4.MockWriter{
-							WriteFunc: func(p []byte) (n int, err error) {
+							WriteFunc: func(p []byte) (int, error) {
 								return w.Write(p)
 							},
 							FlushFunc: func() error {
@@ -186,7 +186,7 @@ func Test_lz4Compressor_CompressVector(t *testing.T) {
 				lz4: &lz4.MockLZ4{
 					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
 						return &lz4.MockWriter{
-							WriteFunc: func(p []byte) (n int, err error) {
+							WriteFunc: func(p []byte) (int, error) {
 								return w.Write(p)
 							},
 							FlushFunc: func() error {
@@ -219,7 +219,7 @@ func Test_lz4Compressor_CompressVector(t *testing.T) {
 				lz4: &lz4.MockLZ4{
 					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
 						return &lz4.MockWriter{
-							WriteFunc: func(p []byte) (n int, err error) {
+							WriteFunc: func(p []byte) (int, error) {
 								return 0, errors.New("write err")
 							},
 							FlushFunc: func() error {
@@ -252,7 +252,7 @@ func Test_lz4Compressor_CompressVector(t *testing.T) {
 				lz4: &lz4.MockLZ4{
 					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
 						return &lz4.MockWriter{
-							WriteFunc: func(p []byte) (n int, err error) {
+							WriteFunc: func(p []byte) (int, error) {
 								return w.Write(p)
 							},
 							FlushFunc: func() error {
@@ -285,7 +285,7 @@ func Test_lz4Compressor_CompressVector(t *testing.T) {
 				lz4: &lz4.MockLZ4{
 					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
 						return &lz4.MockWriter{
-							WriteFunc: func(p []byte) (n int, err error) {
+							WriteFunc: func(p []byte) (int, error) {
 								return w.Write(p)
 							},
 							FlushFunc: func() error {
@@ -379,7 +379,7 @@ func Test_lz4Compressor_DecompressVector(t *testing.T) {
 				lz4: &lz4.MockLZ4{
 					NewReaderFunc: func(r io.Reader) lz4.Reader {
 						return &lz4.MockReader{
-							ReadFunc: func(p []byte) (n int, err error) {
+							ReadFunc: func(p []byte) (int, error) {
 								return r.Read(p)
 							},
 						}
@@ -405,7 +405,7 @@ func Test_lz4Compressor_DecompressVector(t *testing.T) {
 				lz4: &lz4.MockLZ4{
 					NewReaderFunc: func(r io.Reader) lz4.Reader {
 						return &lz4.MockReader{
-							ReadFunc: func(p []byte) (n int, err error) {
+							ReadFunc: func(p []byte) (int, error) {
 								return 0, errors.New("copy err")
 							},
 						}
@@ -432,7 +432,7 @@ func Test_lz4Compressor_DecompressVector(t *testing.T) {
 				lz4: &lz4.MockLZ4{
 					NewReaderFunc: func(r io.Reader) lz4.Reader {
 						return &lz4.MockReader{
-							ReadFunc: func(p []byte) (n int, err error) {
+							ReadFunc: func(p []byte) (int, error) {
 								return r.Read(p)
 							},
 						}
@@ -683,7 +683,7 @@ func Test_lz4Reader_Read(t *testing.T) {
 			},
 			fields: fields{
 				r: &MockReadCloser{
-					ReadFunc: func(p []byte) (n int, err error) {
+					ReadFunc: func(p []byte) (int, error) {
 						return 10, nil
 					},
 				},
@@ -828,7 +828,7 @@ func Test_lz4Writer_Write(t *testing.T) {
 			},
 			fields: fields{
 				w: &MockWriteCloser{
-					WriteFunc: func(p []byte) (n int, err error) {
+					WriteFunc: func(p []byte) (int, error) {
 						return 10, nil
 					},
 				},

--- a/internal/compress/lz4_test.go
+++ b/internal/compress/lz4_test.go
@@ -154,9 +154,7 @@ func Test_lz4Compressor_CompressVector(t *testing.T) {
 				lz4: &lz4.MockLZ4{
 					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
 						return &lz4.MockWriter{
-							WriteFunc: func(p []byte) (int, error) {
-								return w.Write(p)
-							},
+							WriteFunc: w.Write,
 							FlushFunc: func() error {
 								return nil
 							},
@@ -186,9 +184,7 @@ func Test_lz4Compressor_CompressVector(t *testing.T) {
 				lz4: &lz4.MockLZ4{
 					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
 						return &lz4.MockWriter{
-							WriteFunc: func(p []byte) (int, error) {
-								return w.Write(p)
-							},
+							WriteFunc: w.Write,
 							FlushFunc: func() error {
 								return nil
 							},
@@ -252,9 +248,7 @@ func Test_lz4Compressor_CompressVector(t *testing.T) {
 				lz4: &lz4.MockLZ4{
 					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
 						return &lz4.MockWriter{
-							WriteFunc: func(p []byte) (int, error) {
-								return w.Write(p)
-							},
+							WriteFunc: w.Write,
 							FlushFunc: func() error {
 								return errors.New("flush err")
 							},
@@ -285,9 +279,7 @@ func Test_lz4Compressor_CompressVector(t *testing.T) {
 				lz4: &lz4.MockLZ4{
 					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
 						return &lz4.MockWriter{
-							WriteFunc: func(p []byte) (int, error) {
-								return w.Write(p)
-							},
+							WriteFunc: w.Write,
 							FlushFunc: func() error {
 								return nil
 							},
@@ -379,9 +371,7 @@ func Test_lz4Compressor_DecompressVector(t *testing.T) {
 				lz4: &lz4.MockLZ4{
 					NewReaderFunc: func(r io.Reader) lz4.Reader {
 						return &lz4.MockReader{
-							ReadFunc: func(p []byte) (int, error) {
-								return r.Read(p)
-							},
+							ReadFunc: r.Read,
 						}
 					},
 				},
@@ -432,9 +422,7 @@ func Test_lz4Compressor_DecompressVector(t *testing.T) {
 				lz4: &lz4.MockLZ4{
 					NewReaderFunc: func(r io.Reader) lz4.Reader {
 						return &lz4.MockReader{
-							ReadFunc: func(p []byte) (int, error) {
-								return r.Read(p)
-							},
+							ReadFunc: r.Read,
 						}
 					},
 				},

--- a/internal/compress/lz4_test.go
+++ b/internal/compress/lz4_test.go
@@ -198,20 +198,6 @@ func Test_lz4Compressor_CompressVector(t *testing.T) {
 						return nil, errors.New("compress err")
 					},
 				},
-				compressionLevel: 0,
-				lz4: &lz4.MockLZ4{
-					NewWriterLevelFunc: func(w io.Writer, level int) lz4.Writer {
-						return &lz4.MockWriter{
-							WriteFunc: w.Write,
-							FlushFunc: func() error {
-								return nil
-							},
-							CloseFunc: func() error {
-								return nil
-							},
-						}
-					},
-				},
 			},
 			want: want{
 				want: nil,
@@ -235,9 +221,6 @@ func Test_lz4Compressor_CompressVector(t *testing.T) {
 						return &lz4.MockWriter{
 							WriteFunc: func(p []byte) (int, error) {
 								return 0, errors.New("write err")
-							},
-							FlushFunc: func() error {
-								return nil
 							},
 							CloseFunc: func() error {
 								return nil

--- a/internal/compress/lz4_test.go
+++ b/internal/compress/lz4_test.go
@@ -27,45 +27,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-// func TestLZ4CompressVector(t *testing.T) {
-// 	tests := []struct {
-// 		vector []float32
-// 	}{
-// 		{
-// 			vector: []float32{0.1, 0.2, 0.3},
-// 		},
-// 		{
-// 			vector: []float32{0.4, 0.2, 0.3, 0.1},
-// 		},
-// 		{
-// 			vector: []float32{0.1, 0.5, 0.12, 0.13, 1.0},
-// 		},
-// 	}
-//
-// 	for _, tc := range tests {
-// 		lz4c, err := NewLZ4()
-// 		if err != nil {
-// 			t.Fatalf("initialize failed: %s", err)
-// 		}
-//
-// 		compressed, err := lz4c.CompressVector(tc.vector)
-// 		if err != nil {
-// 			t.Fatalf("Compress failed: %s", err)
-// 		}
-//
-// 		decompressed, err := lz4c.DecompressVector(compressed)
-// 		if err != nil {
-// 			t.Fatalf("Decompress failed: %s", err)
-// 		}
-// 		t.Logf("converted: origin %+v, compressed -> decompressed %+v", tc.vector, decompressed)
-// 		for i := range tc.vector {
-// 			if tc.vector[i] != decompressed[i] {
-// 				t.Fatalf("Invalid convert: origin %+v, compressed -> decompressed %+v", tc.vector, decompressed)
-// 			}
-// 		}
-// 	}
-// }
-
 func TestNewLZ4(t *testing.T) {
 	type args struct {
 		opts []LZ4Option


### PR DESCRIPTION
Signed-off-by: vankichi <kyukawa315@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
- Test
    - create test for `internal/compress/lz4`
    - add comment for each exportable var/function for `internal/compress/lz4`
- Refactor
    - change to use named return at `CompressVector()` because to get an `error` which will be cause at defer function.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.14.4
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.0

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [x] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
