### PR TITLE
Add test for internal/errors/compressor.go

### DIFF
--- a/internal/errors/compressor.go
+++ b/internal/errors/compressor.go
@@ -31,7 +31,7 @@ var (
 	// ErrCompressedDataNotFound returns an error of compressed data is not found.
 	ErrCompressedDataNotFound = New("compressed data not found")
 
-	// ErrDecompressedDataNotFound returns an error of decompressed data not found.
+	// ErrDecompressedDataNotFound returns an error of decompressed data is not found.
 	ErrDecompressedDataNotFound = New("decompressed data not found")
 
 	// ErrCompressFailed returns an error of compress failed.

--- a/internal/errors/compressor.go
+++ b/internal/errors/compressor.go
@@ -40,7 +40,7 @@ var (
 	// ErrDecompressFailed returns an error of decompress failed.
 	ErrDecompressFailed = New("decompress failed")
 
-	// ErrCompressorRegistererIsNotRunning represents a function to generate an error of compressor registerers not running.
+	// ErrCompressorRegistererIsNotRunning represents a function to generate an error of compressor registerers is not running.
 	ErrCompressorRegistererIsNotRunning = func() error {
 		return New("compressor registerers is not running")
 	}

--- a/internal/errors/compressor.go
+++ b/internal/errors/compressor.go
@@ -42,11 +42,11 @@ var (
 
 	// ErrCompressorRegistererIsNotRunning represents a function to generate an error of compressor registerers not running.
 	ErrCompressorRegistererIsNotRunning = func() error {
-		return Errorf("compressor registerers is not running")
+		return New("compressor registerers is not running")
 	}
 
 	// ErrCompressorRegistererChannelIsFull represents a function to generate an error that compressor registerer channel is full.
 	ErrCompressorRegistererChannelIsFull = func() error {
-		return Errorf("compressor registerer channel is full")
+		return New("compressor registerer channel is full")
 	}
 )

--- a/internal/errors/compressor.go
+++ b/internal/errors/compressor.go
@@ -37,7 +37,7 @@ var (
 	// ErrCompressFailed returns an error of compress failed.
 	ErrCompressFailed = New("compress failed")
 
-	// ErrDecompressFailed returns an error of decompress failed.
+	// ErrDecompressFailed returns an error of decompressing failed.
 	ErrDecompressFailed = New("decompress failed")
 
 	// ErrCompressorRegistererIsNotRunning represents a function to generate an error of compressor registerers is not running.

--- a/internal/errors/compressor.go
+++ b/internal/errors/compressor.go
@@ -28,7 +28,7 @@ var (
 		return Errorf("compressor %s not found", name)
 	}
 
-	// ErrCompressedDataNotFound returns an error of compressed data not found.
+	// ErrCompressedDataNotFound returns an error of compressed data is not found.
 	ErrCompressedDataNotFound = New("compressed data not found")
 
 	// ErrDecompressedDataNotFound returns an error of decompressed data not found.

--- a/internal/errors/compressor.go
+++ b/internal/errors/compressor.go
@@ -18,28 +18,34 @@
 package errors
 
 var (
-	// internal compressor
+	// ErrInvalidCompressionLevel represents a function to generate an error of invalid compression level.
 	ErrInvalidCompressionLevel = func(level int) error {
 		return Errorf("invalid compression level: %d", level)
 	}
 
-	// Compressor
+	// ErrCompressorNameNotFound represents a function to generate an error of compressor not found.
 	ErrCompressorNameNotFound = func(name string) error {
 		return Errorf("compressor %s not found", name)
 	}
 
+	// ErrCompressedDataNotFound returns an error of compressed data not found.
 	ErrCompressedDataNotFound = New("compressed data not found")
 
+	// ErrDecompressedDataNotFound returns an error of decompressed data not found.
 	ErrDecompressedDataNotFound = New("decompressed data not found")
 
+	// ErrCompressFailed returns an error of compress failed.
 	ErrCompressFailed = New("compress failed")
 
+	// ErrDecompressFailed returns an error of decompress failed.
 	ErrDecompressFailed = New("decompress failed")
 
+	// ErrCompressorRegistererIsNotRunning represents a function to generate an error of compressor registerers not running.
 	ErrCompressorRegistererIsNotRunning = func() error {
 		return Errorf("compressor registerers is not running")
 	}
 
+	// ErrCompressorRegistererChannelIsFull represents a function to generate an error that compressor registerer channel is full.
 	ErrCompressorRegistererChannelIsFull = func() error {
 		return Errorf("compressor registerer channel is full")
 	}

--- a/internal/errors/compressor_test.go
+++ b/internal/errors/compressor_test.go
@@ -46,7 +46,7 @@ func TestErrInvalidCompressionLevel(t *testing.T) {
 			},
 		},
 		{
-			name: "returns error when compression leve is the maximum value of int",
+			name: "returns error when compression leve is the maximum number of int",
 			args: args{
 				level: int(math.MaxInt64),
 			},
@@ -55,7 +55,7 @@ func TestErrInvalidCompressionLevel(t *testing.T) {
 			},
 		},
 		{
-			name: "returns error when compression leve is the minimum value of int",
+			name: "returns error when compression leve is the minimum number of int",
 			args: args{
 				level: int(math.MinInt64),
 			},

--- a/internal/errors/compressor_test.go
+++ b/internal/errors/compressor_test.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"math"
 	"testing"
 )
 
@@ -42,6 +43,24 @@ func TestErrInvalidCompressionLevel(t *testing.T) {
 			},
 			want: want{
 				want: New("invalid compression level: 0"),
+			},
+		},
+		{
+			name: "returns error when compression leve is the maximum value of int",
+			args: args{
+				level: int(math.MaxInt64),
+			},
+			want: want{
+				want: Errorf("invalid compression level: %d", int(math.MaxInt64)),
+			},
+		},
+		{
+			name: "returns error when compression leve is the minimum value of int",
+			args: args{
+				level: int(math.MinInt64),
+			},
+			want: want{
+				want: Errorf("invalid compression level: %d", int(math.MinInt64)),
 			},
 		},
 	}

--- a/internal/errors/compressor_test.go
+++ b/internal/errors/compressor_test.go
@@ -32,7 +32,7 @@ func TestErrInvalidCompressionLevel(t *testing.T) {
 				level: 100,
 			},
 			want: want{
-				want: Errorf("invalid compression level: %d", 100),
+				want: New("invalid compression level: 100"),
 			},
 		},
 		{
@@ -41,7 +41,7 @@ func TestErrInvalidCompressionLevel(t *testing.T) {
 				level: 0,
 			},
 			want: want{
-				want: Errorf("invalid compression level: %d", 0),
+				want: New("invalid compression level: 0"),
 			},
 		},
 	}
