### PR TITLE
Fix invalid data loading code in example

### DIFF
--- a/example/client/agent/main.go
+++ b/example/client/agent/main.go
@@ -171,7 +171,7 @@ func load(path string) (ids []string, train, test [][]float32, err error) {
 		row, dim := int(dims[0]), int(dims[1])
 
 		// Gets the stored vector. All are represented as one-dimensional arrays.
-		vec := make([]float64, sp.SimpleExtentNPoints())
+		vec := make([]float32, sp.SimpleExtentNPoints())
 		if err := d.Read(&vec); err != nil {
 			return nil, err
 		}

--- a/example/client/agent/main.go
+++ b/example/client/agent/main.go
@@ -171,6 +171,8 @@ func load(path string) (ids []string, train, test [][]float32, err error) {
 		row, dim := int(dims[0]), int(dims[1])
 
 		// Gets the stored vector. All are represented as one-dimensional arrays.
+		// The type of the slice depends on your dataset.
+		// For fashion-mnist-784-euclidean.hdf5, the datatype is float32.
 		vec := make([]float32, sp.SimpleExtentNPoints())
 		if err := d.Read(&vec); err != nil {
 			return nil, err

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -153,6 +153,8 @@ func load(path string) (ids []string, train, test [][]float32, err error) {
 		row, dim := int(dims[0]), int(dims[1])
 
 		// Gets the stored vector. All are represented as one-dimensional arrays.
+		// The type of the slice depends on your dataset.
+		// For fashion-mnist-784-euclidean.hdf5, the datatype is float32.
 		vec := make([]float32, sp.SimpleExtentNPoints())
 		if err := d.Read(&vec); err != nil {
 			return nil, err

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -153,7 +153,7 @@ func load(path string) (ids []string, train, test [][]float32, err error) {
 		row, dim := int(dims[0]), int(dims[1])
 
 		// Gets the stored vector. All are represented as one-dimensional arrays.
-		vec := make([]float64, sp.SimpleExtentNPoints())
+		vec := make([]float32, sp.SimpleExtentNPoints())
 		if err := d.Read(&vec); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
I fixed the invalid data loading code in example/main.go.
I've already mentioned about it a month ago, but it's not fixed yet.
https://github.com/vdaas/vald/projects/4#card-51586276

HDF5 formatted data of fashion-mnist has its data as float32 values. So it should be loaded as float32.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
nothing

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
nothing

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.15.7
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.13.1

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
