### PR TITLE
add internal/errors/redis test

### DIFF
--- a/internal/errors/redis.go
+++ b/internal/errors/redis.go
@@ -23,7 +23,7 @@ var (
 	ErrRedisInvalidKVVKPrefix = func(kv, vk string) error {
 		return Errorf("kv index and vk prefix must be defferent.\t(kv: %s,\tvk: %s)", kv, vk)
 	}
-	
+
 	// NewErrRedisNotFoundIdentity represents a function to generate an ErrRedisNotFoundIdentity error.
 	NewErrRedisNotFoundIdentity = func() error {
 		return &ErrRedisNotFoundIdentity{
@@ -31,12 +31,12 @@ var (
 		}
 	}
 
-	// ErrRedisNotFound represents a function to wrap redis key not found error and err.
+	// ErrRedisNotFound represents a function to wrap Redis key not found error and err.
 	ErrRedisNotFound = func(key string) error {
 		return Wrapf(NewErrRedisNotFoundIdentity(), "error redis key '%s' not found", key)
 	}
 
-	// ErrRedisInvalidOption generates a new error of redis invalid option.
+	// ErrRedisInvalidOption generates a new error of Redis invalid option.
 	ErrRedisInvalidOption = New("error redis invalid option")
 
 	// ErrRedisGetOperationFailed represents a function to wrap failed to fetch key error and err.
@@ -62,10 +62,11 @@ var (
 	// ErrRedisAddrsNotFound generates a new error of address not found.
 	ErrRedisAddrsNotFound = New("error redis addrs not found")
 
-	// ErrRedisConnectionPingFailed generates a new error of redis connection ping failed.
+	// ErrRedisConnectionPingFailed generates a new error of Redis connection ping failed.
 	ErrRedisConnectionPingFailed = New("error redis connection ping failed")
 )
 
+// ErrRedisNotFoundIdentity represents a struct that includes err and has method for Redis error handling.
 type ErrRedisNotFoundIdentity struct {
 	err error
 }

--- a/internal/errors/redis.go
+++ b/internal/errors/redis.go
@@ -66,7 +66,7 @@ var (
 	ErrRedisConnectionPingFailed = New("error redis connection ping failed")
 )
 
-// ErrRedisNotFoundIdentity represents a struct that includes err and has method for Redis error handling.
+// ErrRedisNotFoundIdentity represents a struct that includes err and has a method for Redis error handling.
 type ErrRedisNotFoundIdentity struct {
 	err error
 }

--- a/internal/errors/redis.go
+++ b/internal/errors/redis.go
@@ -19,56 +19,71 @@ package errors
 
 var (
 
-	// Redis.
+	// ErrRedisInvalidKVVKPrefix represents a function to generate an error that kv index and vk prefix are invalid.
 	ErrRedisInvalidKVVKPrefix = func(kv, vk string) error {
 		return Errorf("kv index and vk prefix must be defferent.\t(kv: %s,\tvk: %s)", kv, vk)
 	}
-
+	
+	// NewErrRedisNotFoundIdentity represents a function to generate an ErrRedisNotFoundIdentity error.
 	NewErrRedisNotFoundIdentity = func() error {
 		return &ErrRedisNotFoundIdentity{
 			err: New("error redis entry not found"),
 		}
 	}
 
+	// ErrRedisNotFound represents a function to wrap redis key not found error and err.
 	ErrRedisNotFound = func(key string) error {
 		return Wrapf(NewErrRedisNotFoundIdentity(), "error redis key '%s' not found", key)
 	}
 
+	// ErrRedisInvalidOption generates a new error of redis invalid option.
 	ErrRedisInvalidOption = New("error redis invalid option")
 
+	// ErrRedisGetOperationFailed represents a function to wrap failed to fetch key error and err.
 	ErrRedisGetOperationFailed = func(key string, err error) error {
 		return Wrapf(err, "Failed to fetch key (%s)", key)
 	}
 
+	// ErrRedisSetOperationFailed represents a function to wrap failed to set key error and err.
 	ErrRedisSetOperationFailed = func(key string, err error) error {
 		return Wrapf(err, "Failed to set key (%s)", key)
 	}
 
+	// ErrRedisSetOperationFailed represents a function to wrap failed to delete key error and err.
 	ErrRedisDeleteOperationFailed = func(key string, err error) error {
 		return Wrapf(err, "Failed to delete key (%s)", key)
 	}
 
+	// ErrRedisSetOperationFailed represents a function to generate an error that invalid configuration version.
 	ErrInvalidConfigVersion = func(cur, con string) error {
 		return Errorf("invalid config version %s not satisfies version constraints %s", cur, con)
 	}
 
-	ErrRedisAddrsNotFound = New("addrs not found")
+	// ErrRedisAddrsNotFound generates a new error of address not found.
+	ErrRedisAddrsNotFound = New("error redis addrs not found")
 
-	ErrRedisConnectionPingFailed = New("error Redis connection ping failed")
+	// ErrRedisConnectionPingFailed generates a new error of redis connection ping failed.
+	ErrRedisConnectionPingFailed = New("error redis connection ping failed")
 )
 
 type ErrRedisNotFoundIdentity struct {
 	err error
 }
 
+// Error returns the string of ErrRedisNotFoundIdentity.error.
 func (e *ErrRedisNotFoundIdentity) Error() string {
-	return e.err.Error()
+	if e.err != nil {
+		return e.err.Error()
+	}
+	return ""
 }
 
+// Unwrap returns the error value of ErrRedisNotFoundIdentity.
 func (e *ErrRedisNotFoundIdentity) Unwrap() error {
 	return e.err
 }
 
+// IsErrRedisNotFound compares the input error and ErrRedisNotFoundIdentity.error and returns true or false that is the result of errors.As.
 func IsErrRedisNotFound(err error) bool {
 	target := new(ErrRedisNotFoundIdentity)
 	return As(err, &target)

--- a/internal/errors/redis_test.go
+++ b/internal/errors/redis_test.go
@@ -872,7 +872,7 @@ func TestIsErrRedisNotFound(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return false when err is nil",
+			name: "return false when err is not ErrRedisNotFoundIdentity ",
 			args: args{
 				err: New("err: Redis not found identity"),
 			},

--- a/internal/errors/redis_test.go
+++ b/internal/errors/redis_test.go
@@ -24,6 +24,704 @@ import (
 	"go.uber.org/goleak"
 )
 
+func TestErrRedisInvalidKVVKPrefic(t *testing.T) {
+	type fields struct {
+		kv string
+		vk string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		fields     fields
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	const str = "vdaas"
+	tests := []test{
+		func() test {
+			return test{
+				name: "return an ErrRedisInvalidKVVKPrefix error when kv and vk are not empty",
+				fields: fields{
+					kv: str,
+					vk: str,
+				},
+				want: want{
+					want: Errorf("kv index and vk prefix must be defferent.\t(kv: %s,\tvk: %s)", str, str),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "return an ErrRedisInvalidKVVKPrefix error when kv is not empty and vk is empty",
+				fields: fields{
+					kv: str,
+				},
+				want: want{
+					want: Errorf("kv index and vk prefix must be defferent.\t(kv: %s,\tvk: %s)", str, ""),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "return an ErrRedisInvalidKVVKPrefix error when kv is not empty and vk is not empty",
+				fields: fields{
+					vk: str,
+				},
+				want: want{
+					want: Errorf("kv index and vk prefix must be defferent.\t(kv: %s,\tvk: %s)", "", str),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name:   "return an ErrRedisInvalidKVVKPrefix error when kv and vk are empty",
+				fields: fields{},
+				want: want{
+					want: Errorf("kv index and vk prefix must be defferent.\t(kv: %s,\tvk: %s)", "", ""),
+				},
+			}
+		}(),
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrRedisInvalidKVVKPrefix(test.fields.kv, test.fields.vk)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestNewErrRedisNotFoundIdentity(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		func() test {
+			return test{
+				name: "return an NewErrRedisNotFoundIdentity error",
+				want: want{
+					want: &ErrRedisNotFoundIdentity{
+						err: New("error redis entry not found"),
+					},
+				},
+			}
+		}(),
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := NewErrRedisNotFoundIdentity()
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrRdisNotFound(t *testing.T) {
+	type fields struct {
+		key string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		fields     fields
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return an ErrRedisNotFound error when key is not empty",
+			fields: fields{
+				key: "vdaas",
+			},
+			want: want{
+				want: Wrap(NewErrRedisNotFoundIdentity(), "error redis key 'vdaas' not found"),
+			},
+		},
+		{
+			name:   "return an ErrRedisNotFound error when key is empty",
+			fields: fields{},
+			want: want{
+				want: Wrap(NewErrRedisNotFoundIdentity(), "error redis key '' not found"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrRedisNotFound(test.fields.key)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrRedisInvalidOption(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return an ErrRedisInvalidOption error",
+			want: want{
+				want: New("error redis invalid option"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrRedisInvalidOption
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrRedisGetOperationFailed(t *testing.T) {
+	type fields struct {
+		key string
+		err error
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		fields     fields
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	const key = "vdaas"
+	err := New("redis error")
+	tests := []test{
+		func() test {
+			return test{
+				name: "return a wraped error when key is not empty and err is not nil",
+				fields: fields{
+					key: key,
+					err: err,
+				},
+				want: want{
+					want: Wrapf(err, "Failed to fetch key (%s)", key),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "return a wraped error when key is not empty and err is nil",
+				fields: fields{
+					key: key,
+				},
+				want: want{
+					want: Wrapf(nil, "Failed to fetch key (%s)", key),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "return a wraped error when key is empty and err is not nil",
+				fields: fields{
+					err: err,
+				},
+				want: want{
+					want: Wrap(err, "Failed to fetch key ()"),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name:   "return a wraped error when key is empty and err is nil",
+				fields: fields{},
+				want: want{
+					want: Wrap(nil, "Failed to fetch key ()"),
+				},
+			}
+		}(),
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrRedisGetOperationFailed(test.fields.key, test.fields.err)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrRedisSetOperationFailed(t *testing.T) {
+	type fields struct {
+		key string
+		err error
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		fields     fields
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	const key = "vdaas"
+	err := New("redis error")
+	tests := []test{
+		func() test {
+			return test{
+				name: "return a wraped error when key is not empty and err is not nil",
+				fields: fields{
+					key: key,
+					err: err,
+				},
+				want: want{
+					want: Wrapf(err, "Failed to set key (%s)", key),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "return a wraped error when key is not empty and err is nil",
+				fields: fields{
+					key: key,
+				},
+				want: want{
+					want: Wrapf(nil, "Failed to set key (%s)", key),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "return a wraped error when key is empty and err is not nil",
+				fields: fields{
+					err: err,
+				},
+				want: want{
+					want: Wrap(err, "Failed to set key ()"),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name:   "return a wraped error when key is empty and err is nil",
+				fields: fields{},
+				want: want{
+					want: Wrap(nil, "Failed to set key ()"),
+				},
+			}
+		}(),
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrRedisSetOperationFailed(test.fields.key, test.fields.err)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrRedisDeleteOperationFailed(t *testing.T) {
+	type fields struct {
+		key string
+		err error
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		fields     fields
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	const key = "vdaas"
+	err := New("redis error")
+	tests := []test{
+		func() test {
+			return test{
+				name: "return a wraped error when key is not empty and err is not nil",
+				fields: fields{
+					key: key,
+					err: err,
+				},
+				want: want{
+					want: Wrapf(err, "Failed to delete key (%s)", key),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "return a wraped error when key is not empty and err is nil",
+				fields: fields{
+					key: key,
+				},
+				want: want{
+					want: Wrapf(nil, "Failed to delete key (%s)", key),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "return a wraped error when key is empty and err is not nil",
+				fields: fields{
+					err: err,
+				},
+				want: want{
+					want: Wrap(err, "Failed to delete key ()"),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name:   "return a wraped error when key is empty and err is nil",
+				fields: fields{},
+				want: want{
+					want: Wrap(nil, "Failed to delete key ()"),
+				},
+			}
+		}(),
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrRedisDeleteOperationFailed(test.fields.key, test.fields.err)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrInvalidConfigVersion(t *testing.T) {
+	type fields struct {
+		cur string
+		con string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		fields     fields
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	const cur = "1.0.1"
+	const con = "1.1.0"
+	tests := []test{
+		func() test {
+			return test{
+				name: "return an config invalid error when cur and con are not empty",
+				fields: fields{
+					cur: cur,
+					con: con,
+				},
+				want: want{
+					want: Errorf("invalid config version %s not satisfies version constraints %s", cur, con),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "return an config invalid error when cur is empty and con is not empty",
+				fields: fields{
+					con: con,
+				},
+				want: want{
+					want: Errorf("invalid config version  not satisfies version constraints %s", con),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "return an config invalid error when cur is not empty and con is empty",
+				fields: fields{
+					cur: cur,
+				},
+				want: want{
+					want: Errorf("invalid config version %s not satisfies version constraints ", cur),
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "return an config invalid error when cur and con are empty",
+				fields: fields{
+				},
+				want: want{
+					want: New("invalid config version  not satisfies version constraints "),
+				},
+			}
+		}(),
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+			
+			got := ErrInvalidConfigVersion(test.fields.cur, test.fields.con)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrRedisAddrsNotFound(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return an ErrRedisAddrsNotFound error",
+			want: want{
+				want: New("error redis addrs not found"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrRedisAddrsNotFound
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrRedisConnectionPingFailed(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return an ErrRedisConnectionPingFailed error",
+			want: want{
+				want: New("error redis connection ping failed"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrRedisConnectionPingFailed
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
 func TestErrRedisNotFoundIdentity_Error(t *testing.T) {
 	type fields struct {
 		err error
@@ -46,31 +744,22 @@ func TestErrRedisNotFoundIdentity_Error(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           err: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           err: nil,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "Success when err is not nil",
+			fields: fields{
+				err: New("Not found identity"),
+			},
+			want: want{
+				want: "Not found identity",
+			},
+		},
+		{
+			name:   "Success when err is nil",
+			fields: fields{},
+			want: want{
+				want: "",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -89,75 +778,6 @@ func TestErrRedisNotFoundIdentity_Error(t *testing.T) {
 			}
 
 			got := e.Error()
-			if err := test.checkFunc(test.want, got); err != nil {
-				tt.Errorf("error = %v", err)
-			}
-		})
-	}
-}
-
-func TestIsErrRedisNotFound(t *testing.T) {
-	type args struct {
-		err error
-	}
-	type want struct {
-		want bool
-	}
-	type test struct {
-		name       string
-		args       args
-		want       want
-		checkFunc  func(want, bool) error
-		beforeFunc func(args)
-		afterFunc  func(args)
-	}
-	defaultCheckFunc := func(w want, got bool) error {
-		if !reflect.DeepEqual(got, w.want) {
-			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
-		}
-		return nil
-	}
-	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           err: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           err: nil,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(tt *testing.T) {
-			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
-			}
-			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
-			}
-			if test.checkFunc == nil {
-				test.checkFunc = defaultCheckFunc
-			}
-
-			got := IsErrRedisNotFound(test.args.err)
 			if err := test.checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -188,37 +808,27 @@ func TestErrRedisNotFoundIdentity_Unwrap(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           err: nil,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           err: nil,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name:   "returns nil when err is nil",
+			fields: fields{},
+			want:   want{},
+		},
+		{
+			name: "returns err when err is not nil",
+			fields: fields{
+				err: New("err: Redis not found identity"),
+			},
+			want: want{
+				err: New("err: Redis not found identity"),
+			},
+		},
 	}
 
-	for _, test := range tests {
+	for _, tc := range tests {
+		test := tc
 		t.Run(test.name, func(tt *testing.T) {
 			tt.Parallel()
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
@@ -234,6 +844,73 @@ func TestErrRedisNotFoundIdentity_Unwrap(t *testing.T) {
 
 			err := e.Unwrap()
 			if err := test.checkFunc(test.want, err); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestIsErrRedisNotFound(t *testing.T) {
+	type args struct {
+		err error
+	}
+	type want struct {
+		want bool
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, bool) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got bool) error {
+		if !reflect.DeepEqual(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return false when err is nil",
+			args: args{
+				err: New("err: Redis not found identity"),
+			},
+			want: want{},
+		},
+		{
+			name: "return false when err does not match ErrRedisNotFoundIdentity",
+			args: args{
+				err: &ErrRedisNotFoundIdentity{
+					err: New("err: Redis not found identity"),
+				},
+			},
+			want: want{
+				want: true,
+			},
+		},
+		{
+			name: "return false when err is nil",
+			args: args{},
+			want: want{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := IsErrRedisNotFound(test.args.err)
+			if err := test.checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
 		})

--- a/internal/errors/redis_test.go
+++ b/internal/errors/redis_test.go
@@ -600,9 +600,8 @@ func TestErrInvalidConfigVersion(t *testing.T) {
 		}(),
 		func() test {
 			return test{
-				name: "return an config invalid error when cur and con are empty",
-				fields: fields{
-				},
+				name:   "return an config invalid error when cur and con are empty",
+				fields: fields{},
 				want: want{
 					want: New("invalid config version  not satisfies version constraints "),
 				},
@@ -621,7 +620,7 @@ func TestErrInvalidConfigVersion(t *testing.T) {
 			if test.checkFunc == nil {
 				test.checkFunc = defaultCheckFunc
 			}
-			
+
 			got := ErrInvalidConfigVersion(test.fields.cur, test.fields.con)
 			if err := test.checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)


### PR DESCRIPTION
Signed-off-by: vankichi <kyukawa315@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
This PR includes the following changes:
  - add unit test for `internal/errors/redis`
  - add comment for each function of `internal/errros/redis.go`
 
**Grammar check has passed.**

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
