### PR TITLE
Create internal/net/http/client option test

### DIFF
--- a/.github/conflint.yaml
+++ b/.github/conflint.yaml
@@ -1,5 +1,5 @@
 kubeval:
   - files:
-    - k8s/**/*.yaml
+      - k8s/**/*.yaml
     strict: true
     ignoreMissingSchemas: true

--- a/internal/db/nosql/cassandra/cassandra_mock.go
+++ b/internal/db/nosql/cassandra/cassandra_mock.go
@@ -1,3 +1,18 @@
+//
+// Copyright (C) 2019-2020 Vdaas.org Vald team ( kpango, rinx, kmrmt )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package cassandra
 
 import "github.com/gocql/gocql"

--- a/internal/net/http/client/client_test.go
+++ b/internal/net/http/client/client_test.go
@@ -28,10 +28,8 @@ import (
 
 	"github.com/vdaas/vald/internal/backoff"
 	"github.com/vdaas/vald/internal/errors"
-	htr "github.com/vdaas/vald/internal/net/http/transport"
 	"github.com/vdaas/vald/internal/test/comparator"
 	"go.uber.org/goleak"
-	"golang.org/x/net/http2"
 )
 
 var (
@@ -86,47 +84,36 @@ func TestNew(t *testing.T) {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 		}
-
-		opts := []comparator.Option{
-			comparator.AllowUnexported(http.Client{}),
-
-			comparator.Comparer(func(x, y http.RoundTripper) bool {
-				return true
-				//return comparator.Diff(x, y) == ""
-			}),
-		}
-		if diff := comparator.Diff(got, w.want, opts...); diff != "" {
-			return errors.New(diff)
+		if !reflect.DeepEqual(got, w.want) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
 		}
 		return nil
 	}
 	tests := []test{
-		{
-			name: "return default http client success",
-			args: args{
-				opts: nil,
-			},
-			want: want{
-				want: &http.Client{
-					Transport: func() http.RoundTripper {
-						t := &http.Transport{
-							Proxy:              http.ProxyFromEnvironment,
-							DisableKeepAlives:  false,
-							DisableCompression: false,
-						}
-						_ = http2.ConfigureTransport(t)
-
-						return htr.NewExpBackoff(
-							htr.WithRoundTripper(t),
-
-							htr.WithBackoff(
-								backoff.New(),
-							),
-						)
-					}(),
-				},
-			},
-		},
+		// TODO test cases
+		/*
+		   {
+		       name: "test_case_1",
+		       args: args {
+		           opts: nil,
+		       },
+		       want: want{},
+		       checkFunc: defaultCheckFunc,
+		   },
+		*/
+		// TODO test cases
+		/*
+		   func() test {
+		       return test {
+		           name: "test_case_2",
+		           args: args {
+		           opts: nil,
+		           },
+		           want: want{},
+		           checkFunc: defaultCheckFunc,
+		       }
+		   }(),
+		*/
 	}
 
 	for _, test := range tests {

--- a/internal/net/http/client/option.go
+++ b/internal/net/http/client/option.go
@@ -168,7 +168,6 @@ func WithExpectContinueTimeout(dur string) Option {
 		d, err := timeutil.Parse(dur)
 		if err != nil {
 			return errors.NewErrCriticalOption("expectContinueTimeout", dur, err)
-			//return err
 		}
 
 		tr.ExpectContinueTimeout = d

--- a/internal/net/http/client/option.go
+++ b/internal/net/http/client/option.go
@@ -23,13 +23,14 @@ import (
 	"net/url"
 
 	"github.com/vdaas/vald/internal/backoff"
+	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/timeutil"
 )
 
 type Option func(*transport) error
 
 var (
-	defaultOptions = []Option{
+	defaultOpts = []Option{
 		WithProxy(http.ProxyFromEnvironment),
 		WithEnableKeepAlives(true),
 		WithEnableCompression(true),
@@ -38,9 +39,10 @@ var (
 
 func WithProxy(px func(*http.Request) (*url.URL, error)) Option {
 	return func(tr *transport) error {
-		if px != nil {
-			tr.Proxy = px
+		if px == nil {
+			return errors.NewErrInvalidOption("proxy", px)
 		}
+		tr.Proxy = px
 
 		return nil
 	}
@@ -48,9 +50,10 @@ func WithProxy(px func(*http.Request) (*url.URL, error)) Option {
 
 func WithDialContext(dx func(ctx context.Context, network, addr string) (net.Conn, error)) Option {
 	return func(tr *transport) error {
-		if dx != nil {
-			tr.DialContext = dx
+		if dx == nil {
+			return errors.NewErrInvalidOption("dialContext", dx)
 		}
+		tr.DialContext = dx
 
 		return nil
 	}
@@ -59,9 +62,12 @@ func WithDialContext(dx func(ctx context.Context, network, addr string) (net.Con
 
 func WithTLSHandshakeTimeout(dur string) Option {
 	return func(tr *transport) error {
+		if len(dur) == 0 {
+			return errors.NewErrInvalidOption("TLSHandshakeTimeout", dur)
+		}
 		d, err := timeutil.Parse(dur)
 		if err != nil {
-			return err
+			return errors.NewErrCriticalOption("TLSHandshakeTimeout", dur)
 		}
 
 		tr.TLSHandshakeTimeout = d
@@ -112,9 +118,12 @@ func WithMaxConnsPerHost(cn int) Option {
 
 func WithIdleConnTimeout(dur string) Option {
 	return func(tr *transport) error {
+		if len(dur) == 0 {
+			return errors.NewErrInvalidOption("idleConnTimeout", dur)
+		}
 		d, err := timeutil.Parse(dur)
 		if err != nil {
-			return err
+			return errors.NewErrCriticalOption("idleConnTimeout", dur)
 		}
 
 		tr.IdleConnTimeout = d
@@ -125,9 +134,12 @@ func WithIdleConnTimeout(dur string) Option {
 
 func WithResponseHeaderTimeout(dur string) Option {
 	return func(tr *transport) error {
+		if len(dur) == 0 {
+			return errors.NewErrInvalidOption("responseHeaderTimeout", dur)
+		}
 		d, err := timeutil.Parse(dur)
 		if err != nil {
-			return err
+			return errors.NewErrCriticalOption("responseHeaderTimeout", dur)
 		}
 
 		tr.ResponseHeaderTimeout = d
@@ -138,9 +150,12 @@ func WithResponseHeaderTimeout(dur string) Option {
 
 func WithExpectContinueTimeout(dur string) Option {
 	return func(tr *transport) error {
+		if len(dur) == 0 {
+			return errors.NewErrInvalidOption("expectContinueTimeout", dur)
+		}
 		d, err := timeutil.Parse(dur)
 		if err != nil {
-			return err
+			return errors.NewErrCriticalOption("expectContinueTimeout", dur)
 		}
 
 		tr.ExpectContinueTimeout = d
@@ -151,9 +166,10 @@ func WithExpectContinueTimeout(dur string) Option {
 
 func WithProxyConnectHeader(header http.Header) Option {
 	return func(tr *transport) error {
-		if header != nil {
-			tr.ProxyConnectHeader = header
+		if header == nil {
+			return errors.NewErrInvalidOption("proxyConnectHeader", header)
 		}
+		tr.ProxyConnectHeader = header
 
 		return nil
 	}

--- a/internal/net/http/client/option.go
+++ b/internal/net/http/client/option.go
@@ -27,6 +27,7 @@ import (
 	"github.com/vdaas/vald/internal/timeutil"
 )
 
+// Option represent the functional option for transport.
 type Option func(*transport) error
 
 var (
@@ -37,6 +38,7 @@ var (
 	}
 )
 
+// WithProxy returns the option to set the transport proxy.
 func WithProxy(px func(*http.Request) (*url.URL, error)) Option {
 	return func(tr *transport) error {
 		if px == nil {
@@ -48,6 +50,7 @@ func WithProxy(px func(*http.Request) (*url.URL, error)) Option {
 	}
 }
 
+// WithDialContext returns the option to set the dial context.
 func WithDialContext(dx func(ctx context.Context, network, addr string) (net.Conn, error)) Option {
 	return func(tr *transport) error {
 		if dx == nil {
@@ -60,6 +63,7 @@ func WithDialContext(dx func(ctx context.Context, network, addr string) (net.Con
 
 }
 
+// WithTLSHandshakeTimeout returns the option to set the TLS handshake timeout.
 func WithTLSHandshakeTimeout(dur string) Option {
 	return func(tr *transport) error {
 		if len(dur) == 0 {
@@ -67,7 +71,7 @@ func WithTLSHandshakeTimeout(dur string) Option {
 		}
 		d, err := timeutil.Parse(dur)
 		if err != nil {
-			return errors.NewErrCriticalOption("TLSHandshakeTimeout", dur)
+			return errors.NewErrCriticalOption("TLSHandshakeTimeout", dur, err)
 		}
 
 		tr.TLSHandshakeTimeout = d
@@ -76,6 +80,7 @@ func WithTLSHandshakeTimeout(dur string) Option {
 	}
 }
 
+// WithEnableKeepAlives returns the option to enable keep alive.
 func WithEnableKeepAlives(enable bool) Option {
 	return func(tr *transport) error {
 		tr.DisableKeepAlives = !enable
@@ -84,6 +89,7 @@ func WithEnableKeepAlives(enable bool) Option {
 	}
 }
 
+// WithEnableCompression returns the option to enable compression.
 func WithEnableCompression(enable bool) Option {
 	return func(tr *transport) error {
 		tr.DisableCompression = !enable
@@ -92,6 +98,7 @@ func WithEnableCompression(enable bool) Option {
 	}
 }
 
+// WithMaxIdleConns returns the option to set the max idle connection.
 func WithMaxIdleConns(cn int) Option {
 	return func(tr *transport) error {
 		tr.MaxIdleConns = cn
@@ -100,6 +107,7 @@ func WithMaxIdleConns(cn int) Option {
 	}
 }
 
+// WithMaxIdleConnsPerHost returns the option to set the max idle connection per host.
 func WithMaxIdleConnsPerHost(cn int) Option {
 	return func(tr *transport) error {
 		tr.MaxIdleConnsPerHost = cn
@@ -108,6 +116,7 @@ func WithMaxIdleConnsPerHost(cn int) Option {
 	}
 }
 
+// WithMaxConnsPerHost returns the option to set the max connections per host.
 func WithMaxConnsPerHost(cn int) Option {
 	return func(tr *transport) error {
 		tr.MaxConnsPerHost = cn
@@ -116,6 +125,7 @@ func WithMaxConnsPerHost(cn int) Option {
 	}
 }
 
+// WithIdleConnTimeout returns the option to set the idle connection timeout.
 func WithIdleConnTimeout(dur string) Option {
 	return func(tr *transport) error {
 		if len(dur) == 0 {
@@ -123,7 +133,7 @@ func WithIdleConnTimeout(dur string) Option {
 		}
 		d, err := timeutil.Parse(dur)
 		if err != nil {
-			return errors.NewErrCriticalOption("idleConnTimeout", dur)
+			return errors.NewErrCriticalOption("idleConnTimeout", dur, err)
 		}
 
 		tr.IdleConnTimeout = d
@@ -132,6 +142,7 @@ func WithIdleConnTimeout(dur string) Option {
 	}
 }
 
+// WithResponseHeaderTimeout returns the option to set the response header timeout.
 func WithResponseHeaderTimeout(dur string) Option {
 	return func(tr *transport) error {
 		if len(dur) == 0 {
@@ -139,7 +150,7 @@ func WithResponseHeaderTimeout(dur string) Option {
 		}
 		d, err := timeutil.Parse(dur)
 		if err != nil {
-			return errors.NewErrCriticalOption("responseHeaderTimeout", dur)
+			return errors.NewErrCriticalOption("responseHeaderTimeout", dur, err)
 		}
 
 		tr.ResponseHeaderTimeout = d
@@ -148,6 +159,7 @@ func WithResponseHeaderTimeout(dur string) Option {
 	}
 }
 
+// WithExpectContinueTimeout returns the option to set the expect continue timeout.
 func WithExpectContinueTimeout(dur string) Option {
 	return func(tr *transport) error {
 		if len(dur) == 0 {
@@ -155,7 +167,8 @@ func WithExpectContinueTimeout(dur string) Option {
 		}
 		d, err := timeutil.Parse(dur)
 		if err != nil {
-			return errors.NewErrCriticalOption("expectContinueTimeout", dur)
+			return errors.NewErrCriticalOption("expectContinueTimeout", dur, err)
+			//return err
 		}
 
 		tr.ExpectContinueTimeout = d
@@ -164,6 +177,7 @@ func WithExpectContinueTimeout(dur string) Option {
 	}
 }
 
+//  WithProxyConnectHeader returns the option to set the proxy connect header.
 func WithProxyConnectHeader(header http.Header) Option {
 	return func(tr *transport) error {
 		if header == nil {
@@ -175,46 +189,50 @@ func WithProxyConnectHeader(header http.Header) Option {
 	}
 }
 
+//  WithMaxResponseHeaderBytes returns the option to set the max response header bytes.
 func WithMaxResponseHeaderBytes(bs int64) Option {
 	return func(tr *transport) error {
 		tr.MaxResponseHeaderBytes = bs
-
 		return nil
 	}
 }
 
+//  WithWriteBufferSize returns the option to set the write buffer size.
 func WithWriteBufferSize(bs int64) Option {
 	return func(tr *transport) error {
 		tr.WriteBufferSize = int(bs)
-
 		return nil
 	}
 }
 
+//  WithReadBufferSize returns the option to set the read buffer size.
 func WithReadBufferSize(bs int64) Option {
 	return func(tr *transport) error {
 		tr.ReadBufferSize = int(bs)
-
 		return nil
 	}
 }
 
+//  WithForceAttemptHTTP2 returns the option to force attempt HTTP2 for the HTTP transport.
 func WithForceAttemptHTTP2(force bool) Option {
 	return func(tr *transport) error {
 		tr.ForceAttemptHTTP2 = force
-
 		return nil
 	}
 }
 
+//  WithBackoffOpts returns the option to set the options to initialize backoff.
 func WithBackoffOpts(opts ...backoff.Option) Option {
 	return func(tr *transport) error {
+		if len(opts) == 0 {
+			return errors.NewErrInvalidOption("backoffOpts", opts)
+		}
 		if tr.backoffOpts == nil {
 			tr.backoffOpts = opts
+			return nil
 		}
 
 		tr.backoffOpts = append(tr.backoffOpts, opts...)
-
 		return nil
 	}
 }

--- a/internal/net/http/client/option_test.go
+++ b/internal/net/http/client/option_test.go
@@ -494,6 +494,19 @@ func TestWithMaxIdleConns(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "set conn success with 0 value",
+			args: args{
+				cn: 0,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						MaxIdleConns: 0,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -562,6 +575,19 @@ func TestWithMaxIdleConnsPerHost(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "set conn per host success with 0 value",
+			args: args{
+				cn: 0,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						MaxIdleConnsPerHost: 0,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -625,6 +651,19 @@ func TestWithMaxConnsPerHost(t *testing.T) {
 				obj: &T{
 					Transport: &http.Transport{
 						MaxConnsPerHost: 5,
+					},
+				},
+			},
+		},
+		{
+			name: "set conn per host success with 0 value",
+			args: args{
+				cn: 0,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						MaxConnsPerHost: 0,
 					},
 				},
 			},
@@ -1057,6 +1096,19 @@ func TestWithMaxResponseHeaderBytes(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "set max response header byte with 0 value",
+			args: args{
+				bs: 0,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						MaxResponseHeaderBytes: 0,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -1125,6 +1177,19 @@ func TestWithWriteBufferSize(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "set write buffer size with 0 value",
+			args: args{
+				bs: 0,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						WriteBufferSize: 0,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -1189,6 +1254,19 @@ func TestWithReadBufferSize(t *testing.T) {
 				obj: &T{
 					Transport: &http.Transport{
 						ReadBufferSize: 5,
+					},
+				},
+			},
+		},
+		{
+			name: "set buffer size success with 0 value",
+			args: args{
+				bs: 0,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						ReadBufferSize: 0,
 					},
 				},
 			},

--- a/internal/net/http/client/option_test.go
+++ b/internal/net/http/client/option_test.go
@@ -164,9 +164,7 @@ func TestWithDialContext(t *testing.T) {
 		}(),
 		{
 			name: "return error when dial context is nil",
-			args: args{
-				dx: nil,
-			},
+			args: args{},
 			want: want{
 				obj: &T{
 					Transport: &http.Transport{},
@@ -255,9 +253,7 @@ func TestWithTLSHandshakeTimeout(t *testing.T) {
 		},
 		{
 			name: "set timeout failed with empty value",
-			args: args{
-				dur: "",
-			},
+			args: args{},
 			want: want{
 				obj: &T{
 					Transport: &http.Transport{},
@@ -495,10 +491,8 @@ func TestWithMaxIdleConns(t *testing.T) {
 			},
 		},
 		{
-			name: "set conn success with 0 value",
-			args: args{
-				cn: 0,
-			},
+			name: "set conn success with default value",
+			args: args{},
 			want: want{
 				obj: &T{
 					Transport: &http.Transport{
@@ -576,10 +570,8 @@ func TestWithMaxIdleConnsPerHost(t *testing.T) {
 			},
 		},
 		{
-			name: "set conn per host success with 0 value",
-			args: args{
-				cn: 0,
-			},
+			name: "set conn per host success with default value",
+			args: args{},
 			want: want{
 				obj: &T{
 					Transport: &http.Transport{
@@ -656,10 +648,8 @@ func TestWithMaxConnsPerHost(t *testing.T) {
 			},
 		},
 		{
-			name: "set conn per host success with 0 value",
-			args: args{
-				cn: 0,
-			},
+			name: "set conn per host success with default value",
+			args: args{},
 			want: want{
 				obj: &T{
 					Transport: &http.Transport{
@@ -750,9 +740,7 @@ func TestWithIdleConnTimeout(t *testing.T) {
 		},
 		{
 			name: "set timeout failed with empty value",
-			args: args{
-				dur: "",
-			},
+			args: args{},
 			want: want{
 				obj: &T{
 					Transport: &http.Transport{},
@@ -842,9 +830,7 @@ func TestWithResponseHeaderTimeout(t *testing.T) {
 		},
 		{
 			name: "set timeout failed with empty value",
-			args: args{
-				dur: "",
-			},
+			args: args{},
 			want: want{
 				obj: &T{
 					Transport: &http.Transport{},
@@ -934,9 +920,7 @@ func TestWithExpectContinueTimeout(t *testing.T) {
 		},
 		{
 			name: "set timeout failed with empty value",
-			args: args{
-				dur: "",
-			},
+			args: args{},
 			want: want{
 				obj: &T{
 					Transport: &http.Transport{},
@@ -1018,9 +1002,7 @@ func TestWithProxyConnectHeader(t *testing.T) {
 		},
 		{
 			name: "return error when header is nil",
-			args: args{
-				header: nil,
-			},
+			args: args{},
 			want: want{
 				obj: &T{
 					Transport: &http.Transport{},
@@ -1097,10 +1079,8 @@ func TestWithMaxResponseHeaderBytes(t *testing.T) {
 			},
 		},
 		{
-			name: "set max response header byte with 0 value",
-			args: args{
-				bs: 0,
-			},
+			name: "set max response header byte with default value",
+			args: args{},
 			want: want{
 				obj: &T{
 					Transport: &http.Transport{
@@ -1178,10 +1158,8 @@ func TestWithWriteBufferSize(t *testing.T) {
 			},
 		},
 		{
-			name: "set write buffer size with 0 value",
-			args: args{
-				bs: 0,
-			},
+			name: "set write buffer size with default value",
+			args: args{},
 			want: want{
 				obj: &T{
 					Transport: &http.Transport{
@@ -1259,10 +1237,8 @@ func TestWithReadBufferSize(t *testing.T) {
 			},
 		},
 		{
-			name: "set buffer size success with 0 value",
-			args: args{
-				bs: 0,
-			},
+			name: "set buffer size success with default value",
+			args: args{},
 			want: want{
 				obj: &T{
 					Transport: &http.Transport{
@@ -1430,9 +1406,7 @@ func TestWithBackoffOpts(t *testing.T) {
 		},
 		{
 			name: "return error when opt is empty",
-			args: args{
-				opts: nil,
-			},
+			args: args{},
 			fields: fields{
 				backoffOpts: []backoff.Option{backoff.WithRetryCount(20)},
 			},

--- a/internal/net/http/client/option_test.go
+++ b/internal/net/http/client/option_test.go
@@ -22,1945 +22,1378 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/vdaas/vald/internal/backoff"
+	"github.com/vdaas/vald/internal/errors"
+	"github.com/vdaas/vald/internal/test/comparator"
 	"go.uber.org/goleak"
 )
 
 func TestWithProxy(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		px func(*http.Request) (*url.URL, error)
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           px: nil,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           px: nil,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		func() test {
+			p := func(*http.Request) (*url.URL, error) {
+				return nil, nil
+			}
+			return test{
+				name: "set proxy success",
+				args: args{
+					px: p,
+				},
+				want: want{
+					obj: &T{
+						Transport: &http.Transport{
+							Proxy: p,
+						},
+					},
+				},
+			}
+		}(),
+		{
+			name: "return error when proxy is nil",
+			args: args{
+				px: nil,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{},
+				},
+				err: errors.NewErrInvalidOption("proxy", nil),
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithProxy(test.args.px)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithProxy(test.args.px)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithProxy(test.args.px)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithDialContext(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		dx func(ctx context.Context, network, addr string) (net.Conn, error)
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           dx: nil,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           dx: nil,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		func() test {
+			d := func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return nil, nil
+			}
+			return test{
+				name: "set dial context success",
+				args: args{
+					dx: d,
+				},
+				want: want{
+					obj: &T{
+						Transport: &http.Transport{
+							DialContext: d,
+						},
+					},
+				},
+			}
+		}(),
+		{
+			name: "return error when dial context is nil",
+			args: args{
+				dx: nil,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{},
+				},
+				err: errors.NewErrInvalidOption("dialContext", nil),
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithDialContext(test.args.dx)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithDialContext(test.args.dx)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithDialContext(test.args.dx)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithTLSHandshakeTimeout(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		dur string
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
-
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           dur: "",
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           dur: "",
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set timeout success",
+			args: args{
+				dur: "5s",
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						TLSHandshakeTimeout: 5 * time.Second,
+					},
+				},
+			},
+		},
+		{
+			name: "set timeout failed with invalid value",
+			args: args{
+				dur: "dummy",
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{},
+				},
+				err: errors.NewErrCriticalOption("TLSHandshakeTimeout", "dummy", errors.New("invalid timeout value: dummy\t:timeout parse error out put failed: time: invalid duration \"dummy\"")),
+			},
+		},
+		{
+			name: "set timeout failed with empty value",
+			args: args{
+				dur: "",
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{},
+				},
+				err: errors.NewErrInvalidOption("TLSHandshakeTimeout", ""),
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithTLSHandshakeTimeout(test.args.dur)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithTLSHandshakeTimeout(test.args.dur)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithTLSHandshakeTimeout(test.args.dur)
+			obj := &T{
+				Transport: new(http.Transport),
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithEnableKeepAlives(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		enable bool
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           enable: false,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           enable: false,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set enable success",
+			args: args{
+				enable: true,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						DisableKeepAlives: false,
+					},
+				},
+			},
+		},
+		{
+			name: "set disable success",
+			args: args{
+				enable: false,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						DisableKeepAlives: true,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithEnableKeepAlives(test.args.enable)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithEnableKeepAlives(test.args.enable)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithEnableKeepAlives(test.args.enable)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithEnableCompression(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		enable bool
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           enable: false,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           enable: false,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set enable success",
+			args: args{
+				enable: true,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						DisableCompression: false,
+					},
+				},
+			},
+		},
+		{
+			name: "set disable success",
+			args: args{
+				enable: false,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						DisableCompression: true,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithEnableCompression(test.args.enable)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithEnableCompression(test.args.enable)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithEnableCompression(test.args.enable)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithMaxIdleConns(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		cn int
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
-
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           cn: 0,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           cn: 0,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set conn success",
+			args: args{
+				cn: 5,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						MaxIdleConns: 5,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithMaxIdleConns(test.args.cn)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithMaxIdleConns(test.args.cn)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithMaxIdleConns(test.args.cn)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithMaxIdleConnsPerHost(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		cn int
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           cn: 0,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           cn: 0,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set conn per host success",
+			args: args{
+				cn: 5,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						MaxIdleConnsPerHost: 5,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithMaxIdleConnsPerHost(test.args.cn)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithMaxIdleConnsPerHost(test.args.cn)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithMaxIdleConnsPerHost(test.args.cn)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithMaxConnsPerHost(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		cn int
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
-
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           cn: 0,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           cn: 0,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set conn per host success",
+			args: args{
+				cn: 5,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						MaxConnsPerHost: 5,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithMaxConnsPerHost(test.args.cn)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithMaxConnsPerHost(test.args.cn)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithMaxConnsPerHost(test.args.cn)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithIdleConnTimeout(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		dur string
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           dur: "",
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           dur: "",
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set timeout success",
+			args: args{
+				dur: "5s",
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						IdleConnTimeout: 5 * time.Second,
+					},
+				},
+			},
+		},
+		{
+			name: "set timeout failed with invalid value",
+			args: args{
+				dur: "dummy",
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{},
+				},
+				err: errors.NewErrCriticalOption("idleConnTimeout", "dummy", errors.New("invalid timeout value: dummy\t:timeout parse error out put failed: time: invalid duration \"dummy\"")),
+			},
+		},
+		{
+			name: "set timeout failed with empty value",
+			args: args{
+				dur: "",
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{},
+				},
+				err: errors.NewErrInvalidOption("idleConnTimeout", ""),
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithIdleConnTimeout(test.args.dur)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithIdleConnTimeout(test.args.dur)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithIdleConnTimeout(test.args.dur)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithResponseHeaderTimeout(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		dur string
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           dur: "",
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           dur: "",
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set timeout success",
+			args: args{
+				dur: "5s",
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						ResponseHeaderTimeout: 5 * time.Second,
+					},
+				},
+			},
+		},
+		{
+			name: "set timeout failed with invalid value",
+			args: args{
+				dur: "dummy",
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{},
+				},
+				err: errors.NewErrCriticalOption("responseHeaderTimeout", "dummy", errors.New("invalid timeout value: dummy\t:timeout parse error out put failed: time: invalid duration \"dummy\"")),
+			},
+		},
+		{
+			name: "set timeout failed with empty value",
+			args: args{
+				dur: "",
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{},
+				},
+				err: errors.NewErrInvalidOption("responseHeaderTimeout", ""),
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithResponseHeaderTimeout(test.args.dur)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithResponseHeaderTimeout(test.args.dur)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithResponseHeaderTimeout(test.args.dur)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithExpectContinueTimeout(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		dur string
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           dur: "",
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           dur: "",
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set timeout success",
+			args: args{
+				dur: "5s",
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						ExpectContinueTimeout: 5 * time.Second,
+					},
+				},
+			},
+		},
+		{
+			name: "set timeout failed with invalid value",
+			args: args{
+				dur: "dummy",
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{},
+				},
+				err: errors.NewErrCriticalOption("expectContinueTimeout", "dummy", errors.New("invalid timeout value: dummy\t:timeout parse error out put failed: time: invalid duration \"dummy\"")),
+			},
+		},
+		{
+			name: "set timeout failed with empty value",
+			args: args{
+				dur: "",
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{},
+				},
+				err: errors.NewErrInvalidOption("expectContinueTimeout", ""),
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithExpectContinueTimeout(test.args.dur)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithExpectContinueTimeout(test.args.dur)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithExpectContinueTimeout(test.args.dur)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithProxyConnectHeader(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		header http.Header
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           header: nil,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           header: nil,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set header success",
+			args: args{
+				header: http.Header(
+					map[string][]string{"dummy": []string{"val"}},
+				),
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						ProxyConnectHeader: http.Header(
+							map[string][]string{"dummy": []string{"val"}},
+						),
+					},
+				},
+			},
+		},
+		{
+			name: "return error when header is nil",
+			args: args{
+				header: nil,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{},
+				},
+				err: errors.NewErrInvalidOption("proxyConnectHeader", http.Header(nil)),
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithProxyConnectHeader(test.args.header)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithProxyConnectHeader(test.args.header)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithProxyConnectHeader(test.args.header)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithMaxResponseHeaderBytes(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		bs int64
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           bs: 0,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           bs: 0,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set max response header byte",
+			args: args{
+				bs: 5,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						MaxResponseHeaderBytes: 5,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithMaxResponseHeaderBytes(test.args.bs)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithMaxResponseHeaderBytes(test.args.bs)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithMaxResponseHeaderBytes(test.args.bs)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithWriteBufferSize(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		bs int64
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           bs: 0,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           bs: 0,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set write buffer size",
+			args: args{
+				bs: 5,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						WriteBufferSize: 5,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithWriteBufferSize(test.args.bs)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithWriteBufferSize(test.args.bs)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithWriteBufferSize(test.args.bs)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithReadBufferSize(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		bs int64
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           bs: 0,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           bs: 0,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set buffer size success",
+			args: args{
+				bs: 5,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						ReadBufferSize: 5,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithReadBufferSize(test.args.bs)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithReadBufferSize(test.args.bs)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithReadBufferSize(test.args.bs)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithForceAttemptHTTP2(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		force bool
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           force: false,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           force: false,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set force http2 success",
+			args: args{
+				force: true,
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{
+						ForceAttemptHTTP2: true,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithForceAttemptHTTP2(test.args.force)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithForceAttemptHTTP2(test.args.force)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithForceAttemptHTTP2(test.args.force)
+			obj := &T{
+				Transport: &http.Transport{},
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithBackoffOpts(t *testing.T) {
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = transport
 	type args struct {
 		opts []backoff.Option
 	}
+	type fields struct {
+		backoffOpts []backoff.Option
+	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		fields     fields
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if diff := comparator.Diff(obj, w.obj, transportComparator...); diff != "" {
+			return errors.New(diff)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           opts: nil,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           opts: nil,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set backoff opts success when origin backoff opts is nil",
+			args: args{
+				opts: []backoff.Option{backoff.WithEnableErrorLog()},
+			},
+			want: want{
+				obj: &T{
+					Transport:   &http.Transport{},
+					backoffOpts: []backoff.Option{backoff.WithEnableErrorLog()},
+				},
+			},
+		},
+		{
+			name: "set backoff opts success when origin backoff opts is not nil",
+			args: args{
+				opts: []backoff.Option{backoff.WithEnableErrorLog()},
+			},
+			fields: fields{
+				backoffOpts: []backoff.Option{backoff.WithRetryCount(20)},
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{},
+					backoffOpts: []backoff.Option{
+						backoff.WithRetryCount(20),
+						backoff.WithEnableErrorLog(),
+					},
+				},
+			},
+		},
+		{
+			name: "return error when opt is empty",
+			args: args{
+				opts: nil,
+			},
+			fields: fields{
+				backoffOpts: []backoff.Option{backoff.WithRetryCount(20)},
+			},
+			want: want{
+				obj: &T{
+					Transport: &http.Transport{},
+					backoffOpts: []backoff.Option{
+						backoff.WithRetryCount(20),
+					},
+				},
+				err: func() error {
+					var bo []backoff.Option
+					return errors.NewErrInvalidOption("backoffOpts", bo)
+				}(),
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithBackoffOpts(test.args.opts...)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithBackoffOpts(test.args.opts...)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithBackoffOpts(test.args.opts...)
+			obj := &T{
+				Transport:   &http.Transport{},
+				backoffOpts: test.fields.backoffOpts,
+			}
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR implements http client option test. 
This PR also includes the following changes:
- [Test related] add the comparator implementation of `transport` to the `client_test.go` 
- [Refactor] Refactor the error returned from the option and handle it in `New()` 
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.15.2
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
