### PR TITLE
add io/ioutil test

### DIFF
--- a/internal/io/ioutil/ioutil.go
+++ b/internal/io/ioutil/ioutil.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vdaas/vald/internal/safety"
 )
 
+// ReadFile reads the file and returns the number of bytes read and any error encountered.
 func ReadFile(path string) ([]byte, error) {
 	f, err := os.OpenFile(path, os.O_RDONLY, os.ModePerm)
 	if err != nil {
@@ -39,7 +40,6 @@ func ReadFile(path string) ([]byte, error) {
 	}
 
 	buf := bytes.NewBuffer(make([]byte, 0, n))
-
 	err = safety.RecoverFunc(func() (err error) {
 		_, err = buf.ReadFrom(f)
 		return err

--- a/internal/io/ioutil/ioutil_test.go
+++ b/internal/io/ioutil/ioutil_test.go
@@ -19,11 +19,11 @@ package ioutil
 
 import (
 	"bytes"
-	"encoding/gob"
 	"os"
 	"reflect"
 	"testing"
 
+	"github.com/vdaas/vald/internal/compress/gob"
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/log"
 	"go.uber.org/goleak"
@@ -112,7 +112,7 @@ func TestReadFile(t *testing.T) {
 					want: func() []byte {
 						strs := genStr()
 						buf := &bytes.Buffer{}
-						gob.NewEncoder(buf).Encode(strs)
+						gob.New().NewEncoder(buf).Encode(strs)
 						return buf.Bytes()
 					}(),
 				},
@@ -124,7 +124,7 @@ func TestReadFile(t *testing.T) {
 					defer fp.Close()
 					strs := genStr()
 					buf := &bytes.Buffer{}
-					gob.NewEncoder(buf).Encode(strs)
+					gob.New().NewEncoder(buf).Encode(strs)
 					_, err = fp.Write(buf.Bytes())
 					if err != nil {
 						log.Error(err)

--- a/internal/io/ioutil/ioutil_test.go
+++ b/internal/io/ioutil/ioutil_test.go
@@ -37,14 +37,15 @@ func genStr() []string {
 	return str
 }
 
-func genNonPermittedFile(path string) {
+func genNonPermittedFile(t *testing.T, path string) {
+	t.Helper()
 	fp, err := os.Create(path)
 	if err != nil {
-		log.Error(err)
+		t.Fatal(err)
 	}
 	err = fp.Chmod(0333)
 	if err != nil {
-		log.Error(err)
+		t.Fatal(err)
 	}
 	defer fp.Close()
 }

--- a/internal/io/ioutil/ioutil_test.go
+++ b/internal/io/ioutil/ioutil_test.go
@@ -90,13 +90,13 @@ func TestReadFile(t *testing.T) {
 				beforeFunc: func(args) {
 					fp, err := os.Create(fName)
 					if err != nil {
-						log.Error(err)
+						t.Fatal(err)
 					}
 					defer fp.Close()
 				},
 				afterFunc: func(args) {
 					if err := os.Remove(fName); err != nil {
-						log.Error(err)
+						t.Fatal(err)
 					}
 				},
 			}
@@ -122,28 +122,28 @@ func TestReadFile(t *testing.T) {
 				beforeFunc: func(args) {
 					fp, err := os.Create(fName)
 					if err != nil {
-						log.Error(err)
+						t.Fatal(err)
 					}
 					strs := genStr()
 					buf := &bytes.Buffer{}
 					if err = gob.New().NewEncoder(buf).Encode(strs); err != nil {
-						log.Error(err)
+						t.Fatal(err)
 					}
 					if _, err = fp.Write(buf.Bytes()); err != nil {
-						log.Error(err)
+						t.Fatal(err)
 					}
 					defer fp.Close()
 				},
 				afterFunc: func(args) {
 					if err := os.Remove(fName); err != nil {
-						log.Error(err)
+						t.Fatal(err)
 					}
 				},
 			}
 		}(),
 		func() test {
 			fName := "cannot_read_ioutil_test.txt"
-			genNonPermittedFile(fName)
+			genNonPermittedFile(t, fName)
 			return test{
 				name: "return (nil, error) when path is exist file cannot be opend due to permission",
 				args: args{
@@ -157,7 +157,7 @@ func TestReadFile(t *testing.T) {
 				},
 				afterFunc: func(args) {
 					if err := os.Remove(fName); err != nil {
-						log.Error(err)
+						t.Fatal(err)
 					}
 				},
 			}


### PR DESCRIPTION
Signed-off-by: vankichi <kyukawa315@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:
I created the unit test for `internal/io/ioutil.go`
Also, I added the comment for each function of `internal/io/ioutil.go`

**NOTE**
It is too hard (maybe unreachable) to generate the error about `r.ReadFrom(f)`.
I ignored the test case about it, and also got SET WG agreement about it.

<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
