### PR TITLE
Add test case for internal/errors/mysql.go

### DIFF
--- a/internal/errors/mysql.go
+++ b/internal/errors/mysql.go
@@ -18,63 +18,77 @@
 package errors
 
 var (
-	// ErrMySQLConnectionPingFailed represents an error that the ping to MySQL failed.
+	// ErrMySQLConnectionPingFailed represents an error that the ping failed.
 	ErrMySQLConnectionPingFailed = New("error MySQL connection ping failed")
 
+	// NewErrMySQLNotFoundIdentity represents a function to generate an error that the element is not found.
 	NewErrMySQLNotFoundIdentity = func() error {
 		return &ErrMySQLNotFoundIdentity{
 			err: New("error mysql element not found"),
 		}
 	}
 
+	// ErrMySQLConnectionClosed represents a function to generate an error that the connection closed.
 	ErrMySQLConnectionClosed = New("error MySQL connection closed")
 
+	// ErrMySQLTransactionNotCreated represents an error that the transaction is not closed.
 	ErrMySQLTransactionNotCreated = New("error MySQL transaction not created")
 
+	// ErrRequiredElementNotFoundByUUID represents a function to generate an error that the required element is not found.
 	ErrRequiredElementNotFoundByUUID = func(uuid string) error {
 		return Wrapf(NewErrMySQLNotFoundIdentity(), "error required element not found, uuid: %s", uuid)
 	}
 
+	// NewErrMySQLInvalidArgumentIdentity represents a function to generate an error that the argument is invalid.
 	NewErrMySQLInvalidArgumentIdentity = func() error {
 		return &ErrMySQLInvalidArgumentIdentity{
 			err: New("error mysql invalid argument"),
 		}
 	}
 
+	// ErrRequiredMemberNotFilled represents a function to generate an error that the required member is not filled.
 	ErrRequiredMemberNotFilled = func(member string) error {
 		return Wrapf(NewErrMySQLInvalidArgumentIdentity(), "error required member not filled (member: %s)", member)
 	}
 )
 
+// ErrMySQLNotFoundIdentity represents a custom error type that the element is not found.
 type ErrMySQLNotFoundIdentity struct {
 	err error
 }
 
+// Error returns the string of internal error.
 func (e *ErrMySQLNotFoundIdentity) Error() string {
 	return e.err.Error()
 }
 
+// Unwrap returns the internal error.
 func (e *ErrMySQLNotFoundIdentity) Unwrap() error {
 	return e.err
 }
 
+// IsErrMySQLNotFound returns true when the err type is ErrMySQLNotFoundIdentity.
 func IsErrMySQLNotFound(err error) bool {
 	target := new(ErrMySQLNotFoundIdentity)
 	return As(err, &target)
 }
 
+// ErrMySQLInvalidArgumentIdentity represents a custom error type that the argument is not found.
 type ErrMySQLInvalidArgumentIdentity struct {
 	err error
 }
 
+// Error returns the string of internal error.
 func (e *ErrMySQLInvalidArgumentIdentity) Error() string {
 	return e.err.Error()
 }
 
+// Unwrap returns the internal error.
 func (e *ErrMySQLInvalidArgumentIdentity) Unwrap() error {
 	return e.err
 }
 
