### PR TITLE
Add internal/core/algorithm/ngt/util.go test

### DIFF
--- a/internal/core/algorithm/ngt/util_test.go
+++ b/internal/core/algorithm/ngt/util_test.go
@@ -65,7 +65,7 @@ func Test_fileExists(t *testing.T) {
 			},
 			beforeFunc: func(t *testing.T, args args) {
 				t.Helper()
-				if err := os.MkdirAll(args.path, 0777); err != nil {
+				if err := os.MkdirAll(args.path, 0750); err != nil {
 					t.Fatal(err)
 				}
 			},

--- a/internal/core/algorithm/ngt/util_test.go
+++ b/internal/core/algorithm/ngt/util_test.go
@@ -52,6 +52,9 @@ func Test_fileExists(t *testing.T) {
 	const (
 		testDirPath  = "utiltest/index"
 		testFilePath = "utiltest-ngt-meta.kvsdb"
+
+		testFailsDirPath  = "utiltest-fails/index"
+		testFailsFilePath = "utiltest-ngt-meta-fails.kvsdb"
 	)
 
 	tests := []test{
@@ -106,7 +109,7 @@ func Test_fileExists(t *testing.T) {
 		{
 			name: "return false when the directory does not exist",
 			args: args{
-				path: "utiltest-fails/index",
+				path: testFailsDirPath,
 			},
 			want: want{
 				want: false,
@@ -115,7 +118,7 @@ func Test_fileExists(t *testing.T) {
 		{
 			name: "return false when the file exists",
 			args: args{
-				path: "utiltest-ngt-meta-fails.kvsdb",
+				path: testFailsFilePath,
 			},
 			want: want{
 				want: false,

--- a/internal/core/algorithm/ngt/util_test.go
+++ b/internal/core/algorithm/ngt/util_test.go
@@ -60,6 +60,7 @@ func Test_fileExists(t *testing.T) {
 	)
 
 	defaultAfterFunc := func(t *testing.T, args args) {
+		t.Helper()
 		if err := os.RemoveAll(baseDir); err != nil {
 			t.Error(err)
 		}

--- a/internal/core/algorithm/ngt/util_test.go
+++ b/internal/core/algorithm/ngt/util_test.go
@@ -1,0 +1,145 @@
+//
+// Copyright (C) 2019-2021 vdaas.org vald team <vald@vdaas.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package ngt provides implementation of Go API for https://github.com/yahoojapan/NGT
+package ngt
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"go.uber.org/goleak"
+
+	"github.com/vdaas/vald/internal/errors"
+)
+
+func Test_fileExists(t *testing.T) {
+	type args struct {
+		path string
+	}
+	type want struct {
+		want bool
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, bool) error
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
+	}
+	defaultCheckFunc := func(w want, got bool) error {
+		if !reflect.DeepEqual(got, w.want) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+
+	const (
+		testDirPath  = "utiltest/index"
+		testFilePath = "utiltest-ngt-meta.kvsdb"
+	)
+
+	tests := []test{
+		{
+			name: "return true when the directory exists",
+			args: args{
+				path: testDirPath,
+			},
+			beforeFunc: func(t *testing.T, args args) {
+				t.Helper()
+				if err := os.MkdirAll(args.path, 0777); err != nil {
+					t.Fatal(err)
+				}
+			},
+			afterFunc: func(t *testing.T, args args) {
+				t.Helper()
+				if err := os.RemoveAll(args.path); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: want{
+				want: true,
+			},
+		},
+		{
+			name: "return true when the file exists",
+			args: args{
+				path: testFilePath,
+			},
+			beforeFunc: func(t *testing.T, args args) {
+				t.Helper()
+				f, err := os.Create(args.path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() {
+					if err := f.Close(); err != nil {
+						t.Error(err)
+					}
+				}()
+			},
+			afterFunc: func(t *testing.T, args args) {
+				t.Helper()
+				if err := os.Remove(args.path); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: want{
+				want: true,
+			},
+		},
+		{
+			name: "return false when the directory does not exist",
+			args: args{
+				path: "utiltest-fails/index",
+			},
+			want: want{
+				want: false,
+			},
+		},
+		{
+			name: "return false when the file exists",
+			args: args{
+				path: "utiltest-ngt-meta-fails.kvsdb",
+			},
+			want: want{
+				want: false,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
+			if test.beforeFunc != nil {
+				test.beforeFunc(tt, test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(tt, test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := fileExists(test.args.path)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: hlts2 <hiroto.funakoshi.hiroto@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

I added test for `internal/core/algorithm/ngt/util.go`.
And I did not write godoc comment because the test target is not an unexported function.
thank you always.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
