### PR TITLE
Add test case for internal/errors/grpc.go

### DIFF
--- a/hack/license/gen/main.go
+++ b/hack/license/gen/main.go
@@ -54,15 +54,16 @@ var (
 )
 
 type Data struct {
-	Escape   string
+	Escape     string
 	Maintainer string
-	Year     int
+	Year       int
 }
 
 const (
-	defaultMaintainer     = "vdaas.org vald team <vald@vdaas.org>"
-	maintainerKey         = "MAINTAINER"
+	defaultMaintainer = "vdaas.org vald team <vald@vdaas.org>"
+	maintainerKey     = "MAINTAINER"
 )
+
 func main() {
 	if len(os.Args) < 2 {
 		log.Fatal(errors.New("invalid argument"))
@@ -171,8 +172,8 @@ func readAndRewrite(path string) error {
 	}
 	d := Data{
 		Maintainer: maintainer,
-		Year:     time.Now().Year(),
-		Escape:   sharpEscape,
+		Year:       time.Now().Year(),
+		Escape:     sharpEscape,
 	}
 	if fi.Name() == "LICENSE" {
 		err = license.Execute(buf, d)

--- a/internal/errors/grpc.go
+++ b/internal/errors/grpc.go
@@ -34,7 +34,7 @@ var (
 		return Errorf("invalid gRPC client connection to %s", addr)
 	}
 
-	// ErrGRPCLookupIPAddrNotFound represents a function to generate an error that the vald internal gRPC client couldn't find ip address.
+	// ErrGRPCLookupIPAddrNotFound represents a function to generate an error that the vald internal gRPC client couldn't find IP address.
 	ErrGRPCLookupIPAddrNotFound = func(host string) error {
 		return Errorf("vald internal gRPC client could not find ip addrs for %s", host)
 	}

--- a/internal/errors/grpc.go
+++ b/internal/errors/grpc.go
@@ -19,21 +19,22 @@ package errors
 
 var (
 
-	// gRPC
-
+	// ErrgRPCClientConnectionClose represents a function to generate an error that the gRPC connection couldn't close.
 	ErrgRPCClientConnectionClose = func(name string, err error) error {
 		return Wrapf(err, "%s's gRPC connection close error", name)
 	}
 
+	// ErrInvalidGRPCPort represents a function to generate an error that the gRPC port is invalid.
 	ErrInvalidGRPCPort = func(addr, host string, port uint16) error {
 		return Errorf("invalid gRPC client connection port to addr: %s,\thost: %s\t port: %d", addr, host, port)
 	}
 
+	// ErrInvalidGRPCClientConn represents a function to generate an error that the vald internal gRPC connection is invalid.
 	ErrInvalidGRPCClientConn = func(addr string) error {
 		return Errorf("invalid gRPC client connection to %s", addr)
 	}
 
-	// ErrGRPCLookupIPAddrNotFound represents a function to generate an error that the vald internal gRPC couldn't find ip address.
+	// ErrGRPCLookupIPAddrNotFound represents a function to generate an error that the vald internal gRPC client couldn't find ip address.
 	ErrGRPCLookupIPAddrNotFound = func(host string) error {
 		return Errorf("vald internal gRPC client could not find ip addrs for %s", host)
 	}

--- a/internal/errors/grpc.go
+++ b/internal/errors/grpc.go
@@ -19,8 +19,8 @@ package errors
 
 var (
 
-	// ErrgRPCClientConnectionClose represents a function to generate an error that the gRPC connection couldn't close.
-	ErrgRPCClientConnectionClose = func(name string, err error) error {
+	// ErrGRPCClientConnectionClose represents a function to generate an error that the gRPC connection couldn't close.
+	ErrGRPCClientConnectionClose = func(name string, err error) error {
 		return Wrapf(err, "%s's gRPC connection close error", name)
 	}
 

--- a/internal/errors/grpc.go
+++ b/internal/errors/grpc.go
@@ -33,19 +33,24 @@ var (
 		return Errorf("invalid gRPC client connection to %s", addr)
 	}
 
+	// ErrGRPCLookupIPAddrNotFound represents a function to generate an error that the vald internal gRPC couldn't find ip address.
 	ErrGRPCLookupIPAddrNotFound = func(host string) error {
 		return Errorf("vald internal gRPC client could not find ip addrs for %s", host)
 	}
 
+	// ErrGRPCClientNotFound represents an error that the vald internal gRPC client couldn't find.
 	ErrGRPCClientNotFound = New("vald internal gRPC client not found")
 
+	// ErrGRPCClientConnNotFound represents a function to generate an error that the gRPC client connection couldn't find.
 	ErrGRPCClientConnNotFound = func(addr string) error {
 		return Errorf("gRPC client connection not found in %s", addr)
 	}
 
+	// ErrRPCCallFailed represents a function to generate an error that the RPC call failed.
 	ErrRPCCallFailed = func(addr string, err error) error {
 		return Wrapf(err, "addr: %s", addr)
 	}
 
+	// ErrGRPCTargetAddrNotFound represents an error that the gRPC connection target couldn't find.
 	ErrGRPCTargetAddrNotFound = New("grpc connection target not found")
 )

--- a/internal/errors/grpc.go
+++ b/internal/errors/grpc.go
@@ -52,6 +52,6 @@ var (
 		return Wrapf(err, "addr: %s", addr)
 	}
 
-	// ErrGRPCTargetAddrNotFound represents an error that the gRPC connection target couldn't find.
+	// ErrGRPCTargetAddrNotFound represents an error that the gRPC target address couldn't find.
 	ErrGRPCTargetAddrNotFound = New("grpc connection target not found")
 )

--- a/internal/errors/grpc_test.go
+++ b/internal/errors/grpc_test.go
@@ -159,6 +159,17 @@ func TestErrInvalidGRPCPort(t *testing.T) {
 			},
 		},
 		{
+			name: "return ErrInvalidGRPCPort error when addr is '127.0.0.1' and host is 'gateway.default.svc.cluster.local' and port is '1'",
+			args: args{
+				addr: "127.0.0.1",
+				host: "gateway.default.svc.cluster.local",
+				port: 1,
+			},
+			want: want{
+				want: New("invalid gRPC client connection port to addr: 127.0.0.1,\thost: gateway.default.svc.cluster.local\t port: 1"),
+			},
+		},
+		{
 			name: "return ErrInvalidGRPCPort error when addr is '127.0.0.1' and host is 'gateway.default.svc.cluster.local' and port is maximum value of uint16",
 			args: args{
 				addr: "127.0.0.1",
@@ -167,6 +178,17 @@ func TestErrInvalidGRPCPort(t *testing.T) {
 			},
 			want: want{
 				want: Errorf("invalid gRPC client connection port to addr: 127.0.0.1,\thost: gateway.default.svc.cluster.local\t port: %d", math.MaxUint16),
+			},
+		},
+		{
+			name: "return ErrInvalidGRPCPort error when addr is '127.0.0.1' and host is 'gateway.default.svc.cluster.local' and port is 'MaxUint16-1'",
+			args: args{
+				addr: "127.0.0.1",
+				host: "gateway.default.svc.cluster.local",
+				port: math.MaxUint16 - 1,
+			},
+			want: want{
+				want: Errorf("invalid gRPC client connection port to addr: 127.0.0.1,\thost: gateway.default.svc.cluster.local\t port: %d", math.MaxUint16-1),
 			},
 		},
 	}

--- a/internal/errors/grpc_test.go
+++ b/internal/errors/grpc_test.go
@@ -1,0 +1,451 @@
+package errors
+
+import "testing"
+
+func TestErrgRPCClientConnectionClose(t *testing.T) {
+	type args struct {
+		name string
+		err  error
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return wrapped error when err is server error and name is 'gateway'",
+			args: args{
+				err:  New("server error"),
+				name: "gateway",
+			},
+			want: want{
+				want: New("gateway's gRPC connection close error: server error"),
+			},
+		},
+		{
+			name: "return wrapped error when err is server error and name is empty",
+			args: args{
+				err:  New("server error"),
+				name: "",
+			},
+			want: want{
+				want: New("'s gRPC connection close error: server error"),
+			},
+		},
+		{
+			name: "return error when err is nil error and name is 'gateway'",
+			args: args{
+				err:  nil,
+				name: "gateway",
+			},
+			want: want{
+				want: New("gateway's gRPC connection close error"),
+			},
+		},
+		{
+			name: "return error when err is nil error and addr is empty",
+			args: args{
+				err:  nil,
+				name: "",
+			},
+			want: want{
+				want: New("'s gRPC connection close error"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrgRPCClientConnectionClose(test.args.name, test.args.err)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrInvalidGRPCClientConn(t *testing.T) {
+	type args struct {
+		addr string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return error when addr is '127.0.0.1'",
+			args: args{
+				addr: "127.0.0.1",
+			},
+			want: want{
+				want: New("invalid gRPC client connection to 127.0.0.1"),
+			},
+		},
+		{
+			name: "return error when addr is empty",
+			args: args{
+				addr: "",
+			},
+			want: want{
+				want: New("invalid gRPC client connection to "),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrInvalidGRPCClientConn(test.args.addr)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrGRPCLookupIPAddrNotFound(t *testing.T) {
+	type args struct {
+		host string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return error when host is 'gateway.vald.svc.cluster.local'",
+			args: args{
+				host: "gateway.vald.svc.cluster.local",
+			},
+			want: want{
+				want: New("vald internal gRPC client could not find ip addrs for gateway.vald.svc.cluster.local"),
+			},
+		},
+		{
+			name: "return error when host is empty",
+			args: args{
+				host: "",
+			},
+			want: want{
+				want: New("vald internal gRPC client could not find ip addrs for "),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrGRPCLookupIPAddrNotFound(test.args.host)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrGRPCClientNotFound(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return error",
+			want: want{
+				want: New("vald internal gRPC client not found"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrGRPCClientNotFound
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrGRPCClientConnNotFound(t *testing.T) {
+	type args struct {
+		addr string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return error when addr is '127.0.0.1'",
+			args: args{
+				addr: "127.0.0.1",
+			},
+			want: want{
+				want: New("gRPC client connection not found in 127.0.0.1"),
+			},
+		},
+		{
+			name: "return error when addr is empty",
+			args: args{
+				addr: "",
+			},
+			want: want{
+				want: New("gRPC client connection not found in "),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrGRPCClientConnNotFound(test.args.addr)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrRPCCallFailed(t *testing.T) {
+	type args struct {
+		addr string
+		err  error
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return wrapped error when err is server error and addr is '127.0.0.1'",
+			args: args{
+				err:  New("server error"),
+				addr: "127.0.0.1",
+			},
+			want: want{
+				want: New("addr: 127.0.0.1: server error"),
+			},
+		},
+		{
+			name: "return wrapped error when err is server error and addr is empty",
+			args: args{
+				err:  New("server error"),
+				addr: "",
+			},
+			want: want{
+				want: New("addr: : server error"),
+			},
+		},
+		{
+			name: "return error when err is nil error and addr is '127.0.0.1'",
+			args: args{
+				err:  nil,
+				addr: "127.0.0.1",
+			},
+			want: want{
+				want: New("addr: 127.0.0.1"),
+			},
+		},
+		{
+			name: "return error when err is nil error and addr is empty",
+			args: args{
+				err:  nil,
+				addr: "",
+			},
+			want: want{
+				want: New("addr: "),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrRPCCallFailed(test.args.addr, test.args.err)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrGRPCTargetAddrNotFound(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return error",
+			want: want{
+				want: New("grpc connection target not found"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrGRPCTargetAddrNotFound
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/errors/grpc_test.go
+++ b/internal/errors/grpc_test.go
@@ -26,7 +26,7 @@ func TestErrgRPCClientConnectionClose(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return wrapped error when err is server error and name is 'gateway'",
+			name: "return wrapped ErrgRPCClientConnectionClose error when err is server error and name is 'gateway'",
 			args: args{
 				err:  New("server error"),
 				name: "gateway",
@@ -36,7 +36,7 @@ func TestErrgRPCClientConnectionClose(t *testing.T) {
 			},
 		},
 		{
-			name: "return wrapped error when err is server error and name is empty",
+			name: "return wrapped ErrgRPCClientConnectionClose error when err is server error and name is empty",
 			args: args{
 				err:  New("server error"),
 				name: "",
@@ -46,7 +46,7 @@ func TestErrgRPCClientConnectionClose(t *testing.T) {
 			},
 		},
 		{
-			name: "return error when err is nil error and name is 'gateway'",
+			name: "return ErrgRPCClientConnectionClose error when err is nil error and name is 'gateway'",
 			args: args{
 				err:  nil,
 				name: "gateway",
@@ -56,7 +56,7 @@ func TestErrgRPCClientConnectionClose(t *testing.T) {
 			},
 		},
 		{
-			name: "return error when err is nil error and addr is empty",
+			name: "return ErrgRPCClientConnectionClose error when err is nil error and addr is empty",
 			args: args{
 				err:  nil,
 				name: "",
@@ -110,7 +110,7 @@ func TestErrInvalidGRPCClientConn(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return error when addr is '127.0.0.1'",
+			name: "return ErrInvalidGRPCClientConn error when addr is '127.0.0.1'",
 			args: args{
 				addr: "127.0.0.1",
 			},
@@ -119,7 +119,7 @@ func TestErrInvalidGRPCClientConn(t *testing.T) {
 			},
 		},
 		{
-			name: "return error when addr is empty",
+			name: "return ErrInvalidGRPCClientConn error when addr is empty",
 			args: args{
 				addr: "",
 			},
@@ -172,7 +172,7 @@ func TestErrGRPCLookupIPAddrNotFound(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return error when host is 'gateway.vald.svc.cluster.local'",
+			name: "return ErrGRPCLookupIPAddrNotFound error when host is 'gateway.vald.svc.cluster.local'",
 			args: args{
 				host: "gateway.vald.svc.cluster.local",
 			},
@@ -181,7 +181,7 @@ func TestErrGRPCLookupIPAddrNotFound(t *testing.T) {
 			},
 		},
 		{
-			name: "return error when host is empty",
+			name: "return ErrGRPCLookupIPAddrNotFound error when host is empty",
 			args: args{
 				host: "",
 			},
@@ -230,7 +230,7 @@ func TestErrGRPCClientNotFound(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return error",
+			name: "return ErrGRPCLookupIPAddrNotFound error",
 			want: want{
 				want: New("vald internal gRPC client not found"),
 			},
@@ -280,7 +280,7 @@ func TestErrGRPCClientConnNotFound(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return error when addr is '127.0.0.1'",
+			name: "return ErrGRPCClientConnNotFound error when addr is '127.0.0.1'",
 			args: args{
 				addr: "127.0.0.1",
 			},
@@ -289,7 +289,7 @@ func TestErrGRPCClientConnNotFound(t *testing.T) {
 			},
 		},
 		{
-			name: "return error when addr is empty",
+			name: "return ErrGRPCClientConnNotFound error when addr is empty",
 			args: args{
 				addr: "",
 			},
@@ -343,7 +343,7 @@ func TestErrRPCCallFailed(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return wrapped error when err is server error and addr is '127.0.0.1'",
+			name: "return wrapped ErrRPCCallFailed error when err is server error and addr is '127.0.0.1'",
 			args: args{
 				err:  New("server error"),
 				addr: "127.0.0.1",
@@ -353,7 +353,7 @@ func TestErrRPCCallFailed(t *testing.T) {
 			},
 		},
 		{
-			name: "return wrapped error when err is server error and addr is empty",
+			name: "return wrapped ErrRPCCallFailed error when err is server error and addr is empty",
 			args: args{
 				err:  New("server error"),
 				addr: "",
@@ -363,7 +363,7 @@ func TestErrRPCCallFailed(t *testing.T) {
 			},
 		},
 		{
-			name: "return error when err is nil error and addr is '127.0.0.1'",
+			name: "return ErrRPCCallFailed error when err is nil error and addr is '127.0.0.1'",
 			args: args{
 				err:  nil,
 				addr: "127.0.0.1",
@@ -373,7 +373,7 @@ func TestErrRPCCallFailed(t *testing.T) {
 			},
 		},
 		{
-			name: "return error when err is nil error and addr is empty",
+			name: "return ErrRPCCallFailed error when err is nil error and addr is empty",
 			args: args{
 				err:  nil,
 				addr: "",
@@ -423,7 +423,7 @@ func TestErrGRPCTargetAddrNotFound(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return error",
+			name: "return ErrGRPCTargetAddrNotFound error",
 			want: want{
 				want: New("grpc connection target not found"),
 			},

--- a/internal/errors/grpc_test.go
+++ b/internal/errors/grpc_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright (C) 2019-2021 vdaas.org vald team <vald@vdaas.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package errors
 
 import (

--- a/internal/errors/grpc_test.go
+++ b/internal/errors/grpc_test.go
@@ -49,7 +49,7 @@ func TestErrGRPCClientConnectionClose(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrGRPCClientConnectionClose error when err is nil error and name is 'gateway'",
+			name: "return ErrGRPCClientConnectionClose error when err is nil and name is 'gateway'",
 			args: args{
 				err:  nil,
 				name: "gateway",
@@ -59,7 +59,7 @@ func TestErrGRPCClientConnectionClose(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrGRPCClientConnectionClose error when err is nil error and addr is empty",
+			name: "return ErrGRPCClientConnectionClose error when err is nil and addr is empty",
 			args: args{
 				err:  nil,
 				name: "",

--- a/internal/errors/grpc_test.go
+++ b/internal/errors/grpc_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestErrgRPCClientConnectionClose(t *testing.T) {
+func TestErrGRPCClientConnectionClose(t *testing.T) {
 	type args struct {
 		name string
 		err  error
@@ -29,7 +29,7 @@ func TestErrgRPCClientConnectionClose(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return wrapped ErrgRPCClientConnectionClose error when err is server error and name is 'gateway'",
+			name: "return wrapped ErrGRPCClientConnectionClose error when err is server error and name is 'gateway'",
 			args: args{
 				err:  New("server error"),
 				name: "gateway",
@@ -39,7 +39,7 @@ func TestErrgRPCClientConnectionClose(t *testing.T) {
 			},
 		},
 		{
-			name: "return wrapped ErrgRPCClientConnectionClose error when err is server error and name is empty",
+			name: "return wrapped ErrGRPCClientConnectionClose error when err is server error and name is empty",
 			args: args{
 				err:  New("server error"),
 				name: "",
@@ -49,7 +49,7 @@ func TestErrgRPCClientConnectionClose(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrgRPCClientConnectionClose error when err is nil error and name is 'gateway'",
+			name: "return ErrGRPCClientConnectionClose error when err is nil error and name is 'gateway'",
 			args: args{
 				err:  nil,
 				name: "gateway",
@@ -59,7 +59,7 @@ func TestErrgRPCClientConnectionClose(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrgRPCClientConnectionClose error when err is nil error and addr is empty",
+			name: "return ErrGRPCClientConnectionClose error when err is nil error and addr is empty",
 			args: args{
 				err:  nil,
 				name: "",
@@ -82,7 +82,7 @@ func TestErrgRPCClientConnectionClose(t *testing.T) {
 				test.checkFunc = defaultCheckFunc
 			}
 
-			got := ErrgRPCClientConnectionClose(test.args.name, test.args.err)
+			got := ErrGRPCClientConnectionClose(test.args.name, test.args.err)
 			if err := test.checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->

I added the test cases for internal/errors/grpc.go and comments.

And I modified the function name based on kevin-san's comment.
- https://github.com/vdaas/vald/pull/903#discussion_r551683532


***grammar check passed***

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.15.2
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