+// IsErrMySQLInvalidArgument returns true when the err type is ErrMySQLInvalidArgumentIdentity.
 func IsErrMySQLInvalidArgument(err error) bool {
 	target := new(ErrMySQLInvalidArgumentIdentity)
 	return As(err, &target)

--- a/internal/errors/mysql.go
+++ b/internal/errors/mysql.go
@@ -18,7 +18,7 @@
 package errors
 
 var (
-	// MySQL.
+	// ErrMySQLConnectionPingFailed represents an error that the ping to MySQL failed.
 	ErrMySQLConnectionPingFailed = New("error MySQL connection ping failed")
 
 	NewErrMySQLNotFoundIdentity = func() error {

--- a/internal/errors/mysql_test.go
+++ b/internal/errors/mysql_test.go
@@ -52,6 +52,7 @@ func TestErrMySQLConnectionPingFailed(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -100,6 +101,7 @@ func TestNewErrMySQLNotFoundIdentity(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -146,6 +148,7 @@ func TestErrMySQLConnectionClosed(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -192,6 +195,7 @@ func TestErrMySQLTransactionNotCreated(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -258,6 +262,7 @@ func TestErrRequiredElementNotFoundByUUID(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -306,6 +311,7 @@ func TestNewErrMySQLInvalidArgumentIdentity(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -372,6 +378,7 @@ func TestErrRequiredMemberNotFilled(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
+			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -391,7 +398,6 @@ func TestErrRequiredMemberNotFilled(t *testing.T) {
 }
 
 func TestErrMySQLNotFoundIdentity_Error(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		err error
 	}
@@ -424,10 +430,8 @@ func TestErrMySQLNotFoundIdentity_Error(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		test := tc
+	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			tt.Parallel()
 			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
@@ -451,7 +455,6 @@ func TestErrMySQLNotFoundIdentity_Error(t *testing.T) {
 }
 
 func TestErrMySQLNotFoundIdentity_Unwrap(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		err error
 	}
@@ -493,10 +496,8 @@ func TestErrMySQLNotFoundIdentity_Unwrap(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		test := tc
+	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			tt.Parallel()
 			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
@@ -520,7 +521,6 @@ func TestErrMySQLNotFoundIdentity_Unwrap(t *testing.T) {
 }
 
 func TestIsErrMySQLNotFound(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		err error
 	}
@@ -571,10 +571,8 @@ func TestIsErrMySQLNotFound(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		test := tc
+	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			tt.Parallel()
 			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
@@ -595,7 +593,6 @@ func TestIsErrMySQLNotFound(t *testing.T) {
 }
 
 func TestErrMySQLInvalidArgumentIdentity_Error(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		err error
 	}
@@ -628,10 +625,8 @@ func TestErrMySQLInvalidArgumentIdentity_Error(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		test := tc
+	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			tt.Parallel()
 			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
@@ -655,7 +650,6 @@ func TestErrMySQLInvalidArgumentIdentity_Error(t *testing.T) {
 }
 
 func TestErrMySQLInvalidArgumentIdentity_Unwrap(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		err error
 	}
@@ -697,10 +691,8 @@ func TestErrMySQLInvalidArgumentIdentity_Unwrap(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		test := tc
+	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			tt.Parallel()
 			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc()
@@ -724,7 +716,6 @@ func TestErrMySQLInvalidArgumentIdentity_Unwrap(t *testing.T) {
 }
 
 func TestIsErrMySQLInvalidArgument(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		err error
 	}
@@ -775,10 +766,8 @@ func TestIsErrMySQLInvalidArgument(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		test := tc
+	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			tt.Parallel()
 			defer goleak.VerifyNone(tt)
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)

--- a/internal/errors/mysql_test.go
+++ b/internal/errors/mysql_test.go
@@ -24,6 +24,372 @@ import (
 	"go.uber.org/goleak"
 )
 
+func TestErrMySQLConnectionPingFailed(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrMySQLConnectionPingFailed error",
+			want: want{
+				want: New("error MySQL connection ping failed"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrMySQLConnectionPingFailed
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestNewErrMySQLNotFoundIdentity(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return NewErrMySQLNotFoundIdentity error",
+			want: want{
+				want: &ErrMySQLNotFoundIdentity{
+					err: New("error mysql element not found"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := NewErrMySQLNotFoundIdentity()
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrMySQLConnectionClosed(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrMySQLConnectionClosed error",
+			want: want{
+				want: New("error MySQL connection closed"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrMySQLConnectionClosed
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrMySQLTransactionNotCreated(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrMySQLTransactionNotCreated error",
+			want: want{
+				want: New("error MySQL transaction not created"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrMySQLTransactionNotCreated
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrRequiredElementNotFoundByUUID(t *testing.T) {
+	type args struct {
+		uuid string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return wrapped ErrRequiredElementNotFoundByUUID error when uuid is 'ef45b56c-1d90-12a7-c143-2567vaef218d'",
+			args: args{
+				uuid: "ef45b56c-1d90-12a7-c143-2567vaef218d",
+			},
+			want: want{
+				want: &ErrMySQLNotFoundIdentity{
+					err: New("error required element not found, uuid: ef45b56c-1d90-12a7-c143-2567vaef218d: error mysql element not found"),
+				},
+			},
+		},
+		{
+			name: "return wrapped ErrRequiredElementNotFoundByUUID error when uuid is empty",
+			args: args{
+				uuid: "",
+			},
+			want: want{
+				want: &ErrMySQLNotFoundIdentity{
+					err: New("error required element not found, uuid: : error mysql element not found"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrRequiredElementNotFoundByUUID(test.args.uuid)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestNewErrMySQLInvalidArgumentIdentity(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrMySQLInvalidArgumentIdentity error",
+			want: want{
+				want: &ErrMySQLInvalidArgumentIdentity{
+					err: New("error mysql invalid argument"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := NewErrMySQLInvalidArgumentIdentity()
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrRequiredMemberNotFilled(t *testing.T) {
+	type args struct {
+		member string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return wrapped ErrRequiredMemberNotFilled error when member is 'vector'",
+			args: args{
+				member: "vector",
+			},
+			want: want{
+				want: &ErrMySQLNotFoundIdentity{
+					err: New("error required member not filled (member: vector): error mysql invalid argument"),
+				},
+			},
+		},
+		{
+			name: "return wrapped ErrRequiredMemberNotFilled error when member is empty",
+			args: args{
+				member: "",
+			},
+			want: want{
+				want: &ErrMySQLNotFoundIdentity{
+					err: New("error required member not filled (member: ): error mysql invalid argument"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrRequiredMemberNotFilled(test.args.member)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
 func TestErrMySQLNotFoundIdentity_Error(t *testing.T) {
 	t.Parallel()
 	type fields struct {
@@ -47,31 +413,15 @@ func TestErrMySQLNotFoundIdentity_Error(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           err: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           err: nil,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return string of internal error when err of fields is 'error mysql element not found'",
+			fields: fields{
+				err: New("error mysql element not found"),
+			},
+			want: want{
+				want: "error mysql element not found",
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -123,31 +473,24 @@ func TestErrMySQLNotFoundIdentity_Unwrap(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           err: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           err: nil,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return internal error when err of fields is 'error mysql element not found'",
+			fields: fields{
+				err: New("error mysql element not found"),
+			},
+			want: want{
+				err: New("error mysql element not found"),
+			},
+		},
+		{
+			name: "return nil when err of field is nil'",
+			fields: fields{
+				err: nil,
+			},
+			want: want{
+				err: nil,
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -199,31 +542,33 @@ func TestIsErrMySQLNotFound(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           err: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           err: nil,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return true when err is 'ErrMySQLNotFoundIdentity'",
+			args: args{
+				err: new(ErrMySQLNotFoundIdentity),
+			},
+			want: want{
+				want: true,
+			},
+		},
+		{
+			name: "return false when err is 'database error'",
+			args: args{
+				err: New("database error"),
+			},
+			want: want{
+				want: false,
+			},
+		},
+		{
+			name: "return false when err is nil",
+			args: args{
+				err: nil,
+			},
+			want: want{
+				want: false,
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -272,31 +617,15 @@ func TestErrMySQLInvalidArgumentIdentity_Error(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           err: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           err: nil,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return string of internal error when err of fields is 'error mysql invalid argument'",
+			fields: fields{
+				err: New("error mysql invalid argument"),
+			},
+			want: want{
+				want: "error mysql invalid argument",
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -348,31 +677,24 @@ func TestErrMySQLInvalidArgumentIdentity_Unwrap(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           err: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           err: nil,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return internal error when err of fields is 'rror mysql invalid argument'",
+			fields: fields{
+				err: New("rror mysql invalid argument"),
+			},
+			want: want{
+				err: New("rror mysql invalid argument"),
+			},
+		},
+		{
+			name: "return nil when err of fields is nil'",
+			fields: fields{
+				err: nil,
+			},
+			want: want{
+				err: nil,
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -424,31 +746,33 @@ func TestIsErrMySQLInvalidArgument(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           err: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           err: nil,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "return true when err is 'ErrMySQLInvalidArgumentIdentity'",
+			args: args{
+				err: new(ErrMySQLInvalidArgumentIdentity),
+			},
+			want: want{
+				want: true,
+			},
+		},
+		{
+			name: "return false when err is 'database error'",
+			args: args{
+				err: New("database error"),
+			},
+			want: want{
+				want: false,
+			},
+		},
+		{
+			name: "return false when err is nil",
+			args: args{
+				err: nil,
+			},
+			want: want{
+				want: false,
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/errors/mysql_test.go
+++ b/internal/errors/mysql_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestErrMySQLConnectionPingFailed(t *testing.T) {
+	t.Parallel()
 	type want struct {
 		want error
 	}
@@ -52,7 +53,8 @@ func TestErrMySQLConnectionPingFailed(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -72,6 +74,7 @@ func TestErrMySQLConnectionPingFailed(t *testing.T) {
 }
 
 func TestNewErrMySQLNotFoundIdentity(t *testing.T) {
+	t.Parallel()
 	type want struct {
 		want error
 	}
@@ -101,7 +104,8 @@ func TestNewErrMySQLNotFoundIdentity(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -121,6 +125,7 @@ func TestNewErrMySQLNotFoundIdentity(t *testing.T) {
 }
 
 func TestErrMySQLConnectionClosed(t *testing.T) {
+	t.Parallel()
 	type want struct {
 		want error
 	}
@@ -148,7 +153,8 @@ func TestErrMySQLConnectionClosed(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -168,6 +174,7 @@ func TestErrMySQLConnectionClosed(t *testing.T) {
 }
 
 func TestErrMySQLTransactionNotCreated(t *testing.T) {
+	t.Parallel()
 	type want struct {
 		want error
 	}
@@ -195,7 +202,8 @@ func TestErrMySQLTransactionNotCreated(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -215,6 +223,7 @@ func TestErrMySQLTransactionNotCreated(t *testing.T) {
 }
 
 func TestErrRequiredElementNotFoundByUUID(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		uuid string
 	}
@@ -262,7 +271,8 @@ func TestErrRequiredElementNotFoundByUUID(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -282,6 +292,7 @@ func TestErrRequiredElementNotFoundByUUID(t *testing.T) {
 }
 
 func TestNewErrMySQLInvalidArgumentIdentity(t *testing.T) {
+	t.Parallel()
 	type want struct {
 		want error
 	}
@@ -311,7 +322,8 @@ func TestNewErrMySQLInvalidArgumentIdentity(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -331,6 +343,7 @@ func TestNewErrMySQLInvalidArgumentIdentity(t *testing.T) {
 }
 
 func TestErrRequiredMemberNotFilled(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		member string
 	}
@@ -378,7 +391,8 @@ func TestErrRequiredMemberNotFilled(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -398,6 +412,7 @@ func TestErrRequiredMemberNotFilled(t *testing.T) {
 }
 
 func TestErrMySQLNotFoundIdentity_Error(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		err error
 	}
@@ -432,7 +447,8 @@ func TestErrMySQLNotFoundIdentity_Error(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -455,6 +471,7 @@ func TestErrMySQLNotFoundIdentity_Error(t *testing.T) {
 }
 
 func TestErrMySQLNotFoundIdentity_Unwrap(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		err error
 	}
@@ -498,7 +515,8 @@ func TestErrMySQLNotFoundIdentity_Unwrap(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -521,6 +539,7 @@ func TestErrMySQLNotFoundIdentity_Unwrap(t *testing.T) {
 }
 
 func TestIsErrMySQLNotFound(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		err error
 	}
@@ -573,7 +592,8 @@ func TestIsErrMySQLNotFound(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -593,6 +613,7 @@ func TestIsErrMySQLNotFound(t *testing.T) {
 }
 
 func TestErrMySQLInvalidArgumentIdentity_Error(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		err error
 	}
@@ -627,7 +648,8 @@ func TestErrMySQLInvalidArgumentIdentity_Error(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -650,6 +672,7 @@ func TestErrMySQLInvalidArgumentIdentity_Error(t *testing.T) {
 }
 
 func TestErrMySQLInvalidArgumentIdentity_Unwrap(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		err error
 	}
@@ -693,7 +716,8 @@ func TestErrMySQLInvalidArgumentIdentity_Unwrap(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -716,6 +740,7 @@ func TestErrMySQLInvalidArgumentIdentity_Unwrap(t *testing.T) {
 }
 
 func TestIsErrMySQLInvalidArgument(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		err error
 	}
@@ -768,7 +793,8 @@ func TestIsErrMySQLInvalidArgument(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt)
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}

--- a/internal/errors/mysql_test.go
+++ b/internal/errors/mysql_test.go
@@ -93,7 +93,7 @@ func TestNewErrMySQLNotFoundIdentity(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return NewErrMySQLNotFoundIdentity error",
+			name: "return ErrMySQLNotFoundIdentity error",
 			want: want{
 				want: &ErrMySQLNotFoundIdentity{
 					err: New("error mysql element not found"),

--- a/internal/errors/mysql_test.go
+++ b/internal/errors/mysql_test.go
@@ -414,7 +414,7 @@ func TestErrMySQLNotFoundIdentity_Error(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return string of internal error when err of fields is 'error mysql element not found'",
+			name: "return string of internal error when err of field is 'error mysql element not found'",
 			fields: fields{
 				err: New("error mysql element not found"),
 			},
@@ -474,7 +474,7 @@ func TestErrMySQLNotFoundIdentity_Unwrap(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return internal error when err of fields is 'error mysql element not found'",
+			name: "return internal error when err of field is 'error mysql element not found'",
 			fields: fields{
 				err: New("error mysql element not found"),
 			},
@@ -543,7 +543,7 @@ func TestIsErrMySQLNotFound(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return true when err is 'ErrMySQLNotFoundIdentity'",
+			name: "return true when err is ErrMySQLNotFoundIdentity",
 			args: args{
 				err: new(ErrMySQLNotFoundIdentity),
 			},
@@ -618,7 +618,7 @@ func TestErrMySQLInvalidArgumentIdentity_Error(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return string of internal error when err of fields is 'error mysql invalid argument'",
+			name: "return string of internal error when err of field is 'error mysql invalid argument'",
 			fields: fields{
 				err: New("error mysql invalid argument"),
 			},
@@ -678,16 +678,16 @@ func TestErrMySQLInvalidArgumentIdentity_Unwrap(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return internal error when err of fields is 'rror mysql invalid argument'",
+			name: "return internal error when err of field is 'error mysql invalid argument'",
 			fields: fields{
-				err: New("rror mysql invalid argument"),
+				err: New("error mysql invalid argument"),
 			},
 			want: want{
-				err: New("rror mysql invalid argument"),
+				err: New("error mysql invalid argument"),
 			},
 		},
 		{
-			name: "return nil when err of fields is nil'",
+			name: "return nil when err of field is nil'",
 			fields: fields{
 				err: nil,
 			},
@@ -747,7 +747,7 @@ func TestIsErrMySQLInvalidArgument(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return true when err is 'ErrMySQLInvalidArgumentIdentity'",
+			name: "return true when err is ErrMySQLInvalidArgumentIdentity",
 			args: args{
 				err: new(ErrMySQLInvalidArgumentIdentity),
 			},

--- a/internal/errors/mysql_test.go
+++ b/internal/errors/mysql_test.go
@@ -246,7 +246,7 @@ func TestErrRequiredElementNotFoundByUUID(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return wrapped ErrRequiredElementNotFoundByUUID error when uuid is 'ef45b56c-1d90-12a7-c143-2567vaef218d'",
+			name: "return wrapped ErrRequiredElementNotFoundByUUID error when uuid is ef45b56c-1d90-12a7-c143-2567vaef218d",
 			args: args{
 				uuid: "ef45b56c-1d90-12a7-c143-2567vaef218d",
 			},
@@ -366,7 +366,7 @@ func TestErrRequiredMemberNotFilled(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return wrapped ErrRequiredMemberNotFilled error when member is 'vector'",
+			name: "return wrapped ErrRequiredMemberNotFilled error when member is vector",
 			args: args{
 				member: "vector",
 			},
@@ -494,7 +494,7 @@ func TestErrMySQLNotFoundIdentity_Unwrap(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return internal error when err of field is 'error mysql element not found'",
+			name: "return internal error when err of field is error mysql element not found",
 			fields: fields{
 				err: New("error mysql element not found"),
 			},
@@ -503,7 +503,7 @@ func TestErrMySQLNotFoundIdentity_Unwrap(t *testing.T) {
 			},
 		},
 		{
-			name: "return nil when err of field is nil'",
+			name: "return nil when err of field is nil",
 			fields: fields{
 				err: nil,
 			},
@@ -571,7 +571,7 @@ func TestIsErrMySQLNotFound(t *testing.T) {
 			},
 		},
 		{
-			name: "return false when err is 'database error'",
+			name: "return false when err is database error",
 			args: args{
 				err: New("database error"),
 			},
@@ -636,7 +636,7 @@ func TestErrMySQLInvalidArgumentIdentity_Error(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return string of internal error when err of field is 'error mysql invalid argument'",
+			name: "return string of internal error when err of field is error mysql invalid argument",
 			fields: fields{
 				err: New("error mysql invalid argument"),
 			},
@@ -695,7 +695,7 @@ func TestErrMySQLInvalidArgumentIdentity_Unwrap(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return internal error when err of field is 'error mysql invalid argument'",
+			name: "return internal error when err of field is error mysql invalid argument",
 			fields: fields{
 				err: New("error mysql invalid argument"),
 			},
@@ -772,7 +772,7 @@ func TestIsErrMySQLInvalidArgument(t *testing.T) {
 			},
 		},
 		{
-			name: "return false when err is 'database error'",
+			name: "return false when err is database error",
 			args: args{
 				err: New("database error"),
 			},


### PR DESCRIPTION
Signed-off-by: hlts2 <hiroto.funakoshi.hiroto@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

I added the test cases for internal/errors/mysql.go and comments.
And I fixed the test error for parallel testing and existing code to support parallel testing.

#### Details of fails test

goroutine detecting error occurs when we use `t.Parallel` and `goleak.Verity(tt)` in the sub-test.
the goroutine generated by t.Parallel will also be detected by goleak.
So I Changed to use `goleak.IgnoreCurrent` method and ignore goroutines other than the function under test


**grammar check passed**


### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.15.2
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
