### PR TITLE
Fix testing template missing writer handling

### DIFF
--- a/assets/test/templates/common/function.tmpl
+++ b/assets/test/templates/common/function.tmpl
@@ -142,7 +142,7 @@ func {{ .TestName }}(t *testing.T) {
                 {{ $len := len .Results }}
                 {{- if or (ge $len 1) (.OnlyReturnsOneValue) (.OnlyReturnsError) }}
                     {{ template "results" $f }} := {{ template "call" $f }}
-                    if err := test.checkFunc(test.want, {{ template "results" $f }} ); err != nil {
+                    if err := test.checkFunc(test.want, {{ template "results" $f }} {{- range .Parameters }}{{- if .IsWriter }}, {{ Param . }}.String(){{- end }}{{- end }}); err != nil {
                         tt.Errorf("error = %v", err)
                     }
                 {{ else }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR fixes the testing template to include the writer handling.
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.15.2
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
