### PR TITLE
bugfix nil pointer no target discovered

### DIFF
--- a/internal/net/grpc/client.go
+++ b/internal/net/grpc/client.go
@@ -573,7 +573,12 @@ func (g *gRPCClient) Connect(ctx context.Context, addr string, dopts ...DialOpti
 				g.atomicAddrs.Add(addr)
 				return conn, nil
 			}
-			log.Warnf("failed to reconnect unhealthy pool addr= %s\terror= %s", addr, err.Error())
+			log.Warnf("failed to reconnect unhealthy pool addr= %s\terror= %s\t trying to disconnect", addr, func() string {
+				if err != nil {
+					return err.Error()
+				}
+				return "connection response is nil or pool is nil"
+			}())
 			err = g.Disconnect(ctx, addr)
 			if err != nil {
 				log.Warnf("failed to disconnect unhealthy pool addr= %s\terror= %s", addr, err.Error())

--- a/internal/net/grpc/pool/pool.go
+++ b/internal/net/grpc/pool/pool.go
@@ -121,7 +121,7 @@ func New(ctx context.Context, opts ...Option) (c Conn, err error) {
 }
 
 func (p *pool) Connect(ctx context.Context) (c Conn, err error) {
-	if p.closing.Load().(bool) {
+	if p == nil || p.closing.Load().(bool) {
 		return p, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: kpango <kpango@vdaas.org>

<!--- Provide a general summary of your changes in the Title above -->

### Description:
@datelier reports this bug in the commit c1addd22b6ff514161fc3df9915f5948ce145443  
when no target connection found gRPC client continue to discover and connect to target,
but there is no target Connect method returns Error and nil connection which makes nil-pointer panic for logging.
```
2021-03-02 15:00:37     [WARN]: recovered: %+v                                                                                                                                                               
stacktrace:                                                                                                                                                                                                  
%s runtime error: invalid memory address or nil pointer dereference goroutine 119 [running]:                                                                                                                 
runtime/debug.Stack(0xc0004f3590, 0x11a3aa0, 0x1cea7d0)                                                                                                                                                      
        runtime/debug/stack.go:24 +0x9f                                                                                                                                                                      
github.com/vdaas/vald/internal/safety.recoverFunc.func1.1(0xc0004f3e30, 0x1)                                                                                                                                 
        github.com/vdaas/vald/internal/safety/safety.go:41 +0x79                                                                                                                                             
panic(0x11a3aa0, 0x1cea7d0)                                                                                                                                                                                  
        runtime/panic.go:969 +0x1b9                                                                                                                                                                          
github.com/vdaas/vald/internal/net/grpc.(*gRPCClient).Connect.func2(0xc000682dc0, 0x1, 0xc0003eb4d0, 0x10fa580)                                                                                              
        github.com/vdaas/vald/internal/net/grpc/client.go:570 +0x1093                                                                                                                                        
github.com/vdaas/vald/internal/singleflight.(*group).Do(0xc000422f60, 0x1545be0, 0xc000804f60, 0xc0003b6c90, 0x2b, 0xc000824eb0, 0x2b, 0x479f49, 0x203000, 0x203000, ...)                                    
        github.com/vdaas/vald/internal/singleflight/singleflight.go:62 +0xd8                                                                                                                                 
github.com/vdaas/vald/internal/net/grpc.(*gRPCClient).Connect(0xc00032c500, 0x1545be0, 0xc000804f60, 0xc0000440f0, 0x23, 0x0, 0x0, 0x0, 0x0, 0x0, ...)                                                       
        github.com/vdaas/vald/internal/net/grpc/client.go:556 +0x274                                                                                                                                         
github.com/vdaas/vald/internal/net/grpc.(*gRPCClient).StartConnectionMonitor.func1.3(0x11390c0, 0xc0003fd690, 0x1124440, 0x1ca8060, 0xc0004f3b00)                                                            
        github.com/vdaas/vald/internal/net/grpc/client.go:261 +0x190                                                                                                                                         
sync.(*Map).Range(0xc00032c600, 0xc0004f3cc0)                                                                                                                                                                
        sync/map.go:345 +0x1d9                                                                                                                                                                               
github.com/vdaas/vald/internal/net/grpc.(*gRPCClient).StartConnectionMonitor.func1(0x0, 0x0)                                                                                                                 
        github.com/vdaas/vald/internal/net/grpc/client.go:245 +0x40c                                                                                                                                         
github.com/vdaas/vald/internal/safety.recoverFunc.func1(0x0, 0x0)                                                                                                                                            
        github.com/vdaas/vald/internal/safety/safety.go:63 +0x65                                                                                                                                             
github.com/vdaas/vald/internal/errgroup.(*group).Go.func1(0xc00022ec80, 0xc0005e85c0)                                                                                                                        
        github.com/vdaas/vald/internal/errgroup/group.go:110 +0xd6                                                                                                                                           
created by github.com/vdaas/vald/internal/errgroup.(*group).Go                                                                                                                                               
        github.com/vdaas/vald/internal/errgroup/group.go:100 +0x7a
```
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
