### PR TITLE
[patch] bugfix agent duplicated data update execution & gateway nil pointer depends on lost connectivity

### DIFF
--- a/internal/net/grpc/client.go
+++ b/internal/net/grpc/client.go
@@ -434,10 +434,12 @@ func (g *gRPCClient) Connect(ctx context.Context, addr string, dopts ...DialOpti
 		log.Warnf("failed to reconnect unhealthy pool addr= %s\terror= %s", addr, err.Error())
 		g.conns.Delete(addr)
 		atomic.AddUint64(&g.clientCount, ^uint64(0))
-		err = conn.Disconnect()
-		if err != nil {
-			log.Warnf("failed to disconnect unhealthy pool addr= %s\terror= %s", addr, err.Error())
-			g.conns.Delete(addr)
+		if conn != nil {
+			err = conn.Disconnect()
+			if err != nil {
+				log.Warnf("failed to disconnect unhealthy pool addr= %s\terror= %s", addr, err.Error())
+				g.conns.Delete(addr)
+			}
 		}
 	} else if conn == nil {
 		g.conns.Delete(addr)


### PR DESCRIPTION
Signed-off-by: kpango <kpango@vdaas.org>

<!--- Provide a general summary of your changes in the Title above -->

### Description:
this bug fix PR resolves 2 problems.
1. agent component blocking when duplicated data updates execution.
2. gateway nil pointer dereference, due to the persistent client connection lost.
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.15.2
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
