### PR TITLE
Add benchmark for timeutil/time.go

### DIFF
--- a/internal/timeutil/time_bench_test.go
+++ b/internal/timeutil/time_bench_test.go
@@ -1,0 +1,172 @@
+package timeutil
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func BenchmarkParse(b *testing.B) {
+	type args struct {
+		t string
+	}
+	type want struct {
+		want time.Duration
+		err  error
+	}
+	type test struct {
+		name string
+		args args
+		want want
+	}
+
+	tests := []test{
+		{
+			name: "when t is 10ms",
+			args: args{
+				t: "10ms",
+			},
+			want: want{
+				want: 10 * time.Millisecond,
+				err:  nil,
+			},
+		},
+		{
+			name: "when t is 100ms",
+			args: args{
+				t: "100ms",
+			},
+			want: want{
+				want: 100 * time.Millisecond,
+				err:  nil,
+			},
+		},
+		{
+			name: "when t is 1s",
+			args: args{
+				t: "1s",
+			},
+			want: want{
+				want: time.Second,
+				err:  nil,
+			},
+		},
+		{
+			name: "when t is 10s",
+			args: args{
+				t: "10s",
+			},
+			want: want{
+				want: 10 * time.Second,
+				err:  nil,
+			},
+		},
+		{
+			name: "when t is 100s",
+			args: args{
+				t: "100s",
+			},
+			want: want{
+				want: 100 * time.Second,
+				err:  nil,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					got, err := Parse(test.args.t)
+					if err != nil {
+						b.Error(err)
+					}
+					if !reflect.DeepEqual(test.want.want, got) {
+						b.Errorf("want: %v, but got: %v", test.want.want, got)
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkParseWithDefault(b *testing.B) {
+	type args struct {
+		t string
+		d time.Duration
+	}
+	type want struct {
+		want time.Duration
+	}
+	type test struct {
+		name string
+		args args
+		want want
+	}
+
+	tests := []test{
+		{
+			name: "when t is 10second",
+			args: args{
+				t: "10second",
+				d: 50 * time.Millisecond,
+			},
+			want: want{
+				want: 50 * time.Millisecond,
+			},
+		},
+		{
+			name: "when t is 100second",
+			args: args{
+				t: "100second",
+				d: 50 * time.Millisecond,
+			},
+			want: want{
+				want: 50 * time.Millisecond,
+			},
+		},
+		{
+			name: "when t is 1000second",
+			args: args{
+				t: "1000second",
+				d: 50 * time.Millisecond,
+			},
+			want: want{
+				want: 50 * time.Millisecond,
+			},
+		},
+		{
+			name: "when t is 10000second",
+			args: args{
+				t: "1000second",
+				d: 50 * time.Millisecond,
+			},
+			want: want{
+				want: 50 * time.Millisecond,
+			},
+		},
+		{
+			name: "when t is 100000second",
+			args: args{
+				t: "10000second",
+				d: 50 * time.Millisecond,
+			},
+			want: want{
+				want: 50 * time.Millisecond,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					got := ParseWithDefault(test.args.t, test.args.d)
+					if !reflect.DeepEqual(test.want.want, got) {
+						b.Errorf("want: %v, but got: %v", test.want.want, got)
+					}
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: hlts2 <hiroto.funakoshi.hiroto@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

I added a benchmark for `timeutil/time.go`.


I wanted to take a bench mark with multiple parameters.
When I was creating a top-level bench function for each parameter, the number of benchmark function increased.
so I wrote it in a table-driven test. I'm sorry if I made a mistake.


### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
