### PR TITLE
Chart: agent-sidecar on initContainer mode can be deployed without enabling sidecar mode

### DIFF
--- a/charts/vald/templates/agent/daemonset.yaml
+++ b/charts/vald/templates/agent/daemonset.yaml
@@ -54,13 +54,13 @@ spec:
       # annotations:
       #   checksum/configmap: {{ include (print $.Template.BasePath "/agent/configmap.yaml") . | sha256sum }}
     spec:
-      {{- if or .Values.agent.initContainers (and .Values.agent.sidecar.enabled .Values.agent.sidecar.initContainerEnabled) }}
+      {{- if or .Values.agent.initContainers .Values.agent.sidecar.initContainerEnabled }}
       initContainers:
         {{- if .Values.agent.initContainers }}
         {{- $initContainers := dict "initContainers" .Values.agent.initContainers "Values" .Values "namespace" .Release.Namespace -}}
         {{- include "vald.initContainers" $initContainers | trim | nindent 8 }}
         {{- end }}
-        {{- if and .Values.agent.sidecar.enabled .Values.agent.sidecar.initContainerEnabled }}
+        {{- if .Values.agent.sidecar.initContainerEnabled }}
         - name: {{ .Values.agent.sidecar.name }}-init
           image: "{{ .Values.agent.sidecar.image.repository }}:{{ default .Values.defaults.image.tag .Values.agent.sidecar.image.tag }}"
           imagePullPolicy: {{ .Values.agent.sidecar.image.pullPolicy }}

--- a/charts/vald/templates/agent/deployment.yaml
+++ b/charts/vald/templates/agent/deployment.yaml
@@ -59,13 +59,13 @@ spec:
       # annotations:
       #   checksum/configmap: {{ include (print $.Template.BasePath "/agent/configmap.yaml") . | sha256sum }}
     spec:
-      {{- if or .Values.agent.initContainers (and .Values.agent.sidecar.enabled .Values.agent.sidecar.initContainerEnabled) }}
+      {{- if or .Values.agent.initContainers .Values.agent.sidecar.initContainerEnabled }}
       initContainers:
         {{- if .Values.agent.initContainers }}
         {{- $initContainers := dict "initContainers" .Values.agent.initContainers "Values" .Values "namespace" .Release.Namespace -}}
         {{- include "vald.initContainers" $initContainers | trim | nindent 8 }}
         {{- end }}
-        {{- if and .Values.agent.sidecar.enabled .Values.agent.sidecar.initContainerEnabled }}
+        {{- if .Values.agent.sidecar.initContainerEnabled }}
         - name: {{ .Values.agent.sidecar.name }}-init
           image: "{{ .Values.agent.sidecar.image.repository }}:{{ default .Values.defaults.image.tag .Values.agent.sidecar.image.tag }}"
           imagePullPolicy: {{ .Values.agent.sidecar.image.pullPolicy }}

--- a/charts/vald/templates/agent/sidecar-configmap.yaml
+++ b/charts/vald/templates/agent/sidecar-configmap.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-{{- if and .Values.agent.enabled .Values.agent.sidecar.enabled }}
+{{- if and .Values.agent.enabled (or .Values.agent.sidecar.enabled .Values.agent.sidecar.initContainerEnabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/vald/templates/agent/statefulset.yaml
+++ b/charts/vald/templates/agent/statefulset.yaml
@@ -59,13 +59,13 @@ spec:
       # annotations:
       #   checksum/configmap: {{ include (print $.Template.BasePath "/agent/configmap.yaml") . | sha256sum }}
     spec:
-      {{- if or .Values.agent.initContainers (and .Values.agent.sidecar.enabled .Values.agent.sidecar.initContainerEnabled) }}
+      {{- if or .Values.agent.initContainers .Values.agent.sidecar.initContainerEnabled }}
       initContainers:
         {{- if .Values.agent.initContainers }}
         {{- $initContainers := dict "initContainers" .Values.agent.initContainers "Values" .Values "namespace" .Release.Namespace -}}
         {{- include "vald.initContainers" $initContainers | trim | nindent 8 }}
         {{- end }}
-        {{- if and .Values.agent.sidecar.enabled .Values.agent.sidecar.initContainerEnabled }}
+        {{- if .Values.agent.sidecar.initContainerEnabled }}
         - name: {{ .Values.agent.sidecar.name }}-init
           image: "{{ .Values.agent.sidecar.image.repository }}:{{ default .Values.defaults.image.tag .Values.agent.sidecar.image.tag }}"
           imagePullPolicy: {{ .Values.agent.sidecar.image.pullPolicy }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
This PR enables agent-sidecar on initContainer mode without enabling sidecar mode.
This is for a user who want not to overwrite backup files on S3 but want to load them onto the agents.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
nothing

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
nothing

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.15.2
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [X] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
