### PR TITLE
add context argument for backoff & add trace span for backoff

### DIFF
--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -48,6 +48,8 @@ type Backoff interface {
 	Close()
 }
 
+const traceTag = "vald/internal/backoff/Backoff.Do/retry"
+
 func New(opts ...Option) Backoff {
 	b := new(backoff)
 	for _, opt := range append(defaultOpts, opts...) {
@@ -68,7 +70,7 @@ func (b *backoff) Do(ctx context.Context, f func(ctx context.Context) (val inter
 		return
 	}
 
-	ctx, span := trace.StartSpan(ctx, "vald/internal/backoff/Backoff.Do/retry")
+	ctx, span := trace.StartSpan(ctx, traceTag)
 	defer func() {
 		if span != nil {
 			span.End()
@@ -90,7 +92,7 @@ func (b *backoff) Do(ctx context.Context, f func(ctx context.Context) (val inter
 			return nil, errors.Wrap(err, ctx.Err().Error())
 		default:
 			res, ret, err = func() (val interface{}, retryable bool, err error){
-				sctx, span := trace.StartSpan(ctx, "vald/internal/backoff/Backoff.Do/retry/"+strconv.Itoa(cnt+1))
+				sctx, span := trace.StartSpan(ctx, traceTag+"/"+strconv.Itoa(cnt+1))
 				defer func() {
 					if span != nil {
 						span.End()

--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -68,7 +68,7 @@ func (b *backoff) Do(ctx context.Context, f func(ctx context.Context) (val inter
 		return
 	}
 
-	ctx, span := trace.StartSpan(ctx, "vald/internal/backoff/Backoff.Do")
+	ctx, span := trace.StartSpan(ctx, "vald/internal/backoff/Backoff.Do/retry")
 	defer func() {
 		if span != nil {
 			span.End()
@@ -90,7 +90,7 @@ func (b *backoff) Do(ctx context.Context, f func(ctx context.Context) (val inter
 			return nil, errors.Wrap(err, ctx.Err().Error())
 		default:
 			res, ret, err = func() (val interface{}, retryable bool, err error){
-				sctx, span := trace.StartSpan(ctx, "vald/internal/backoff/Backoff.Do/"+strconv.Itoa(cnt+1))
+				sctx, span := trace.StartSpan(ctx, "vald/internal/backoff/Backoff.Do/retry/"+strconv.Itoa(cnt+1))
 				defer func() {
 					if span != nil {
 						span.End()

--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -20,11 +20,13 @@ package backoff
 import (
 	"context"
 	"math"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/log"
+	"github.com/vdaas/vald/internal/observability/trace"
 	"github.com/vdaas/vald/internal/rand"
 )
 
@@ -42,7 +44,7 @@ type backoff struct {
 }
 
 type Backoff interface {
-	Do(context.Context, func() (interface{}, bool, error)) (interface{}, error)
+	Do(context.Context, func(ctx context.Context) (interface{}, bool, error)) (interface{}, error)
 	Close()
 }
 
@@ -60,12 +62,18 @@ func New(opts ...Option) Backoff {
 	return b
 }
 
-func (b *backoff) Do(ctx context.Context, f func() (val interface{}, retryable bool, err error)) (res interface{}, err error) {
-	res, ret, err := f()
+func (b *backoff) Do(ctx context.Context, f func(ctx context.Context) (val interface{}, retryable bool, err error)) (res interface{}, err error) {
+	res, ret, err := f(ctx)
 	if err == nil || !ret {
 		return
 	}
 
+	ctx, span := trace.StartSpan(ctx, "vald/internal/backoff/Backoff.Do")
+	defer func() {
+		if span != nil {
+			span.End()
+		}
+	}()
 	b.wg.Add(1)
 	defer b.wg.Done()
 	timer := time.NewTimer(time.Minute)
@@ -81,7 +89,15 @@ func (b *backoff) Do(ctx context.Context, f func() (val interface{}, retryable b
 		case <-ctx.Done():
 			return nil, errors.Wrap(err, ctx.Err().Error())
 		default:
-			res, ret, err = f()
+			res, ret, err = func() (val interface{}, retryable bool, err error){
+				sctx, span := trace.StartSpan(ctx, "vald/internal/backoff/Backoff.Do/"+strconv.Itoa(cnt+1))
+				defer func() {
+					if span != nil {
+						span.End()
+					}
+				}()
+				return f(sctx)
+			}()
 			if ret && err != nil {
 				if b.errLog {
 					log.Error(err)

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/log"
-	"go.uber.org/goleak"
 )
 
 func TestNew(t *testing.T) {
@@ -73,9 +72,10 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestDo(t *testing.T) {
+func Test_backoff_Do(t *testing.T) {
+	t.Parallel()
 	type args struct {
-		fn   func() (interface{}, bool, error)
+		fn   func(context.Context) (interface{}, bool, error)
 		opts []Option
 	}
 
@@ -90,7 +90,7 @@ func TestDo(t *testing.T) {
 	tests := []test{
 		func() test {
 			cnt := 0
-			fn := func() (interface{}, bool, error) {
+			fn := func(context.Context) (interface{}, bool, error) {
 				cnt++
 				return nil, false, nil
 			}
@@ -123,7 +123,7 @@ func TestDo(t *testing.T) {
 
 		func() test {
 			cnt := 0
-			fn := func() (interface{}, bool, error) {
+			fn := func(context.Context) (interface{}, bool, error) {
 				cnt++
 				if cnt == 2 {
 					return nil, false, nil
@@ -161,7 +161,7 @@ func TestDo(t *testing.T) {
 		func() test {
 			cnt := 0
 			err := errors.New("not retryable error")
-			fn := func() (interface{}, bool, error) {
+			fn := func(context.Context) (interface{}, bool, error) {
 				cnt++
 				return nil, false, err
 			}
@@ -195,7 +195,7 @@ func TestDo(t *testing.T) {
 
 		func() test {
 			cnt := 0
-			fn := func() (interface{}, bool, error) {
+			fn := func(context.Context) (interface{}, bool, error) {
 				cnt++
 				return nil, true, errors.Errorf("error (%d)", cnt)
 			}
@@ -230,7 +230,7 @@ func TestDo(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 
 			cnt := 0
-			fn := func() (interface{}, bool, error) {
+			fn := func(context.Context) (interface{}, bool, error) {
 				cnt++
 				if cnt == 2 {
 					cancel()
@@ -267,7 +267,7 @@ func TestDo(t *testing.T) {
 
 		func() test {
 			err := errors.New("error")
-			fn := func() (interface{}, bool, error) {
+			fn := func(context.Context) (interface{}, bool, error) {
 				return nil, true, err
 			}
 
@@ -296,16 +296,17 @@ func TestDo(t *testing.T) {
 	}
 
 	log.Init()
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := tt.ctxFn()
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			ctx, cancel := test.ctxFn()
 			defer cancel()
-			_, err := New(tt.args.opts...).Do(ctx, tt.args.fn)
-			if tt.want == nil && err != nil {
+			_, err := New(test.args.opts...).Do(ctx, test.args.fn)
+			if test.want == nil && err != nil {
 				t.Errorf("Do return err: %v", err)
 			}
 
-			if err := tt.checkFunc(err, tt.want); err != nil {
+			if err := test.checkFunc(err, test.want); err != nil {
 				t.Error(err)
 			}
 		})
@@ -330,364 +331,6 @@ func TestClose(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.bo.Close()
-		})
-	}
-}
-
-func Test_backoff_Do(t *testing.T) {
-	t.Parallel()
-	type args struct {
-		ctx context.Context
-		f   func() (val interface{}, retryable bool, err error)
-	}
-	type fields struct {
-		wg                    sync.WaitGroup
-		backoffFactor         float64
-		initialDuration       float64
-		jittedInitialDuration float64
-		jitterLimit           float64
-		durationLimit         float64
-		maxDuration           float64
-		maxRetryCount         int
-		backoffTimeLimit      time.Duration
-		errLog                bool
-	}
-	type want struct {
-		wantRes interface{}
-		err     error
-	}
-	type test struct {
-		name       string
-		args       args
-		fields     fields
-		want       want
-		checkFunc  func(want, interface{}, error) error
-		beforeFunc func(args)
-		afterFunc  func(args)
-	}
-	defaultCheckFunc := func(w want, gotRes interface{}, err error) error {
-		if !errors.Is(err, w.err) {
-			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-		}
-		if !reflect.DeepEqual(gotRes, w.wantRes) {
-			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", gotRes, w.wantRes)
-		}
-		return nil
-	}
-	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           ctx: nil,
-		           f: nil,
-		       },
-		       fields: fields {
-		           wg: sync.WaitGroup{},
-		           backoffFactor: 0,
-		           initialDuration: 0,
-		           jittedInitialDuration: 0,
-		           jitterLimit: 0,
-		           durationLimit: 0,
-		           maxDuration: 0,
-		           maxRetryCount: 0,
-		           backoffTimeLimit: nil,
-		           errLog: false,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           ctx: nil,
-		           f: nil,
-		           },
-		           fields: fields {
-		           wg: sync.WaitGroup{},
-		           backoffFactor: 0,
-		           initialDuration: 0,
-		           jittedInitialDuration: 0,
-		           jitterLimit: 0,
-		           durationLimit: 0,
-		           maxDuration: 0,
-		           maxRetryCount: 0,
-		           backoffTimeLimit: nil,
-		           errLog: false,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(tt *testing.T) {
-			tt.Parallel()
-			defer goleak.VerifyNone(tt)
-			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
-			}
-			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
-			}
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
-			b := &backoff{
-				wg:                    test.fields.wg,
-				backoffFactor:         test.fields.backoffFactor,
-				initialDuration:       test.fields.initialDuration,
-				jittedInitialDuration: test.fields.jittedInitialDuration,
-				jitterLimit:           test.fields.jitterLimit,
-				durationLimit:         test.fields.durationLimit,
-				maxDuration:           test.fields.maxDuration,
-				maxRetryCount:         test.fields.maxRetryCount,
-				backoffTimeLimit:      test.fields.backoffTimeLimit,
-				errLog:                test.fields.errLog,
-			}
-
-			gotRes, err := b.Do(test.args.ctx, test.args.f)
-			if err := test.checkFunc(test.want, gotRes, err); err != nil {
-				tt.Errorf("error = %v", err)
-			}
-
-		})
-	}
-}
-
-func Test_backoff_addJitter(t *testing.T) {
-	t.Parallel()
-	type args struct {
-		dur float64
-	}
-	type fields struct {
-		wg                    sync.WaitGroup
-		backoffFactor         float64
-		initialDuration       float64
-		jittedInitialDuration float64
-		jitterLimit           float64
-		durationLimit         float64
-		maxDuration           float64
-		maxRetryCount         int
-		backoffTimeLimit      time.Duration
-		errLog                bool
-	}
-	type want struct {
-		want float64
-	}
-	type test struct {
-		name       string
-		args       args
-		fields     fields
-		want       want
-		checkFunc  func(want, float64) error
-		beforeFunc func(args)
-		afterFunc  func(args)
-	}
-	defaultCheckFunc := func(w want, got float64) error {
-		if !reflect.DeepEqual(got, w.want) {
-			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
-		}
-		return nil
-	}
-	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           dur: 0,
-		       },
-		       fields: fields {
-		           wg: sync.WaitGroup{},
-		           backoffFactor: 0,
-		           initialDuration: 0,
-		           jittedInitialDuration: 0,
-		           jitterLimit: 0,
-		           durationLimit: 0,
-		           maxDuration: 0,
-		           maxRetryCount: 0,
-		           backoffTimeLimit: nil,
-		           errLog: false,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           dur: 0,
-		           },
-		           fields: fields {
-		           wg: sync.WaitGroup{},
-		           backoffFactor: 0,
-		           initialDuration: 0,
-		           jittedInitialDuration: 0,
-		           jitterLimit: 0,
-		           durationLimit: 0,
-		           maxDuration: 0,
-		           maxRetryCount: 0,
-		           backoffTimeLimit: nil,
-		           errLog: false,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(tt *testing.T) {
-			tt.Parallel()
-			defer goleak.VerifyNone(tt)
-			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
-			}
-			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
-			}
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
-			b := &backoff{
-				wg:                    test.fields.wg,
-				backoffFactor:         test.fields.backoffFactor,
-				initialDuration:       test.fields.initialDuration,
-				jittedInitialDuration: test.fields.jittedInitialDuration,
-				jitterLimit:           test.fields.jitterLimit,
-				durationLimit:         test.fields.durationLimit,
-				maxDuration:           test.fields.maxDuration,
-				maxRetryCount:         test.fields.maxRetryCount,
-				backoffTimeLimit:      test.fields.backoffTimeLimit,
-				errLog:                test.fields.errLog,
-			}
-
-			got := b.addJitter(test.args.dur)
-			if err := test.checkFunc(test.want, got); err != nil {
-				tt.Errorf("error = %v", err)
-			}
-
-		})
-	}
-}
-
-func Test_backoff_Close(t *testing.T) {
-	t.Parallel()
-	type fields struct {
-		wg                    sync.WaitGroup
-		backoffFactor         float64
-		initialDuration       float64
-		jittedInitialDuration float64
-		jitterLimit           float64
-		durationLimit         float64
-		maxDuration           float64
-		maxRetryCount         int
-		backoffTimeLimit      time.Duration
-		errLog                bool
-	}
-	type want struct {
-	}
-	type test struct {
-		name       string
-		fields     fields
-		want       want
-		checkFunc  func(want) error
-		beforeFunc func()
-		afterFunc  func()
-	}
-	defaultCheckFunc := func(w want) error {
-		return nil
-	}
-	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           wg: sync.WaitGroup{},
-		           backoffFactor: 0,
-		           initialDuration: 0,
-		           jittedInitialDuration: 0,
-		           jitterLimit: 0,
-		           durationLimit: 0,
-		           maxDuration: 0,
-		           maxRetryCount: 0,
-		           backoffTimeLimit: nil,
-		           errLog: false,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           wg: sync.WaitGroup{},
-		           backoffFactor: 0,
-		           initialDuration: 0,
-		           jittedInitialDuration: 0,
-		           jitterLimit: 0,
-		           durationLimit: 0,
-		           maxDuration: 0,
-		           maxRetryCount: 0,
-		           backoffTimeLimit: nil,
-		           errLog: false,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(tt *testing.T) {
-			tt.Parallel()
-			defer goleak.VerifyNone(tt)
-			if test.beforeFunc != nil {
-				test.beforeFunc()
-			}
-			if test.afterFunc != nil {
-				defer test.afterFunc()
-			}
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
-			b := &backoff{
-				wg:                    test.fields.wg,
-				backoffFactor:         test.fields.backoffFactor,
-				initialDuration:       test.fields.initialDuration,
-				jittedInitialDuration: test.fields.jittedInitialDuration,
-				jitterLimit:           test.fields.jitterLimit,
-				durationLimit:         test.fields.durationLimit,
-				maxDuration:           test.fields.maxDuration,
-				maxRetryCount:         test.fields.maxRetryCount,
-				backoffTimeLimit:      test.fields.backoffTimeLimit,
-				errLog:                test.fields.errLog,
-			}
-
-			b.Close()
-			if err := test.checkFunc(test.want); err != nil {
-				tt.Errorf("error = %v", err)
-			}
 		})
 	}
 }

--- a/internal/net/grpc/client.go
+++ b/internal/net/grpc/client.go
@@ -217,7 +217,7 @@ func (g *gRPCClient) Range(ctx context.Context,
 		default:
 			var err error
 			if g.bo != nil {
-				_, err = g.bo.Do(ctx, func() (r interface{}, ret bool, err error) {
+				_, err = g.bo.Do(ctx, func(ctx context.Context) (r interface{}, ret bool, err error) {
 					err = p.Do(func(conn *ClientConn) (err error) {
 						if conn == nil {
 							return errors.ErrGRPCClientConnNotFound(addr)
@@ -270,7 +270,7 @@ func (g *gRPCClient) RangeConcurrent(ctx context.Context,
 				return nil
 			default:
 				if g.bo != nil {
-					_, err = g.bo.Do(ctx, func() (r interface{}, ret bool, err error) {
+					_, err = g.bo.Do(ctx, func(ctx context.Context) (r interface{}, ret bool, err error) {
 						err = p.Do(func(conn *ClientConn) (err error) {
 							if conn == nil {
 								return errors.ErrGRPCClientConnNotFound(addr)
@@ -329,7 +329,7 @@ func (g *gRPCClient) OrderedRange(ctx context.Context,
 					}
 				}()
 				if g.bo != nil {
-					_, err = g.bo.Do(ctx, func() (r interface{}, ret bool, err error) {
+					_, err = g.bo.Do(ctx, func(ctx context.Context) (r interface{}, ret bool, err error) {
 						err = p.Do(func(conn *ClientConn) (err error) {
 							if conn == nil {
 								return errors.ErrGRPCClientConnNotFound(addr)
@@ -392,7 +392,7 @@ func (g *gRPCClient) OrderedRangeConcurrent(ctx context.Context,
 					return nil
 				default:
 					if g.bo != nil {
-						_, err = g.bo.Do(ctx, func() (r interface{}, ret bool, err error) {
+						_, err = g.bo.Do(ctx, func(ctx context.Context) (r interface{}, ret bool, err error) {
 							err = p.Do(func(conn *ClientConn) (err error) {
 								if conn == nil {
 									return errors.ErrGRPCClientConnNotFound(addr)
@@ -439,7 +439,7 @@ func (g *gRPCClient) Do(ctx context.Context, addr string,
 		return nil, errors.ErrGRPCClientConnNotFound(addr)
 	}
 	if g.bo != nil {
-		data, err = g.bo.Do(ctx, func() (r interface{}, ret bool, err error) {
+		data, err = g.bo.Do(ctx, func(ctx context.Context) (r interface{}, ret bool, err error) {
 			err = p.Do(func(conn *ClientConn) (err error) {
 				if conn == nil {
 					return errors.ErrGRPCClientConnNotFound(addr)

--- a/internal/net/grpc/pool/pool.go
+++ b/internal/net/grpc/pool/pool.go
@@ -251,7 +251,7 @@ func (p *pool) dial(ctx context.Context, addr string) (conn *ClientConn, err err
 	if p.bo != nil {
 		var res interface{}
 		retry := 0
-		res, err = p.bo.Do(ctx, func() (r interface{}, ret bool, err error) {
+		res, err = p.bo.Do(ctx, func(ctx context.Context) (r interface{}, ret bool, err error) {
 			log.Debugf("dialing to %s with backoff, retry: %d", addr, retry)
 			ctx, cancel := context.WithTimeout(ctx, p.dialTimeout)
 			defer cancel()

--- a/internal/net/http/transport/roundtrip.go
+++ b/internal/net/http/transport/roundtrip.go
@@ -18,6 +18,7 @@
 package transport
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -50,7 +51,7 @@ func (e *ert) RoundTrip(req *http.Request) (res *http.Response, err error) {
 	if e.bo == nil {
 		return e.roundTrip(req)
 	}
-	_, err = e.bo.Do(req.Context(), func() (interface{}, bool, error) {
+	_, err = e.bo.Do(req.Context(), func(ctx context.Context) (interface{}, bool, error) {
 		r, err := e.roundTrip(req)
 		if err != nil {
 			return nil, errors.Is(err, errors.ErrTransportRetryable), err


### PR DESCRIPTION
Signed-off-by: kpango <i.can.feel.gravity@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:
this PR include 2 feature for backoff
1. add context argument for backoff function, It will reduce cancel duration when backoff is timed out
2. add trace span for backoff
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.15.2
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