@@ -94,7 +94,7 @@ func TestErrCompressorNameNotFound(t *testing.T) {
 				name: "gob",
 			},
 			want: want{
-				want: Errorf("compressor %s not found", "gob"),
+				want: New("compressor gob not found"),
 			},
 		},
 		{
@@ -103,7 +103,7 @@ func TestErrCompressorNameNotFound(t *testing.T) {
 				name: "",
 			},
 			want: want{
-				want: Errorf("compressor %s not found", ""),
+				want: New("compressor  not found"),
 			},
 		},
 	}

--- a/internal/errors/compressor_test.go
+++ b/internal/errors/compressor_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright (C) 2019-2020 Vdaas.org Vald team ( kpango, rinx, kmrmt )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package errors
 
 import (

--- a/internal/errors/compressor_test.go
+++ b/internal/errors/compressor_test.go
@@ -1,6 +1,8 @@
 package errors
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestErrInvalidCompressionLevel(t *testing.T) {
 	type args struct {

--- a/internal/errors/compressor_test.go
+++ b/internal/errors/compressor_test.go
@@ -1,0 +1,219 @@
+package errors
+
+import "testing"
+
+func TestErrInvalidCompressionLevel(t *testing.T) {
+	type args struct {
+		level int
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "returns error when compression leve is 100",
+			args: args{
+				level: 100,
+			},
+			want: want{
+				want: Errorf("invalid compression level: %d", 100),
+			},
+		},
+		{
+			name: "returns error when compression leve is 0",
+			args: args{
+				level: 0,
+			},
+			want: want{
+				want: Errorf("invalid compression level: %d", 0),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrInvalidCompressionLevel(test.args.level)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrCompressorNameNotFound(t *testing.T) {
+	type args struct {
+		name string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "returns error when name is `gob`",
+			args: args{
+				name: "gob",
+			},
+			want: want{
+				want: Errorf("compressor %s not found", "gob"),
+			},
+		},
+		{
+			name: "returns error when name is empty",
+			args: args{
+				name: "",
+			},
+			want: want{
+				want: Errorf("compressor %s not found", ""),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrCompressorNameNotFound(test.args.name)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrCompressorRegistererIsNotRunning(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "returns error",
+			want: want{
+				want: New("compressor registerers is not running"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrCompressorRegistererIsNotRunning()
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrCompressorRegistererChannelIsFull(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "returns error",
+			want: want{
+				want: New("compressor registerer channel is full"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrCompressorRegistererChannelIsFull()
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

I added test case for `internal/errors/compressor.go`.
And I refactored `internal/errors/compressor.go`.

- WHY
Whenever Errorf has no arguments other than a message, nil is returned.
https://github.com/vdaas/vald/blob/master/internal/errors/compressor.go#L40
https://github.com/vdaas/vald/blob/master/internal/errors/compressor.go#L44

- WHAT
Change from `Errorf` to `New`


***grammar check passed***

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.15.2
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [x] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
