### PR TITLE
[patch] bugfix: do not create metadata file when create/append flag is not set for the agent/agent-sidecar

### DIFF
--- a/internal/core/ngt/ngt.go
+++ b/internal/core/ngt/ngt.go
@@ -220,7 +220,7 @@ func (n *ngt) loadOptions(opts ...Option) (err error) {
 
 func (n *ngt) create() (err error) {
 	if fileExists(n.idxPath) {
-		if err = os.Remove(n.idxPath); err != nil {
+		if err = os.RemoveAll(n.idxPath); err != nil {
 			return err
 		}
 	}

--- a/internal/core/ngt/ngt.go
+++ b/internal/core/ngt/ngt.go
@@ -30,6 +30,7 @@ import (
 	"unsafe"
 
 	"github.com/vdaas/vald/internal/errors"
+	"github.com/vdaas/vald/internal/log"
 )
 
 type (
@@ -220,6 +221,7 @@ func (n *ngt) loadOptions(opts ...Option) (err error) {
 
 func (n *ngt) create() (err error) {
 	if fileExists(n.idxPath) {
+		log.Infof("index path exists, will remove the directory. path: %s", n.idxPath)
 		if err = os.RemoveAll(n.idxPath); err != nil {
 			return err
 		}

--- a/internal/errors/meta.go
+++ b/internal/errors/meta.go
@@ -19,4 +19,5 @@ package errors
 
 var (
 	ErrInvalidMetaDataConfig = New("invalid metadata config")
+	ErrMetadataFileEmpty     = New("metadata file empty")
 )

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -42,9 +42,11 @@ func Open(path string, flg int, perm os.FileMode) (*os.File, error) {
 			}
 		}
 
-		file, err = os.Create(path)
-		if err != nil {
-			return nil, err
+		if flg&(os.O_CREATE|os.O_APPEND) > 0 {
+			file, err = os.Create(path)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		if file != nil {

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -145,7 +145,7 @@ func TestOpen(t *testing.T) {
 			args: args{
 				path: "dummy",
 				flg:  os.O_RDONLY,
-				perm: os.ModeDir,
+				perm: os.ModePerm,
 			},
 			want: want{
 				want: nil,
@@ -165,7 +165,7 @@ func TestOpen(t *testing.T) {
 			args: args{
 				path: "dummy/dummy",
 				flg:  os.O_RDONLY,
-				perm: os.ModeDir,
+				perm: os.ModePerm,
 			},
 			want: want{
 				want: nil,
@@ -177,6 +177,12 @@ func TestOpen(t *testing.T) {
 						return err
 					}(),
 				},
+			},
+			afterFunc: func(t *testing.T, _ args) {
+				t.Helper()
+				if err := os.RemoveAll("dummy"); err != nil {
+					t.Fatal(err)
+				}
 			},
 		},
 	}

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -19,6 +19,7 @@ package file
 
 import (
 	"os"
+	"syscall"
 	"testing"
 
 	"github.com/vdaas/vald/internal/errors"
@@ -136,6 +137,46 @@ func TestOpen(t *testing.T) {
 			want: want{
 				want: nil,
 				err:  errors.ErrPathNotSpecified,
+			},
+		},
+
+		{
+			name: "returns (nil, error) when file does not exists and flag is not CREATE or APPEND",
+			args: args{
+				path: "dummy",
+				flg:  os.O_RDONLY,
+				perm: os.ModeDir,
+			},
+			want: want{
+				want: nil,
+				err: &os.PathError{
+					Op:   "open",
+					Path: "dummy",
+					Err: func() error {
+						_, err := syscall.Open("dummy", syscall.O_RDONLY|syscall.O_CLOEXEC, 0)
+						return err
+					}(),
+				},
+			},
+		},
+
+		{
+			name: "returns (nil, error) when the folder does not exists and flag is not CREATE or APPEND",
+			args: args{
+				path: "dummy/dummy",
+				flg:  os.O_RDONLY,
+				perm: os.ModeDir,
+			},
+			want: want{
+				want: nil,
+				err: &os.PathError{
+					Op:   "open",
+					Path: "dummy/dummy",
+					Err: func() error {
+						_, err := syscall.Open("dummy/", syscall.O_RDONLY|syscall.O_CLOEXEC, 0)
+						return err
+					}(),
+				},
 			},
 		},
 	}

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -186,7 +186,7 @@ func (n *ngt) initNGT(opts ...core.Option) (err error) {
 			log.Debugf("[2]agent metadata= %#v", agentMetadata)
 
 			var fi os.FileInfo
-			if fi, err = os.Stat(filepath.Join(n.path, kvsFileName)); os.IsNotExist(err) {
+			if fi, err = os.Stat(filepath.Join(n.path, kvsFileName)); os.IsNotExist(err) || fi.Size() == 0 {
 				log.Warn("kvsdb file is not exist")
 				n.core, err = core.New(opts...)
 				return err

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -181,17 +181,13 @@ func (n *ngt) initNGT(opts ...core.Option) (err error) {
 	if err != nil || agentMetadata == nil || agentMetadata.NGT == nil || agentMetadata.NGT.IndexCount == 0 {
 		log.Warnf("cannot read metadata from %s: %v", metadata.AgentMetadataFileName, err)
 
-		log.Debugf("[1]agent metadata= %#v", agentMetadata)
 		if os.IsNotExist(err) || agentMetadata == nil || agentMetadata.NGT == nil || agentMetadata.NGT.IndexCount == 0 {
-			log.Debugf("[2]agent metadata= %#v", agentMetadata)
-
 			var fi os.FileInfo
 			if fi, err = os.Stat(filepath.Join(n.path, kvsFileName)); os.IsNotExist(err) || fi.Size() == 0 {
 				log.Warn("kvsdb file is not exist")
 				n.core, err = core.New(opts...)
 				return err
 			}
-			log.Debugf("file info= %#v", fi)
 
 			if os.IsPermission(err) {
 				log.Debugf("no permission for kvsdb file,\tpath: %s,\terr: %v", filepath.Join(n.path, kvsFileName), err)

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -178,11 +178,11 @@ func (n *ngt) initNGT(opts ...core.Option) (err error) {
 	log.Debugf("load index from %s", n.path)
 
 	agentMetadata, err := metadata.Load(filepath.Join(n.path, metadata.AgentMetadataFileName))
-	if err != nil || agentMetadata.NGT == nil || agentMetadata.NGT.IndexCount == 0 {
+	if err != nil || agentMetadata == nil || agentMetadata.NGT == nil || agentMetadata.NGT.IndexCount == 0 {
 		log.Warnf("cannot read metadata from %s: %v", metadata.AgentMetadataFileName, err)
 
 		log.Debugf("[1]agent metadata= %#v", agentMetadata)
-		if os.IsNotExist(err) || agentMetadata.NGT == nil || agentMetadata.NGT.IndexCount == 0 {
+		if os.IsNotExist(err) || agentMetadata == nil || agentMetadata.NGT == nil || agentMetadata.NGT.IndexCount == 0 {
 			log.Debugf("[2]agent metadata= %#v", agentMetadata)
 
 			var fi os.FileInfo

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -186,6 +186,9 @@ func (n *ngt) initNGT(opts ...core.Option) (err error) {
 	log.Debugf("load index from %s", n.path)
 
 	agentMetadata, err := metadata.Load(filepath.Join(n.path, metadata.AgentMetadataFileName))
+	if err != nil {
+		log.Warnf("cannot read metadata from %s: %s", metadata.AgentMetadataFileName, err)
+	}
 	if os.IsNotExist(err) || agentMetadata == nil || agentMetadata.NGT == nil || agentMetadata.NGT.IndexCount == 0 {
 		log.Warnf("cannot read metadata from %s: %v", metadata.AgentMetadataFileName, err)
 

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -181,14 +181,16 @@ func (n *ngt) initNGT(opts ...core.Option) (err error) {
 	if err != nil {
 		log.Warnf("cannot read metadata from %s: %s", metadata.AgentMetadataFileName, err)
 
-		if _, err = os.Stat(filepath.Join(n.path, kvsFileName)); os.IsNotExist(err) {
-			log.Warn("kvsdb file is not exist")
-			n.core, err = core.New(opts...)
-			return err
-		}
-		if os.IsPermission(err) {
-			log.Debugf("no permission for kvsdb file,\tpath: %s,\terr: %v", filepath.Join(n.path, kvsFileName), err)
-			return err
+		if os.IsNotExist(err) {
+			if _, err = os.Stat(filepath.Join(n.path, kvsFileName)); os.IsNotExist(err) {
+				log.Warn("kvsdb file is not exist")
+				n.core, err = core.New(opts...)
+				return err
+			}
+			if os.IsPermission(err) {
+				log.Debugf("no permission for kvsdb file,\tpath: %s,\terr: %v", filepath.Join(n.path, kvsFileName), err)
+				return err
+			}
 		}
 	}
 

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -178,10 +178,10 @@ func (n *ngt) initNGT(opts ...core.Option) (err error) {
 	log.Debugf("load index from %s", n.path)
 
 	agentMetadata, err := metadata.Load(filepath.Join(n.path, metadata.AgentMetadataFileName))
-	if err != nil {
+	if err != nil || agentMetadata.NGT == nil || agentMetadata.NGT.IndexCount == 0 {
 		log.Warnf("cannot read metadata from %s: %s", metadata.AgentMetadataFileName, err)
 
-		if os.IsNotExist(err) {
+		if os.IsNotExist(err) || agentMetadata.NGT == nil || agentMetadata.NGT.IndexCount == 0 {
 			if _, err = os.Stat(filepath.Join(n.path, kvsFileName)); os.IsNotExist(err) {
 				log.Warn("kvsdb file is not exist")
 				n.core, err = core.New(opts...)

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -179,14 +179,20 @@ func (n *ngt) initNGT(opts ...core.Option) (err error) {
 
 	agentMetadata, err := metadata.Load(filepath.Join(n.path, metadata.AgentMetadataFileName))
 	if err != nil || agentMetadata.NGT == nil || agentMetadata.NGT.IndexCount == 0 {
-		log.Warnf("cannot read metadata from %s: %s", metadata.AgentMetadataFileName, err)
+		log.Warnf("cannot read metadata from %s: %v", metadata.AgentMetadataFileName, err)
 
+		log.Debugf("[1]agent metadata= %#v", agentMetadata)
 		if os.IsNotExist(err) || agentMetadata.NGT == nil || agentMetadata.NGT.IndexCount == 0 {
-			if _, err = os.Stat(filepath.Join(n.path, kvsFileName)); os.IsNotExist(err) {
+			log.Debugf("[2]agent metadata= %#v", agentMetadata)
+
+			var fi os.FileInfo
+			if fi, err = os.Stat(filepath.Join(n.path, kvsFileName)); os.IsNotExist(err) {
 				log.Warn("kvsdb file is not exist")
 				n.core, err = core.New(opts...)
 				return err
 			}
+			log.Debugf("file info= %#v", fi)
+
 			if os.IsPermission(err) {
 				log.Debugf("no permission for kvsdb file,\tpath: %s,\terr: %v", filepath.Join(n.path, kvsFileName), err)
 				return err

--- a/pkg/agent/internal/metadata/metadata.go
+++ b/pkg/agent/internal/metadata/metadata.go
@@ -59,7 +59,7 @@ func Load(path string) (meta *Metadata, err error) {
 		return nil, err
 	}
 
-	return &meta, nil
+	return meta, nil
 }
 
 func Store(path string, meta *Metadata) error {

--- a/pkg/agent/internal/metadata/metadata.go
+++ b/pkg/agent/internal/metadata/metadata.go
@@ -39,6 +39,9 @@ type NGT struct {
 }
 
 func Load(path string) (*Metadata, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, err
+	}
 	f, err := file.Open(path, os.O_RDONLY|os.O_SYNC, os.ModePerm)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR fix a bug when the agent sidecar try to open the `metadata.json` file and  if the file is not exists, the empty file will be created and causing agent failed to start.
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.15.2
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
