### PR TITLE
Add test case for internal/errors/ngt.go

### DIFF
--- a/internal/errors/ngt.go
+++ b/internal/errors/ngt.go
@@ -37,7 +37,7 @@ var (
 		return Errorf("dimension size %d is invalid, the supporting dimension size must be between 2 ~ %d", current, limit)
 	}
 
-	// ErrDimensionLimitExceed represents a function to generate an error that the supported dimension limit exceded.
+	// ErrDimensionLimitExceed represents a function to generate an error that the supported dimension limit exceeded.
 	ErrDimensionLimitExceed = func(current, limit int) error {
 		return Errorf("supported dimension limit exceed:\trequired = %d,\tlimit = %d", current, limit)
 	}
@@ -78,7 +78,7 @@ var (
 		return Wrap(err, "failed to set search edge size")
 	}
 
-	// ErrUncommittedIndexExists represents a function to generate an error that the uncommitted indexes exists.
+	// ErrUncommittedIndexExists represents a function to generate an error that the uncommitted indexes exist.
 	ErrUncommittedIndexExists = func(num uint64) error {
 		return Errorf("%d indexes are not committed", num)
 	}

--- a/internal/errors/ngt.go
+++ b/internal/errors/ngt.go
@@ -18,16 +18,18 @@
 package errors
 
 var (
-	// NGT.
-
+	// ErrCreateProperty represents an error that the property creation failed.
 	ErrCreateProperty = func(err error) error {
 		return Wrap(err, "failed to create property")
 	}
 
+	// ErrIndexNotFound represents an error that the index file is not found.
 	ErrIndexNotFound = New("index file not found")
 
+	// ErrIndexLoadTimeout represents an error that the index loading timeout.
 	ErrIndexLoadTimeout = New("index load timeout")
 
+	// ErrInvalidDimensionSize represents a function to generate an error that the dimension size is invalid.
 	ErrInvalidDimensionSize = func(current, limit int) error {
 		if limit == 0 {
 			return Errorf("dimension size %d is invalid, the supporting dimension size must be bigger than 2", current)
@@ -35,51 +37,64 @@ var (
 		return Errorf("dimension size %d is invalid, the supporting dimension size must be between 2 ~ %d", current, limit)
 	}
 
+	// ErrDimensionLimitExceed represents a function to generate an error that the supported dimension limit exceded.
 	ErrDimensionLimitExceed = func(current, limit int) error {
 		return Errorf("supported dimension limit exceed:\trequired = %d,\tlimit = %d", current, limit)
 	}
 
+	// ErrIncompatibleDimensionSize represents a function to generate an error that the incompatible dimension size detected.
 	ErrIncompatibleDimensionSize = func(req, dim int) error {
 		return Errorf("incompatible dimension size detected\trequested: %d,\tconfigured: %d", req, dim)
 	}
 
+	// ErrUnsupportedObjectType represents an error that the object type is unsupported.
 	ErrUnsupportedObjectType = New("unsupported ObjectType")
 
+	// ErrUnsupportedDistanceType represents an error that the distance type is unsupported.
 	ErrUnsupportedDistanceType = New("unsupported DistanceType")
 
+	// ErrFailedToSetDistanceType represents a function to generate an error that the set of distance type failed.
 	ErrFailedToSetDistanceType = func(err error, distance string) error {
 		return Wrap(err, "failed to set distance type "+distance)
 	}
 
+	// ErrFailedToSetObjectType represents a function to generate an error that the set of object type failed.
 	ErrFailedToSetObjectType = func(err error, t string) error {
 		return Wrap(err, "failed to set object type "+t)
 	}
 
+	// ErrFailedToSetDimension represents a function to generate an error that the set of dimension failed.
 	ErrFailedToSetDimension = func(err error) error {
 		return Wrap(err, "failed to set dimension")
 	}
 
+	// ErrFailedToSetCreationEdgeSize represents a function to generate an error that the set of creation edge size failed.
 	ErrFailedToSetCreationEdgeSize = func(err error) error {
 		return Wrap(err, "failed to set creation edge size")
 	}
 
+	// ErrFailedToSetSearchEdgeSize represents a function to generate an error that the set of search edge size failed.
 	ErrFailedToSetSearchEdgeSize = func(err error) error {
 		return Wrap(err, "failed to set search edge size")
 	}
 
+	// ErrUncommittedIndexExists represents a function to generate an error that the uncommitted indexes exists.
 	ErrUncommittedIndexExists = func(num uint64) error {
 		return Errorf("%d indexes are not committed", num)
 	}
 
+	// ErrUncommittedIndexNotFound represents an error that the uncommitted indexes are not found.
 	ErrUncommittedIndexNotFound = New("uncommitted indexes are not found")
 
-	// ErrCAPINotImplemented raises using not implemented function in C API.
+	// ErrCAPINotImplemented represents an error that the function is not implemented in C API.
 	ErrCAPINotImplemented = New("not implemented in C API")
 
+	// ErrUUIDAlreadyExists represents a function to generate an error that the uuid already exists.
 	ErrUUIDAlreadyExists = func(uuid string, oid uint) error {
 		return Errorf("ngt uuid %s object id %d already exists ", uuid, oid)
 	}
 
+	// ErrUUIDNotFound represents a function to generate an error that the uuid is not found.
 	ErrUUIDNotFound = func(id uint32) error {
 		if id == 0 {
 			return Errorf("ngt object uuid not found", id)
@@ -87,14 +102,17 @@ var (
 		return Errorf("ngt object uuid %d's metadata not found", id)
 	}
 
+	// ErrObjectIDNotFound represents a function to generate an error that the object id is not found.
 	ErrObjectIDNotFound = func(uuid string) error {
 		return Errorf("ngt uuid %s's object id not found", uuid)
 	}
 
+	// ErrObjectNotFound represents a function to generate an error that the object is not found.
 	ErrObjectNotFound = func(err error, uuid string) error {
 		return Wrapf(err, "ngt uuid %s's object not found", uuid)
 	}
 
+	// ErrRemoveRequestedBeforeIndexing represents a function to generate an error that the object is not indexed so can not remove it.
 	ErrRemoveRequestedBeforeIndexing = func(oid uint) error {
 		return Errorf("object id %d is not indexed we cannot remove it", oid)
 	}

--- a/internal/errors/ngt.go
+++ b/internal/errors/ngt.go
@@ -97,7 +97,7 @@ var (
 	// ErrUUIDNotFound represents a function to generate an error that the uuid is not found.
 	ErrUUIDNotFound = func(id uint32) error {
 		if id == 0 {
-			return Errorf("ngt object uuid not found", id)
+			return New("ngt object uuid not found")
 		}
 		return Errorf("ngt object uuid %d's metadata not found", id)
 	}

--- a/internal/errors/ngt.go
+++ b/internal/errors/ngt.go
@@ -18,7 +18,7 @@
 package errors
 
 var (
-	// ErrCreateProperty represents an error that the property creation failed.
+	// ErrCreateProperty represents a function to generate an error that the property creation failed.
 	ErrCreateProperty = func(err error) error {
 		return Wrap(err, "failed to create property")
 	}

--- a/internal/errors/ngt_test.go
+++ b/internal/errors/ngt_test.go
@@ -1,0 +1,1 @@
+package errors

--- a/internal/errors/ngt_test.go
+++ b/internal/errors/ngt_test.go
@@ -28,7 +28,7 @@ func TestErrCreateProperty(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return wrapped ErrCreateProperty error when the err is ngt error",
+			name: "return wrapped ErrCreateProperty error when err is ngt error",
 			args: args{
 				err: New("ngt error"),
 			},
@@ -37,7 +37,7 @@ func TestErrCreateProperty(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrCreateProperty error when the err is nil",
+			name: "return ErrCreateProperty error when err is nil",
 			args: args{
 				err: nil,
 			},
@@ -208,7 +208,7 @@ func TestErrDimensionLimitExceed(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrDimensionLimitExceed error when current is 0 and limit is 0",
+			name: "return ErrDimensionLimitExceed error when current and limit are the minimum value of math.Int64",
 			args: args{
 				current: int(math.MinInt64),
 				limit:   int(math.MinInt64),
@@ -218,7 +218,7 @@ func TestErrDimensionLimitExceed(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrDimensionLimitExceed error when current is 0 and limit is 0",
+			name: "return ErrDimensionLimitExceed error when current and limit are the maximum value of math.Int64",
 			args: args{
 				current: int(math.MaxInt64),
 				limit:   int(math.MaxInt64),
@@ -334,6 +334,907 @@ func TestErrUnsupportedDistanceType(t *testing.T) {
 			}
 
 			got := ErrUnsupportedDistanceType
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrFailedToSetDistanceType(t *testing.T) {
+	type args struct {
+		err      error
+		distance string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return wrapped ErrFailedToSetDistanceType error when err is ngt error and distance is 'l2'",
+			args: args{
+				err:      New("ngt error"),
+				distance: "l2",
+			},
+			want: want{
+				want: New("failed to set distance type l2: ngt error"),
+			},
+		},
+		{
+			name: "return wrapped ErrFailedToSetDistanceType error when err is ngt error and distance is empty",
+			args: args{
+				err:      New("ngt error"),
+				distance: "",
+			},
+			want: want{
+				want: New("failed to set distance type : ngt error"),
+			},
+		},
+		{
+			name: "return ErrFailedToSetDistanceType error when err is nil and distance is 'l2'",
+			args: args{
+				err:      nil,
+				distance: "l2",
+			},
+			want: want{
+				want: New("failed to set distance type l2"),
+			},
+		},
+		{
+			name: "return ErrFailedToSetDistanceType error when err is nil and distance is empty",
+			args: args{
+				err:      nil,
+				distance: "",
+			},
+			want: want{
+				want: New("failed to set distance type "),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrFailedToSetDistanceType(test.args.err, test.args.distance)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrFailedToSetObjectType(t *testing.T) {
+	type args struct {
+		err error
+		t   string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return wrapped ErrFailedToSetObjectType error when err is ngt error and t is 'Float'",
+			args: args{
+				err: New("ngt error"),
+				t:   "Float",
+			},
+			want: want{
+				want: New("failed to set object type Float: ngt error"),
+			},
+		},
+		{
+			name: "return wrapped ErrFailedToSetObjectType error when err is ngt error and t is empty",
+			args: args{
+				err: New("ngt error"),
+				t:   "",
+			},
+			want: want{
+				want: New("failed to set object type : ngt error"),
+			},
+		},
+		{
+			name: "return ErrFailedToSetObjectType error when err is nil and t is 'Float'",
+			args: args{
+				err: nil,
+				t:   "Float",
+			},
+			want: want{
+				want: New("failed to set object type Float"),
+			},
+		},
+		{
+			name: "return ErrFailedToSetObjectType error when err is nil and t is empty",
+			args: args{
+				err: nil,
+				t:   "",
+			},
+			want: want{
+				want: New("failed to set object type "),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrFailedToSetObjectType(test.args.err, test.args.t)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrFailedToSetDimension(t *testing.T) {
+	type args struct {
+		err error
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return wrapped ErrFailedToSetDimension error when err is ngt error",
+			args: args{
+				err: New("ngt error"),
+			},
+			want: want{
+				want: New("failed to set dimension: ngt error"),
+			},
+		},
+		{
+			name: "return ErrFailedToSetDimension error when err is nil",
+			args: args{
+				err: nil,
+			},
+			want: want{
+				want: New("failed to set dimension"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrFailedToSetDimension(test.args.err)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrFailedToSetCreationEdgeSize(t *testing.T) {
+	type args struct {
+		err error
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return wrapped ErrFailedToSetCreationEdgeSize error when err is ngt error",
+			args: args{
+				err: New("ngt error"),
+			},
+			want: want{
+				want: New("failed to set creation edge size: ngt error"),
+			},
+		},
+		{
+			name: "return ErrFailedToSetCreationEdgeSize error when err is ngt error",
+			args: args{
+				err: nil,
+			},
+			want: want{
+				want: New("failed to set creation edge size"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrFailedToSetCreationEdgeSize(test.args.err)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrFailedToSetSearchEdgeSize(t *testing.T) {
+	type args struct {
+		err error
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return wrapped ErrFailedToSetSearchEdgeSize error when err is ngt error",
+			args: args{
+				err: New("ngt error"),
+			},
+			want: want{
+				want: New("failed to set search edge size: ngt error"),
+			},
+		},
+		{
+			name: "return ErrFailedToSetSearchEdgeSize error when err is nil",
+			args: args{
+				err: nil,
+			},
+			want: want{
+				want: New("failed to set search edge size"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrFailedToSetSearchEdgeSize(test.args.err)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrUncommittedIndexExists(t *testing.T) {
+	type args struct {
+		num uint64
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		func() test {
+			return test{
+				name: "return ErrUncommittedIndexExists error when num is 100",
+				args: args{
+					num: 100,
+				},
+				want: want{
+					want: New("100 indexes are not committed"),
+				},
+			}
+		}(),
+
+		func() test {
+			return test{
+				name: "return ErrUncommittedIndexExists error when num is 0",
+				args: args{
+					num: 0,
+				},
+				want: want{
+					want: New("0 indexes are not committed"),
+				},
+			}
+		}(),
+		func() test {
+			var num uint64 = math.MaxUint64
+			return test{
+				name: "return ErrUncommittedIndexExists error when num is the maximum value of math.Uint64",
+				args: args{
+					num: num,
+				},
+				want: want{
+					want: Errorf("%d indexes are not committed", num),
+				},
+			}
+		}(),
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrUncommittedIndexExists(test.args.num)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrUncommittedIndexNotFound(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrUncommittedIndexNotFound error",
+			want: want{
+				want: New("uncommitted indexes are not found"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrUncommittedIndexNotFound
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrCAPINotImplemented(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrCAPINotImplemented error",
+			want: want{
+				want: New("not implemented in C API"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrCAPINotImplemented
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrUUIDAlreadyExists(t *testing.T) {
+	type args struct {
+		uuid string
+		oid  uint
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrUUIDAlreadyExists error when uuid is '550e8400-e29b-41d4' and oid is 100",
+			args: args{
+				uuid: "550e8400-e29b-41d4",
+				oid:  100,
+			},
+			want: want{
+				want: New("ngt uuid 550e8400-e29b-41d4 object id 100 already exists "),
+			},
+		},
+		{
+			name: "return ErrUUIDAlreadyExists error when uuid is empty and oid is 100",
+			args: args{
+				uuid: "",
+				oid:  100,
+			},
+			want: want{
+				want: New("ngt uuid  object id 100 already exists "),
+			},
+		},
+		{
+			name: "return ErrUUIDAlreadyExists error when uuid is '550e8400-e29b-41d4' and oid is maximum value of math.Uint64",
+			args: args{
+				uuid: "550e8400-e29b-41d4",
+				oid:  uint(math.MaxUint64),
+			},
+			want: want{
+				want: Errorf("ngt uuid 550e8400-e29b-41d4 object id %d already exists ", uint(math.MaxUint64)),
+			},
+		},
+		{
+			name: "return ErrUUIDAlreadyExists error when uuid is empty and oid is 0",
+			args: args{
+				uuid: "",
+				oid:  0,
+			},
+			want: want{
+				want: New("ngt uuid  object id 0 already exists "),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrUUIDAlreadyExists(test.args.uuid, test.args.oid)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrUUIDNotFound(t *testing.T) {
+	type args struct {
+		id uint32
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrUUIDNotFound error when id is 1234",
+			args: args{
+				id: 1234,
+			},
+			want: want{
+				want: New("ngt object uuid 1234's metadata not found"),
+			},
+		},
+		{
+			name: "return ErrUUIDNotFound error when id is maximum value of math.Uint32",
+			args: args{
+				id: math.MaxUint32,
+			},
+			want: want{
+				want: Errorf("ngt object uuid %d's metadata not found", math.MaxUint32),
+			},
+		},
+		{
+			name: "return ErrUUIDNotFound error when id is 0",
+			args: args{
+				id: 0,
+			},
+			want: want{
+				want: New("ngt object uuid not found"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrUUIDNotFound(test.args.id)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrObjectIDNotFound(t *testing.T) {
+	type args struct {
+		uuid string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrObjectIDNotFound error when uuid is '550e8400-e29b-41d4'",
+			args: args{
+				uuid: "550e8400-e29b-41d4",
+			},
+			want: want{
+				want: New("ngt uuid 550e8400-e29b-41d4's object id not found"),
+			},
+		},
+		{
+			name: "return ErrObjectIDNotFound error when uuid is empty",
+			args: args{
+				uuid: "",
+			},
+			want: want{
+				want: New("ngt uuid 's object id not found"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrObjectIDNotFound(test.args.uuid)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrObjectNotFound(t *testing.T) {
+	type args struct {
+		err  error
+		uuid string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return wrapped ErrObjectNotFound error when err is ngt error and uuid is '550e8400-e29b-41d4'",
+			args: args{
+				err:  New("ngt error"),
+				uuid: "550e8400-e29b-41d4",
+			},
+			want: want{
+				want: New("ngt uuid 550e8400-e29b-41d4's object not found: ngt error"),
+			},
+		},
+		{
+			name: "return wrapped ErrObjectNotFound error when err is ngt error and uuid is empty",
+			args: args{
+				err:  New("ngt error"),
+				uuid: "",
+			},
+			want: want{
+				want: New("ngt uuid 's object not found: ngt error"),
+			},
+		},
+		{
+			name: "return ErrObjectNotFound error when err is nil and uuid is '550e8400-e29b-41d4'",
+			args: args{
+				err:  nil,
+				uuid: "550e8400-e29b-41d4",
+			},
+			want: want{
+				want: New("ngt uuid 550e8400-e29b-41d4's object not found"),
+			},
+		},
+		{
+			name: "return ErrObjectNotFound error when err is nil and uuid is empty",
+			args: args{
+				err:  nil,
+				uuid: "",
+			},
+			want: want{
+				want: New("ngt uuid 's object not found"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrObjectNotFound(test.args.err, test.args.uuid)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrRemoveRequestedBeforeIndexing(t *testing.T) {
+	type args struct {
+		oid uint
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrRemoveRequestedBeforeIndexing error when oid is 100",
+			args: args{
+				oid: 100,
+			},
+			want: want{
+				want: New("object id 100 is not indexed we cannot remove it"),
+			},
+		},
+		{
+			name: "return ErrRemoveRequestedBeforeIndexing error when oid is 0",
+			args: args{
+				oid: 0,
+			},
+			want: want{
+				want: New("object id 0 is not indexed we cannot remove it"),
+			},
+		},
+		{
+			name: "return ErrRemoveRequestedBeforeIndexing error when oid is maximum value of uint",
+			args: args{
+				oid: uint(math.MaxUint64),
+			},
+			want: want{
+				want: Errorf("object id %d is not indexed we cannot remove it", uint(math.MaxUint64)),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrRemoveRequestedBeforeIndexing(test.args.oid)
 			if err := test.checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/errors/ngt_test.go
+++ b/internal/errors/ngt_test.go
@@ -208,7 +208,7 @@ func TestErrDimensionLimitExceed(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrDimensionLimitExceed error when current and limit are the minimum value of math.Int64",
+			name: "return ErrDimensionLimitExceed error when current and limit are the minimum value of int",
 			args: args{
 				current: int(math.MinInt64),
 				limit:   int(math.MinInt64),
@@ -218,7 +218,7 @@ func TestErrDimensionLimitExceed(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrDimensionLimitExceed error when current and limit are the maximum value of math.Int64",
+			name: "return ErrDimensionLimitExceed error when current and limit are the maximum value of int",
 			args: args{
 				current: int(math.MaxInt64),
 				limit:   int(math.MaxInt64),
@@ -605,7 +605,7 @@ func TestErrFailedToSetCreationEdgeSize(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrFailedToSetCreationEdgeSize error when err is ngt error",
+			name: "return ErrFailedToSetCreationEdgeSize error when err is nil",
 			args: args{
 				err: nil,
 			},
@@ -745,7 +745,7 @@ func TestErrUncommittedIndexExists(t *testing.T) {
 		func() test {
 			var num uint64 = math.MaxUint64
 			return test{
-				name: "return ErrUncommittedIndexExists error when num is the maximum value of math.Uint64",
+				name: "return ErrUncommittedIndexExists error when num is the maximum value of uint64",
 				args: args{
 					num: num,
 				},
@@ -912,7 +912,7 @@ func TestErrUUIDAlreadyExists(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrUUIDAlreadyExists error when uuid is '550e8400-e29b-41d4' and oid is maximum value of math.Uint64",
+			name: "return ErrUUIDAlreadyExists error when uuid is '550e8400-e29b-41d4' and oid is the maximum value of uint64",
 			args: args{
 				uuid: "550e8400-e29b-41d4",
 				oid:  uint(math.MaxUint64),
@@ -985,7 +985,7 @@ func TestErrUUIDNotFound(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrUUIDNotFound error when id is maximum value of math.Uint32",
+			name: "return ErrUUIDNotFound error when id is the maximum value of uint32",
 			args: args{
 				id: math.MaxUint32,
 			},

--- a/internal/errors/ngt_test.go
+++ b/internal/errors/ngt_test.go
@@ -1,1 +1,342 @@
 package errors
+
+import (
+	"math"
+	"testing"
+)
+
+func TestErrCreateProperty(t *testing.T) {
+	type args struct {
+		err error
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return wrapped ErrCreateProperty error when the err is ngt error",
+			args: args{
+				err: New("ngt error"),
+			},
+			want: want{
+				want: New("failed to create property: ngt error"),
+			},
+		},
+		{
+			name: "return ErrCreateProperty error when the err is nil",
+			args: args{
+				err: nil,
+			},
+			want: want{
+				want: New("failed to create property"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrCreateProperty(test.args.err)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrIndexNotFound(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrIndexNotFound error",
+			want: want{
+				want: New("index file not found"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrIndexNotFound
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrIndexLoadTimeout(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrIndexLoadTimeout error",
+			want: want{
+				want: New("index load timeout"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrIndexLoadTimeout
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrInvalidDimensionSize(t *testing.T) {
+
+}
+
+func TestErrDimensionLimitExceed(t *testing.T) {
+	type args struct {
+		current int
+		limit   int
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrDimensionLimitExceed error when current is 10 and limit is 5",
+			args: args{
+				current: 10,
+				limit:   5,
+			},
+			want: want{
+				want: New("supported dimension limit exceed:\trequired = 10,\tlimit = 5"),
+			},
+		},
+
+		{
+			name: "return ErrDimensionLimitExceed error when current is 0 and limit is 0",
+			args: args{
+				current: 0,
+				limit:   0,
+			},
+			want: want{
+				want: New("supported dimension limit exceed:\trequired = 0,\tlimit = 0"),
+			},
+		},
+		{
+			name: "return ErrDimensionLimitExceed error when current is 0 and limit is 0",
+			args: args{
+				current: int(math.MinInt64),
+				limit:   int(math.MinInt64),
+			},
+			want: want{
+				want: Errorf("supported dimension limit exceed:\trequired = %d,\tlimit = %d", int(math.MinInt64), int(math.MinInt64)),
+			},
+		},
+		{
+			name: "return ErrDimensionLimitExceed error when current is 0 and limit is 0",
+			args: args{
+				current: int(math.MaxInt64),
+				limit:   int(math.MaxInt64),
+			},
+			want: want{
+				want: Errorf("supported dimension limit exceed:\trequired = %d,\tlimit = %d", int(math.MaxInt64), int(math.MaxInt64)),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrDimensionLimitExceed(test.args.current, test.args.limit)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrUnsupportedObjectType(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrUnsupportedObjectType error",
+			want: want{
+				want: New("unsupported ObjectType"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrUnsupportedObjectType
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrUnsupportedDistanceType(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return ErrUnsupportedDistanceType error",
+			want: want{
+				want: New("unsupported DistanceType"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrUnsupportedDistanceType
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/errors/ngt_test.go
+++ b/internal/errors/ngt_test.go
@@ -571,7 +571,7 @@ func TestErrFailedToSetObjectType(t *testing.T) {
 			},
 		},
 		{
-			name: "return an ErrFailedToSetObjectType error when err is nil and t is Float",
+			name: "return an ErrFailedToSetObjectType error when err is nil and t is Int",
 			args: args{
 				err: nil,
 				t:   "Int",

--- a/internal/errors/ngt_test.go
+++ b/internal/errors/ngt_test.go
@@ -28,7 +28,7 @@ func TestErrCreateProperty(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return wrapped ErrCreateProperty error when err is ngt error",
+			name: "return a wrapped ErrCreateProperty error when err is ngt error",
 			args: args{
 				err: New("ngt error"),
 			},
@@ -37,7 +37,7 @@ func TestErrCreateProperty(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrCreateProperty error when err is nil",
+			name: "return an ErrCreateProperty error when err is nil",
 			args: args{
 				err: nil,
 			},
@@ -86,7 +86,7 @@ func TestErrIndexNotFound(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return ErrIndexNotFound error",
+			name: "return an ErrIndexNotFound error",
 			want: want{
 				want: New("index file not found"),
 			},
@@ -132,7 +132,7 @@ func TestErrIndexLoadTimeout(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return ErrIndexLoadTimeout error",
+			name: "return an ErrIndexLoadTimeout error",
 			want: want{
 				want: New("index load timeout"),
 			},
@@ -183,7 +183,7 @@ func TestErrInvalidDimensionSize(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return ErrInvalidDimensionSize error when current is 10 and limit is 5",
+			name: "return an ErrInvalidDimensionSize error when current is 10 and limit is 5",
 			args: args{
 				current: 10,
 				limit:   5,
@@ -193,7 +193,7 @@ func TestErrInvalidDimensionSize(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrInvalidDimensionSize error when current is 0 and limit is 5",
+			name: "return an ErrInvalidDimensionSize error when current is 0 and limit is 5",
 			args: args{
 				current: 0,
 				limit:   5,
@@ -203,7 +203,7 @@ func TestErrInvalidDimensionSize(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrInvalidDimensionSize error when current is 10 and limit is 0",
+			name: "return an ErrInvalidDimensionSize error when current is 10 and limit is 0",
 			args: args{
 				current: 10,
 				limit:   0,
@@ -213,7 +213,7 @@ func TestErrInvalidDimensionSize(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrInvalidDimensionSize error when current is 0 and limit is 0",
+			name: "return an ErrInvalidDimensionSize error when current is 0 and limit is 0",
 			args: args{
 				current: 0,
 				limit:   0,
@@ -223,7 +223,7 @@ func TestErrInvalidDimensionSize(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrInvalidDimensionSize error when current and limit are the minimum value of int",
+			name: "return an ErrInvalidDimensionSize error when current and limit are the minimum value of int",
 			args: args{
 				current: int(math.MinInt64),
 				limit:   int(math.MinInt64),
@@ -233,7 +233,7 @@ func TestErrInvalidDimensionSize(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrInvalidDimensionSize error when current and limit are the minimum value of int",
+			name: "return an ErrInvalidDimensionSize error when current and limit are the minimum value of int",
 			args: args{
 				current: int(math.MaxInt64),
 				limit:   int(math.MaxInt64),
@@ -288,7 +288,7 @@ func TestErrDimensionLimitExceed(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return ErrDimensionLimitExceed error when current is 10 and limit is 5",
+			name: "return an ErrDimensionLimitExceed error when current is 10 and limit is 5",
 			args: args{
 				current: 10,
 				limit:   5,
@@ -299,7 +299,7 @@ func TestErrDimensionLimitExceed(t *testing.T) {
 		},
 
 		{
-			name: "return ErrDimensionLimitExceed error when current is 0 and limit is 0",
+			name: "return an ErrDimensionLimitExceed error when current is 0 and limit is 0",
 			args: args{
 				current: 0,
 				limit:   0,
@@ -309,7 +309,7 @@ func TestErrDimensionLimitExceed(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrDimensionLimitExceed error when current and limit are the minimum value of int",
+			name: "return an ErrDimensionLimitExceed error when current and limit are the minimum value of int",
 			args: args{
 				current: int(math.MinInt64),
 				limit:   int(math.MinInt64),
@@ -319,7 +319,7 @@ func TestErrDimensionLimitExceed(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrDimensionLimitExceed error when current and limit are the maximum value of int",
+			name: "return an ErrDimensionLimitExceed error when current and limit are the maximum value of int",
 			args: args{
 				current: int(math.MaxInt64),
 				limit:   int(math.MaxInt64),
@@ -369,7 +369,7 @@ func TestErrUnsupportedObjectType(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return ErrUnsupportedObjectType error",
+			name: "return an ErrUnsupportedObjectType error",
 			want: want{
 				want: New("unsupported ObjectType"),
 			},
@@ -466,7 +466,7 @@ func TestErrFailedToSetDistanceType(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return wrapped ErrFailedToSetDistanceType error when err is ngt error and distance is 'l2'",
+			name: "return a wrapped ErrFailedToSetDistanceType error when err is ngt error and distance is l2",
 			args: args{
 				err:      New("ngt error"),
 				distance: "l2",
@@ -476,7 +476,7 @@ func TestErrFailedToSetDistanceType(t *testing.T) {
 			},
 		},
 		{
-			name: "return wrapped ErrFailedToSetDistanceType error when err is ngt error and distance is empty",
+			name: "return a wrapped ErrFailedToSetDistanceType error when err is ngt error and distance is empty",
 			args: args{
 				err:      New("ngt error"),
 				distance: "",
@@ -486,17 +486,17 @@ func TestErrFailedToSetDistanceType(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrFailedToSetDistanceType error when err is nil and distance is 'l2'",
+			name: "return an ErrFailedToSetDistanceType error when err is nil and distance is cos",
 			args: args{
 				err:      nil,
-				distance: "l2",
+				distance: "cos",
 			},
 			want: want{
-				want: New("failed to set distance type l2"),
+				want: New("failed to set distance type cos"),
 			},
 		},
 		{
-			name: "return ErrFailedToSetDistanceType error when err is nil and distance is empty",
+			name: "return an ErrFailedToSetDistanceType error when err is nil and distance is empty",
 			args: args{
 				err:      nil,
 				distance: "",
@@ -551,7 +551,7 @@ func TestErrFailedToSetObjectType(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return wrapped ErrFailedToSetObjectType error when err is ngt error and t is 'Float'",
+			name: "return a wrapped ErrFailedToSetObjectType error when err is ngt error and t is Float",
 			args: args{
 				err: New("ngt error"),
 				t:   "Float",
@@ -561,7 +561,7 @@ func TestErrFailedToSetObjectType(t *testing.T) {
 			},
 		},
 		{
-			name: "return wrapped ErrFailedToSetObjectType error when err is ngt error and t is empty",
+			name: "return a wrapped ErrFailedToSetObjectType error when err is ngt error and t is empty",
 			args: args{
 				err: New("ngt error"),
 				t:   "",
@@ -571,17 +571,17 @@ func TestErrFailedToSetObjectType(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrFailedToSetObjectType error when err is nil and t is 'Float'",
+			name: "return an ErrFailedToSetObjectType error when err is nil and t is Float",
 			args: args{
 				err: nil,
-				t:   "Float",
+				t:   "Int",
 			},
 			want: want{
-				want: New("failed to set object type Float"),
+				want: New("failed to set object type Int"),
 			},
 		},
 		{
-			name: "return ErrFailedToSetObjectType error when err is nil and t is empty",
+			name: "return an ErrFailedToSetObjectType error when err is nil and t is empty",
 			args: args{
 				err: nil,
 				t:   "",
@@ -697,7 +697,7 @@ func TestErrFailedToSetCreationEdgeSize(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return wrapped ErrFailedToSetCreationEdgeSize error when err is ngt error",
+			name: "return a wrapped ErrFailedToSetCreationEdgeSize error when err is ngt error",
 			args: args{
 				err: New("ngt error"),
 			},
@@ -706,7 +706,7 @@ func TestErrFailedToSetCreationEdgeSize(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrFailedToSetCreationEdgeSize error when err is nil",
+			name: "return an ErrFailedToSetCreationEdgeSize error when err is nil",
 			args: args{
 				err: nil,
 			},
@@ -759,7 +759,7 @@ func TestErrFailedToSetSearchEdgeSize(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return wrapped ErrFailedToSetSearchEdgeSize error when err is ngt error",
+			name: "return a wrapped ErrFailedToSetSearchEdgeSize error when err is ngt error",
 			args: args{
 				err: New("ngt error"),
 			},
@@ -768,7 +768,7 @@ func TestErrFailedToSetSearchEdgeSize(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrFailedToSetSearchEdgeSize error when err is nil",
+			name: "return an ErrFailedToSetSearchEdgeSize error when err is nil",
 			args: args{
 				err: nil,
 			},
@@ -821,7 +821,7 @@ func TestErrUncommittedIndexExists(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return ErrUncommittedIndexExists error when num is 100",
+			name: "return an ErrUncommittedIndexExists error when num is 100",
 			args: args{
 				num: 100,
 			},
@@ -831,7 +831,7 @@ func TestErrUncommittedIndexExists(t *testing.T) {
 		},
 
 		{
-			name: "return ErrUncommittedIndexExists error when num is 0",
+			name: "return an ErrUncommittedIndexExists error when num is 0",
 			args: args{
 				num: 0,
 			},
@@ -840,7 +840,7 @@ func TestErrUncommittedIndexExists(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrUncommittedIndexExists error when num is the maximum value of uint64",
+			name: "return an ErrUncommittedIndexExists error when num is the maximum value of uint64",
 			args: args{
 				num: math.MaxUint64,
 			},
@@ -986,7 +986,7 @@ func TestErrUUIDAlreadyExists(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return ErrUUIDAlreadyExists error when uuid is '550e8400-e29b-41d4' and oid is 100",
+			name: "return an ErrUUIDAlreadyExists error when uuid is 550e8400-e29b-41d4 and oid is 100",
 			args: args{
 				uuid: "550e8400-e29b-41d4",
 				oid:  100,
@@ -996,7 +996,7 @@ func TestErrUUIDAlreadyExists(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrUUIDAlreadyExists error when uuid is empty and oid is 100",
+			name: "return an ErrUUIDAlreadyExists error when uuid is empty and oid is 100",
 			args: args{
 				uuid: "",
 				oid:  100,
@@ -1006,7 +1006,7 @@ func TestErrUUIDAlreadyExists(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrUUIDAlreadyExists error when uuid is '550e8400-e29b-41d4' and oid is the maximum value of uint64",
+			name: "return an ErrUUIDAlreadyExists error when uuid is 550e8400-e29b-41d4 and oid is the maximum value of uint64",
 			args: args{
 				uuid: "550e8400-e29b-41d4",
 				oid:  uint(math.MaxUint64),
@@ -1016,7 +1016,7 @@ func TestErrUUIDAlreadyExists(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrUUIDAlreadyExists error when uuid is empty and oid is 0",
+			name: "return an ErrUUIDAlreadyExists error when uuid is empty and oid is 0",
 			args: args{
 				uuid: "",
 				oid:  0,
@@ -1070,7 +1070,7 @@ func TestErrUUIDNotFound(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return ErrUUIDNotFound error when id is 1234",
+			name: "return an ErrUUIDNotFound error when id is 1234",
 			args: args{
 				id: 1234,
 			},
@@ -1079,7 +1079,7 @@ func TestErrUUIDNotFound(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrUUIDNotFound error when id is the maximum value of uint32",
+			name: "return an ErrUUIDNotFound error when id is the maximum value of uint32",
 			args: args{
 				id: math.MaxUint32,
 			},
@@ -1088,7 +1088,7 @@ func TestErrUUIDNotFound(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrUUIDNotFound error when id is 0",
+			name: "return an ErrUUIDNotFound error when id is 0",
 			args: args{
 				id: 0,
 			},
@@ -1141,7 +1141,7 @@ func TestErrObjectIDNotFound(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return ErrObjectIDNotFound error when uuid is '550e8400-e29b-41d4'",
+			name: "return an ErrObjectIDNotFound error when uuid is 550e8400-e29b-41d4.",
 			args: args{
 				uuid: "550e8400-e29b-41d4",
 			},
@@ -1150,7 +1150,7 @@ func TestErrObjectIDNotFound(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrObjectIDNotFound error when uuid is empty",
+			name: "return an ErrObjectIDNotFound error when uuid is empty.",
 			args: args{
 				uuid: "",
 			},
@@ -1204,7 +1204,7 @@ func TestErrObjectNotFound(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return wrapped ErrObjectNotFound error when err is ngt error and uuid is '550e8400-e29b-41d4'",
+			name: "return a wrapped ErrObjectNotFound error when err is ngt error and uuid is 550e8400-e29b-41d4",
 			args: args{
 				err:  New("ngt error"),
 				uuid: "550e8400-e29b-41d4",
@@ -1214,7 +1214,7 @@ func TestErrObjectNotFound(t *testing.T) {
 			},
 		},
 		{
-			name: "return wrapped ErrObjectNotFound error when err is ngt error and uuid is empty",
+			name: "return a wrapped ErrObjectNotFound error when err is ngt error and uuid is empty",
 			args: args{
 				err:  New("ngt error"),
 				uuid: "",
@@ -1224,7 +1224,7 @@ func TestErrObjectNotFound(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrObjectNotFound error when err is nil and uuid is '550e8400-e29b-41d4'",
+			name: "return an ErrObjectNotFound error when err is nil and uuid is 550e8400-e29b-41d4",
 			args: args{
 				err:  nil,
 				uuid: "550e8400-e29b-41d4",
@@ -1234,7 +1234,7 @@ func TestErrObjectNotFound(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrObjectNotFound error when err is nil and uuid is empty",
+			name: "return an ErrObjectNotFound error when err is nil and uuid is empty",
 			args: args{
 				err:  nil,
 				uuid: "",
@@ -1288,7 +1288,7 @@ func TestErrRemoveRequestedBeforeIndexing(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return ErrRemoveRequestedBeforeIndexing error when oid is 100",
+			name: "return an ErrRemoveRequestedBeforeIndexing error when oid is 100",
 			args: args{
 				oid: 100,
 			},
@@ -1297,7 +1297,7 @@ func TestErrRemoveRequestedBeforeIndexing(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrRemoveRequestedBeforeIndexing error when oid is 0",
+			name: "return an ErrRemoveRequestedBeforeIndexing error when oid is 0",
 			args: args{
 				oid: 0,
 			},
@@ -1306,7 +1306,7 @@ func TestErrRemoveRequestedBeforeIndexing(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrRemoveRequestedBeforeIndexing error when oid is maximum value of uint",
+			name: "return an ErrRemoveRequestedBeforeIndexing error when oid is maximum value of uint",
 			args: args{
 				oid: uint(math.MaxUint64),
 			},

--- a/internal/errors/ngt_test.go
+++ b/internal/errors/ngt_test.go
@@ -415,7 +415,7 @@ func TestErrUnsupportedDistanceType(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return ErrUnsupportedDistanceType error",
+			name: "return an ErrUnsupportedDistanceType error",
 			want: want{
 				want: New("unsupported DistanceType"),
 			},
@@ -635,7 +635,7 @@ func TestErrFailedToSetDimension(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return wrapped ErrFailedToSetDimension error when err is ngt error",
+			name: "return a wrapped ErrFailedToSetDimension error when err is ngt error",
 			args: args{
 				err: New("ngt error"),
 			},
@@ -644,7 +644,7 @@ func TestErrFailedToSetDimension(t *testing.T) {
 			},
 		},
 		{
-			name: "return ErrFailedToSetDimension error when err is nil",
+			name: "return an ErrFailedToSetDimension error when err is nil",
 			args: args{
 				err: nil,
 			},
@@ -889,7 +889,7 @@ func TestErrUncommittedIndexNotFound(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return ErrUncommittedIndexNotFound error",
+			name: "return an ErrUncommittedIndexNotFound error",
 			want: want{
 				want: New("uncommitted indexes are not found"),
 			},
@@ -935,7 +935,7 @@ func TestErrCAPINotImplemented(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return ErrCAPINotImplemented error",
+			name: "return an ErrCAPINotImplemented error",
 			want: want{
 				want: New("not implemented in C API"),
 			},

--- a/internal/errors/ngt_test.go
+++ b/internal/errors/ngt_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright (C) 2019-2021 vdaas.org vald team <vald@vdaas.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package errors
 
 import (


### PR DESCRIPTION
Signed-off-by: hlts2 <hiroto.funakoshi.hiroto@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

I added the test cases for internal/errors/ngt.go and comments and refactored implementation code.

#### refactor
- WHY
The output of following code is `ngt object uuid not found%!(EXTRA uint32=0)` .
https://github.com/vdaas/vald/blob/master/internal/errors/ngt.go#L85

- WHAT

I changed from `Errorf` to `New`
And I searched for code that uses this implementation. 
According to the results of the investigation, this fix had no effect.
https://github.com/vdaas/vald/search?q=ErrUUIDNotFound

The following is a handler that uses `insert` and` delete` in the above result, but it is not affected by the wording correction.

handler of `Insert`
- https://github.com/vdaas/vald/blob/5c914a2fa02fd0b128fbf24933523dd79d1a31ee/pkg/agent/core/ngt/handler/grpc/handler.go#L282

handler of `Delete`
- https://github.com/vdaas/vald/blob/5c914a2fa02fd0b128fbf24933523dd79d1a31ee/pkg/agent/core/ngt/handler/grpc/handler.go#L526

**grammar check passed**

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.15.6
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
