### PR TITLE
add internal backoff test

### DIFF
--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -66,7 +66,7 @@ func New(opts ...Option) Backoff {
 	return b
 }
 
-// Do tries to backoff using input function and returns the response and error.
+// Do tries to backoff using the input function and returns the response and error.
 func (b *backoff) Do(ctx context.Context, f func(ctx context.Context) (val interface{}, retryable bool, err error)) (res interface{}, err error) {
 	res, ret, err := f(ctx)
 	if err == nil || !ret {
@@ -149,7 +149,7 @@ func (b *backoff) addJitter(dur float64) float64 {
 	return dur + float64(rand.LimitedUint32(uint64(hd))) - hd
 }
 
-// Close closes the wait group.
+// Close wait for the backoff process to complete.
 func (b *backoff) Close() {
 	b.wg.Wait()
 }

--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -43,6 +43,7 @@ type backoff struct {
 	errLog                bool
 }
 
+// Backoff represents an interface to handle backoff operation.
 type Backoff interface {
 	Do(context.Context, func(ctx context.Context) (interface{}, bool, error)) (interface{}, error)
 	Close()
@@ -50,6 +51,7 @@ type Backoff interface {
 
 const traceTag = "vald/internal/backoff/Backoff.Do/retry"
 
+// New creates the new backoff with option.
 func New(opts ...Option) Backoff {
 	b := new(backoff)
 	for _, opt := range append(defaultOptions, opts...) {
@@ -64,6 +66,7 @@ func New(opts ...Option) Backoff {
 	return b
 }
 
+// Do tries to backoff using input function and returns the response and error.
 func (b *backoff) Do(ctx context.Context, f func(ctx context.Context) (val interface{}, retryable bool, err error)) (res interface{}, err error) {
 	res, ret, err := f(ctx)
 	if err == nil || !ret {
@@ -146,6 +149,7 @@ func (b *backoff) addJitter(dur float64) float64 {
 	return dur + float64(rand.LimitedUint32(uint64(hd))) - hd
 }
 
+// Close closes the wait group.
 func (b *backoff) Close() {
 	b.wg.Wait()
 }

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -126,8 +126,7 @@ func Test_backoff_addJitter(t *testing.T) {
 				fields: fields{
 					jitterLimit: 100,
 				},
-				want:      want{},
-				checkFunc: defaultCheckFunc,
+				want: want{},
 			}
 		}(),
 	}
@@ -190,8 +189,7 @@ func Test_backoff_Close(t *testing.T) {
 			fields: fields{
 				wg: sync.WaitGroup{},
 			},
-			want:      want{},
-			checkFunc: defaultCheckFunc,
+			want: want{},
 		},
 	}
 
@@ -263,7 +261,7 @@ func Test_backoff_Do(t *testing.T) {
 	}
 	tests := []test{
 		func() test {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx := context.Background()
 			err := errors.New("error is occurred")
 			f := func(context.Context) (interface{}, bool, error) {
 				return nil, false, err
@@ -277,14 +275,10 @@ func Test_backoff_Do(t *testing.T) {
 				want: want{
 					err: err,
 				},
-				checkFunc: defaultCheckFunc,
-				afterFunc: func(args) {
-					cancel()
-				},
 			}
 		}(),
 		func() test {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx := context.Background()
 			f := func(context.Context) (interface{}, bool, error) {
 				return nil, true, nil
 			}
@@ -294,15 +288,11 @@ func Test_backoff_Do(t *testing.T) {
 					ctx: ctx,
 					f:   f,
 				},
-				want:      want{},
-				checkFunc: defaultCheckFunc,
-				afterFunc: func(args) {
-					cancel()
-				},
+				want: want{},
 			}
 		}(),
 		func() test {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx := context.Background()
 			err := errors.New("erros is occurred")
 			f := func(context.Context) (interface{}, bool, error) {
 				return nil, false, err
@@ -329,14 +319,10 @@ func Test_backoff_Do(t *testing.T) {
 					wantRes: nil,
 					err:     err,
 				},
-				checkFunc: defaultCheckFunc,
-				afterFunc: func(args) {
-					cancel()
-				},
 			}
 		}(),
 		func() test {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx := context.Background()
 			err := errors.New("erros is occurred")
 			f := func(context.Context) (interface{}, bool, error) {
 				return str, true, err
@@ -363,14 +349,10 @@ func Test_backoff_Do(t *testing.T) {
 					wantRes: str,
 					err:     err,
 				},
-				checkFunc: defaultCheckFunc,
-				afterFunc: func(args) {
-					cancel()
-				},
 			}
 		}(),
 		func() test {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx := context.Background()
 			err := errors.New("erros is occurred")
 			cnt := 0
 			f := func(context.Context) (interface{}, bool, error) {
@@ -402,14 +384,10 @@ func Test_backoff_Do(t *testing.T) {
 					wantRes: str,
 					err:     err,
 				},
-				checkFunc: defaultCheckFunc,
-				afterFunc: func(args) {
-					cancel()
-				},
 			}
 		}(),
 		func() test {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx := context.Background()
 			err := errors.New("erros is occurred")
 			cnt := 0
 			f := func(context.Context) (interface{}, bool, error) {
@@ -440,14 +418,10 @@ func Test_backoff_Do(t *testing.T) {
 				want: want{
 					wantRes: str,
 				},
-				checkFunc: defaultCheckFunc,
-				afterFunc: func(args) {
-					cancel()
-				},
 			}
 		}(),
 		func() test {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx := context.Background()
 			err := errors.New("erros is occurred")
 			f := func(context.Context) (interface{}, bool, error) {
 				return str, true, err
@@ -474,14 +448,10 @@ func Test_backoff_Do(t *testing.T) {
 					wantRes: str,
 					err:     err,
 				},
-				checkFunc: defaultCheckFunc,
-				afterFunc: func(args) {
-					cancel()
-				},
 			}
 		}(),
 		func() test {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx := context.Background()
 			err := errors.New("erros is occurred")
 			f := func(context.Context) (interface{}, bool, error) {
 				return str, true, err
@@ -506,10 +476,6 @@ func Test_backoff_Do(t *testing.T) {
 				},
 				want: want{
 					err: errors.ErrBackoffTimeout(err),
-				},
-				checkFunc: defaultCheckFunc,
-				afterFunc: func(args) {
-					cancel()
 				},
 			}
 		}(),
@@ -541,7 +507,6 @@ func Test_backoff_Do(t *testing.T) {
 				want: want{
 					err: err,
 				},
-				checkFunc: defaultCheckFunc,
 			}
 		}(),
 		func() test {
@@ -576,11 +541,10 @@ func Test_backoff_Do(t *testing.T) {
 				want: want{
 					err: err,
 				},
-				checkFunc: defaultCheckFunc,
 			}
 		}(),
 		func() test {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx := context.Background()
 			err := errors.New("erros is occurred")
 			cnt := 0
 			f := func(context.Context) (interface{}, bool, error) {
@@ -610,10 +574,6 @@ func Test_backoff_Do(t *testing.T) {
 				},
 				want: want{
 					err: errors.ErrBackoffTimeout(err),
-				},
-				checkFunc: defaultCheckFunc,
-				afterFunc: func(args) {
-					cancel()
 				},
 			}
 		}(),

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -30,6 +30,8 @@ import (
 	"go.uber.org/goleak"
 )
 
+const str = "success"
+
 func TestMain(m *testing.M) {
 	log.Init()
 	os.Exit(m.Run())
@@ -336,7 +338,6 @@ func Test_backoff_Do(t *testing.T) {
 		func() test {
 			ctx, cancel := context.WithCancel(context.Background())
 			err := errors.New("erros is occurred")
-			str := "connected"
 			f := func(context.Context) (interface{}, bool, error) {
 				return str, true, err
 			}
@@ -371,7 +372,6 @@ func Test_backoff_Do(t *testing.T) {
 		func() test {
 			ctx, cancel := context.WithCancel(context.Background())
 			err := errors.New("erros is occurred")
-			str := "connected"
 			cnt := 0
 			f := func(context.Context) (interface{}, bool, error) {
 				cnt++
@@ -411,7 +411,6 @@ func Test_backoff_Do(t *testing.T) {
 		func() test {
 			ctx, cancel := context.WithCancel(context.Background())
 			err := errors.New("erros is occurred")
-			str := "connected"
 			cnt := 0
 			f := func(context.Context) (interface{}, bool, error) {
 				cnt++
@@ -450,7 +449,6 @@ func Test_backoff_Do(t *testing.T) {
 		func() test {
 			ctx, cancel := context.WithCancel(context.Background())
 			err := errors.New("erros is occurred")
-			str := "connected"
 			f := func(context.Context) (interface{}, bool, error) {
 				return str, true, err
 			}
@@ -485,7 +483,6 @@ func Test_backoff_Do(t *testing.T) {
 		func() test {
 			ctx, cancel := context.WithCancel(context.Background())
 			err := errors.New("erros is occurred")
-			str := "connected"
 			f := func(context.Context) (interface{}, bool, error) {
 				return str, true, err
 			}
@@ -519,7 +516,6 @@ func Test_backoff_Do(t *testing.T) {
 		func() test {
 			ctx, cancel := context.WithCancel(context.Background())
 			err := errors.New("erros is occurred")
-			str := "connected"
 			f := func(context.Context) (interface{}, bool, error) {
 				cancel()
 				return str, true, err
@@ -551,7 +547,6 @@ func Test_backoff_Do(t *testing.T) {
 		func() test {
 			ctx, cancel := context.WithCancel(context.Background())
 			err := errors.New("erros is occurred")
-			str := "connected"
 			cnt := 0
 			f := func(context.Context) (interface{}, bool, error) {
 				cnt++
@@ -587,7 +582,6 @@ func Test_backoff_Do(t *testing.T) {
 		func() test {
 			ctx, cancel := context.WithCancel(context.Background())
 			err := errors.New("erros is occurred")
-			str := "connected"
 			cnt := 0
 			f := func(context.Context) (interface{}, bool, error) {
 				cnt++

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -19,6 +19,7 @@ package backoff
 
 import (
 	"context"
+	"os"
 	"reflect"
 	"sync"
 	"testing"
@@ -28,6 +29,11 @@ import (
 	"github.com/vdaas/vald/internal/log"
 	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	log.Init()
+	os.Exit(m.Run())
+}
 
 func TestNew(t *testing.T) {
 	type test struct {
@@ -73,269 +79,6 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func Test_backoff_Do(t *testing.T) {
-	t.Parallel()
-	type args struct {
-		fn   func(context.Context) (interface{}, bool, error)
-		opts []Option
-	}
-
-	type test struct {
-		name      string
-		args      args
-		ctxFn     func() (context.Context, context.CancelFunc)
-		checkFunc func(got, want error) error
-		want      error
-	}
-
-	tests := []test{
-		func() test {
-			cnt := 0
-			fn := func(context.Context) (interface{}, bool, error) {
-				cnt++
-				return nil, false, nil
-			}
-
-			return test{
-				name: "returns response and nil when function return not nil",
-				args: args{
-					fn: fn,
-					opts: []Option{
-						WithDisableErrorLog(),
-					},
-				},
-				ctxFn: func() (context.Context, context.CancelFunc) {
-					return context.WithCancel(context.Background())
-				},
-				checkFunc: func(got, want error) error {
-					if cnt != 1 {
-						return errors.Errorf("error count is wrong, want: %v, got: %v", 2, cnt)
-					}
-
-					if !errors.Is(want, got) {
-						return errors.Errorf("not equals. want: %v, got: %v", want, got)
-					}
-
-					return nil
-				},
-				want: nil,
-			}
-		}(),
-
-		func() test {
-			cnt := 0
-			fn := func(context.Context) (interface{}, bool, error) {
-				cnt++
-				if cnt == 2 {
-					return nil, false, nil
-				}
-				return nil, true, errors.Errorf("error (%d)", cnt)
-			}
-
-			return test{
-				name: "returns response and nil when retried twice and did not return an error",
-				args: args{
-					fn: fn,
-					opts: []Option{
-						WithDisableErrorLog(),
-						WithRetryCount(6),
-					},
-				},
-				ctxFn: func() (context.Context, context.CancelFunc) {
-					return context.WithCancel(context.Background())
-				},
-				checkFunc: func(got, want error) error {
-					if cnt != 2 {
-						return errors.Errorf("error count is wrong, want: %v, got: %v", 2, cnt)
-					}
-
-					if !errors.Is(want, got) {
-						return errors.Errorf("not equals. want: %v, got: %v", want, got)
-					}
-
-					return nil
-				},
-				want: nil,
-			}
-		}(),
-
-		func() test {
-			cnt := 0
-			err := errors.New("not retryable error")
-			fn := func(context.Context) (interface{}, bool, error) {
-				cnt++
-				return nil, false, err
-			}
-
-			return test{
-				name: "returns error when retryable is false",
-				args: args{
-					fn: fn,
-					opts: []Option{
-						WithDisableErrorLog(),
-						WithRetryCount(6),
-					},
-				},
-				ctxFn: func() (context.Context, context.CancelFunc) {
-					return context.WithCancel(context.Background())
-				},
-				checkFunc: func(got, want error) error {
-					if cnt != 1 {
-						return errors.Errorf("error count is wrong, want: %v, got: %v", 1, cnt)
-					}
-
-					if !errors.Is(want, got) {
-						return errors.Errorf("not equals. want: %v, got: %v", want, got)
-					}
-
-					return nil
-				},
-				want: err,
-			}
-		}(),
-
-		func() test {
-			cnt := 0
-			fn := func(context.Context) (interface{}, bool, error) {
-				cnt++
-				return nil, true, errors.Errorf("error (%d)", cnt)
-			}
-
-			return test{
-				name: "returns error when retrying the maximum number of times",
-				args: args{
-					fn: fn,
-					opts: []Option{
-						WithRetryCount(6),
-					},
-				},
-				ctxFn: func() (context.Context, context.CancelFunc) {
-					return context.WithCancel(context.Background())
-				},
-				checkFunc: func(got, want error) error {
-					if cnt != 7 {
-						return errors.Errorf("error count is wrong, want: %v, got: %v", 7, cnt)
-					}
-
-					if want.Error() != got.Error() {
-						return errors.Errorf("not equals. want: %v, got: %v", want, got)
-					}
-
-					return nil
-				},
-				want: errors.New("error (7)"),
-			}
-		}(),
-
-		func() test {
-			ctx, cancel := context.WithCancel(context.Background())
-
-			cnt := 0
-			fn := func(context.Context) (interface{}, bool, error) {
-				cnt++
-				if cnt == 2 {
-					cancel()
-				}
-				return nil, true, errors.Errorf("error (%d)", cnt)
-			}
-
-			return test{
-				name: "return response and error when context canceled",
-				args: args{
-					fn: fn,
-					opts: []Option{
-						WithDisableErrorLog(),
-						WithRetryCount(6),
-					},
-				},
-				ctxFn: func() (context.Context, context.CancelFunc) {
-					return ctx, cancel
-				},
-				checkFunc: func(got, want error) error {
-					if cnt != 2 {
-						return errors.Errorf("error count is wrong, want: %v, got: %v", 2, cnt)
-					}
-
-					if got.Error() != want.Error() {
-						return errors.Errorf("not equals. want: %v, got: %v", want, got)
-					}
-
-					return nil
-				},
-				want: errors.Wrap(context.Canceled, errors.New("error (2)").Error()),
-			}
-		}(),
-
-		func() test {
-			err := errors.New("error")
-			fn := func(context.Context) (interface{}, bool, error) {
-				return nil, true, err
-			}
-
-			return test{
-				name: "return response and error when backoff timeout",
-				args: args{
-					fn: fn,
-					opts: []Option{
-						WithDisableErrorLog(),
-						WithRetryCount(6),
-						WithBackOffTimeLimit("0s"),
-					},
-				},
-				ctxFn: func() (context.Context, context.CancelFunc) {
-					return context.WithCancel(context.Background())
-				},
-				checkFunc: func(got, want error) error {
-					if !errors.Is(got, want) {
-						return errors.Errorf("not equals. want: %v, got: %v", want, got)
-					}
-					return nil
-				},
-				want: err,
-			}
-		}(),
-	}
-
-	log.Init()
-	for _, test := range tests {
-		t.Run(test.name, func(tt *testing.T) {
-			tt.Parallel()
-			ctx, cancel := test.ctxFn()
-			defer cancel()
-			_, err := New(test.args.opts...).Do(ctx, test.args.fn)
-			if test.want == nil && err != nil {
-				t.Errorf("Do return err: %v", err)
-			}
-
-			if err := test.checkFunc(err, test.want); err != nil {
-				t.Error(err)
-			}
-		})
-	}
-}
-
-func TestClose(t *testing.T) {
-	type test struct {
-		name string
-		bo   *backoff
-	}
-
-	tests := []test{
-		{
-			name: "processing is successes",
-			bo: &backoff{
-				wg: sync.WaitGroup{},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.bo.Close()
-		})
-	}
-}
-
 func Test_backoff_addJitter(t *testing.T) {
 	t.Parallel()
 	type args struct {
@@ -372,62 +115,26 @@ func Test_backoff_addJitter(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           dur: 0,
-		       },
-		       fields: fields {
-		           wg: sync.WaitGroup{},
-		           backoffFactor: 0,
-		           initialDuration: 0,
-		           jittedInitialDuration: 0,
-		           jitterLimit: 0,
-		           durationLimit: 0,
-		           maxDuration: 0,
-		           maxRetryCount: 0,
-		           backoffTimeLimit: nil,
-		           errLog: false,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           dur: 0,
-		           },
-		           fields: fields {
-		           wg: sync.WaitGroup{},
-		           backoffFactor: 0,
-		           initialDuration: 0,
-		           jittedInitialDuration: 0,
-		           jitterLimit: 0,
-		           durationLimit: 0,
-		           maxDuration: 0,
-		           maxRetryCount: 0,
-		           backoffTimeLimit: nil,
-		           errLog: false,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		func() test {
+			return test{
+				name: "success when dur is 0",
+				args: args{
+					dur: 0,
+				},
+				fields: fields{
+					jitterLimit: 100,
+				},
+				want:      want{},
+				checkFunc: defaultCheckFunc,
+			}
+		}(),
 	}
 
 	for _, tc := range tests {
 		test := tc
 		t.Run(test.name, func(tt *testing.T) {
 			tt.Parallel()
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc(test.args)
 			}
@@ -461,16 +168,7 @@ func Test_backoff_addJitter(t *testing.T) {
 func Test_backoff_Close(t *testing.T) {
 	t.Parallel()
 	type fields struct {
-		wg                    sync.WaitGroup
-		backoffFactor         float64
-		initialDuration       float64
-		jittedInitialDuration float64
-		jitterLimit           float64
-		durationLimit         float64
-		maxDuration           float64
-		maxRetryCount         int
-		backoffTimeLimit      time.Duration
-		errLog                bool
+		wg sync.WaitGroup
 	}
 	type want struct{}
 	type test struct {
@@ -485,61 +183,458 @@ func Test_backoff_Close(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           wg: sync.WaitGroup{},
-		           backoffFactor: 0,
-		           initialDuration: 0,
-		           jittedInitialDuration: 0,
-		           jitterLimit: 0,
-		           durationLimit: 0,
-		           maxDuration: 0,
-		           maxRetryCount: 0,
-		           backoffTimeLimit: nil,
-		           errLog: false,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           wg: sync.WaitGroup{},
-		           backoffFactor: 0,
-		           initialDuration: 0,
-		           jittedInitialDuration: 0,
-		           jitterLimit: 0,
-		           durationLimit: 0,
-		           maxDuration: 0,
-		           maxRetryCount: 0,
-		           backoffTimeLimit: nil,
-		           errLog: false,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		{
+			name: "success backoff Close",
+			fields: fields{
+				wg: sync.WaitGroup{},
+			},
+			want:      want{},
+			checkFunc: defaultCheckFunc,
+		},
 	}
 
 	for _, tc := range tests {
 		test := tc
 		t.Run(test.name, func(tt *testing.T) {
 			tt.Parallel()
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc()
 			}
 			if test.afterFunc != nil {
 				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+			b := &backoff{
+				wg: test.fields.wg,
+			}
+
+			b.Close()
+			if err := test.checkFunc(test.want); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func Test_backoff_Do(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		ctx context.Context
+		f   func(ctx context.Context) (val interface{}, retryable bool, err error)
+	}
+	type fields struct {
+		wg                    sync.WaitGroup
+		backoffFactor         float64
+		initialDuration       float64
+		jittedInitialDuration float64
+		jitterLimit           float64
+		durationLimit         float64
+		maxDuration           float64
+		maxRetryCount         int
+		backoffTimeLimit      time.Duration
+		errLog                bool
+	}
+	type want struct {
+		wantRes interface{}
+		err     error
+	}
+	type test struct {
+		name       string
+		args       args
+		fields     fields
+		want       want
+		checkFunc  func(want, interface{}, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, gotRes interface{}, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if !reflect.DeepEqual(gotRes, w.wantRes) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", gotRes, w.wantRes)
+		}
+		return nil
+	}
+	tests := []test{
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := errors.New("error is occurred")
+			f := func(context.Context) (interface{}, bool, error) {
+				return nil, false, err
+			}
+			return test{
+				name: "return nil response and nil error when function returns (nil, false, error)",
+				args: args{
+					ctx: ctx,
+					f:   f,
+				},
+				want: want{
+					err: err,
+				},
+				checkFunc: defaultCheckFunc,
+				afterFunc: func(args) {
+					cancel()
+				},
+			}
+		}(),
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			f := func(context.Context) (interface{}, bool, error) {
+				return nil, true, nil
+			}
+			return test{
+				name: "return nil response and nil error when function returns (nil, true, nil)",
+				args: args{
+					ctx: ctx,
+					f:   f,
+				},
+				want:      want{},
+				checkFunc: defaultCheckFunc,
+				afterFunc: func(args) {
+					cancel()
+				},
+			}
+		}(),
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := errors.New("erros is occurred")
+			f := func(context.Context) (interface{}, bool, error) {
+				return nil, false, err
+			}
+			return test{
+				name: "return response and error when function return (nil, true, error) and maxRetryCount = 0",
+				args: args{
+					ctx: ctx,
+					f:   f,
+				},
+				fields: fields{
+					wg:                    sync.WaitGroup{},
+					backoffFactor:         0,
+					initialDuration:       0,
+					jittedInitialDuration: 0,
+					jitterLimit:           0,
+					durationLimit:         0,
+					maxDuration:           0,
+					maxRetryCount:         0,
+					backoffTimeLimit:      0,
+					errLog:                false,
+				},
+				want: want{
+					wantRes: nil,
+					err:     err,
+				},
+				checkFunc: defaultCheckFunc,
+				afterFunc: func(args) {
+					cancel()
+				},
+			}
+		}(),
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := errors.New("erros is occurred")
+			str := "connected"
+			f := func(context.Context) (interface{}, bool, error) {
+				return str, true, err
+			}
+			return test{
+				name: "return response and nil error when function return (string, true, error) and maxRetryCount = 1",
+				args: args{
+					ctx: ctx,
+					f:   f,
+				},
+				fields: fields{
+					wg:                    sync.WaitGroup{},
+					backoffFactor:         0,
+					initialDuration:       0,
+					jittedInitialDuration: 0,
+					jitterLimit:           0,
+					durationLimit:         0,
+					maxDuration:           0,
+					maxRetryCount:         1,
+					backoffTimeLimit:      10 * time.Minute,
+					errLog:                false,
+				},
+				want: want{
+					wantRes: str,
+					err:     err,
+				},
+				checkFunc: defaultCheckFunc,
+				afterFunc: func(args) {
+					cancel()
+				},
+			}
+		}(),
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := errors.New("erros is occurred")
+			str := "connected"
+			cnt := 0
+			f := func(context.Context) (interface{}, bool, error) {
+				cnt++
+				if cnt == 2 {
+					return str, false, err
+				}
+				return str, true, err
+			}
+			return test{
+				name: "return response and error when function return (string, false, error) at 2nd times and maxRetryCount = 1",
+				args: args{
+					ctx: ctx,
+					f:   f,
+				},
+				fields: fields{
+					wg:                    sync.WaitGroup{},
+					backoffFactor:         0,
+					initialDuration:       0,
+					jittedInitialDuration: 0,
+					jitterLimit:           0,
+					durationLimit:         0,
+					maxDuration:           0,
+					maxRetryCount:         1,
+					backoffTimeLimit:      10 * time.Minute,
+					errLog:                false,
+				},
+				want: want{
+					wantRes: str,
+					err:     err,
+				},
+				checkFunc: defaultCheckFunc,
+				afterFunc: func(args) {
+					cancel()
+				},
+			}
+		}(),
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := errors.New("erros is occurred")
+			str := "connected"
+			cnt := 0
+			f := func(context.Context) (interface{}, bool, error) {
+				cnt++
+				if cnt == 2 {
+					return str, true, nil
+				}
+				return str, true, err
+			}
+			return test{
+				name: "return response and nil error when function return (string, true, nil) at 2nd times and maxRetryCount = 1",
+				args: args{
+					ctx: ctx,
+					f:   f,
+				},
+				fields: fields{
+					wg:                    sync.WaitGroup{},
+					backoffFactor:         0,
+					initialDuration:       0,
+					jittedInitialDuration: 0,
+					jitterLimit:           0,
+					durationLimit:         0,
+					maxDuration:           0,
+					maxRetryCount:         1,
+					backoffTimeLimit:      10 * time.Minute,
+					errLog:                false,
+				},
+				want: want{
+					wantRes: str,
+				},
+				checkFunc: defaultCheckFunc,
+				afterFunc: func(args) {
+					cancel()
+				},
+			}
+		}(),
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := errors.New("erros is occurred")
+			str := "connected"
+			f := func(context.Context) (interface{}, bool, error) {
+				return str, true, err
+			}
+			return test{
+				name: "return response and error when function return (string, false, error) and maxRetryCount = 1, errLog is true",
+				args: args{
+					ctx: ctx,
+					f:   f,
+				},
+				fields: fields{
+					wg:                    sync.WaitGroup{},
+					backoffFactor:         0,
+					initialDuration:       0,
+					jittedInitialDuration: 0,
+					jitterLimit:           0,
+					durationLimit:         10,
+					maxDuration:           0,
+					maxRetryCount:         1,
+					backoffTimeLimit:      10 * time.Minute,
+					errLog:                true,
+				},
+				want: want{
+					wantRes: str,
+					err:     err,
+				},
+				checkFunc: defaultCheckFunc,
+				afterFunc: func(args) {
+					cancel()
+				},
+			}
+		}(),
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := errors.New("erros is occurred")
+			str := "connected"
+			f := func(context.Context) (interface{}, bool, error) {
+				return str, true, err
+			}
+			return test{
+				name: "return nil response and error when function returns (string, false, error) and context will be closed due to timelimit",
+				args: args{
+					ctx: ctx,
+					f:   f,
+				},
+				fields: fields{
+					wg:                    sync.WaitGroup{},
+					backoffFactor:         0,
+					initialDuration:       0,
+					jittedInitialDuration: 0,
+					jitterLimit:           0,
+					durationLimit:         10,
+					maxDuration:           0,
+					maxRetryCount:         1,
+					backoffTimeLimit:      1 * time.Microsecond,
+					errLog:                true,
+				},
+				want: want{
+					err: errors.ErrBackoffTimeout(err),
+				},
+				checkFunc: defaultCheckFunc,
+				afterFunc: func(args) {
+					cancel()
+				},
+			}
+		}(),
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := errors.New("erros is occurred")
+			str := "connected"
+			f := func(context.Context) (interface{}, bool, error) {
+				cancel()
+				return str, true, err
+			}
+			return test{
+				name: "return nil response and error when function returns (string, false, error) and calls cancel()",
+				args: args{
+					ctx: ctx,
+					f:   f,
+				},
+				fields: fields{
+					wg:                    sync.WaitGroup{},
+					backoffFactor:         0,
+					initialDuration:       0,
+					jittedInitialDuration: 0,
+					jitterLimit:           0,
+					durationLimit:         10,
+					maxDuration:           0,
+					maxRetryCount:         1,
+					backoffTimeLimit:      1 * time.Microsecond,
+					errLog:                true,
+				},
+				want: want{
+					err: err,
+				},
+				checkFunc: defaultCheckFunc,
+			}
+		}(),
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := errors.New("erros is occurred")
+			str := "connected"
+			cnt := 0
+			f := func(context.Context) (interface{}, bool, error) {
+				cnt++
+				if cnt > 1 {
+					cancel()
+				}
+				return str, true, err
+			}
+			return test{
+				name: "return response and error when function calls cancel()",
+				args: args{
+					ctx: ctx,
+					f:   f,
+				},
+				fields: fields{
+					wg:                    sync.WaitGroup{},
+					backoffFactor:         0,
+					initialDuration:       0,
+					jittedInitialDuration: 0,
+					jitterLimit:           0,
+					durationLimit:         10,
+					maxDuration:           0,
+					maxRetryCount:         1,
+					backoffTimeLimit:      100 * time.Microsecond,
+					errLog:                true,
+				},
+				want: want{
+					err: err,
+				},
+				checkFunc: defaultCheckFunc,
+			}
+		}(),
+		func() test {
+			ctx, cancel := context.WithCancel(context.Background())
+			err := errors.New("erros is occurred")
+			str := "connected"
+			cnt := 0
+			f := func(context.Context) (interface{}, bool, error) {
+				cnt++
+				if cnt > 1 {
+					time.Sleep(10000 * time.Microsecond)
+				}
+				return str, true, err
+			}
+			return test{
+				name: "return nil response and error when function returns ends due to backoffTimeLimit",
+				args: args{
+					ctx: ctx,
+					f:   f,
+				},
+				fields: fields{
+					wg:                    sync.WaitGroup{},
+					backoffFactor:         0,
+					initialDuration:       0,
+					jittedInitialDuration: 0,
+					jitterLimit:           0,
+					durationLimit:         10,
+					maxDuration:           0,
+					maxRetryCount:         1,
+					backoffTimeLimit:      100 * time.Microsecond,
+					errLog:                true,
+				},
+				want: want{
+					err: errors.ErrBackoffTimeout(err),
+				},
+				checkFunc: defaultCheckFunc,
+				afterFunc: func(args) {
+					cancel()
+				},
+			}
+		}(),
+	}
+
+	for _, tc := range tests {
+		test := tc
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
 			}
 			if test.checkFunc == nil {
 				test.checkFunc = defaultCheckFunc
@@ -557,10 +652,11 @@ func Test_backoff_Close(t *testing.T) {
 				errLog:                test.fields.errLog,
 			}
 
-			b.Close()
-			if err := test.checkFunc(test.want); err != nil {
+			gotRes, err := b.Do(test.args.ctx, test.args.f)
+			if err := test.checkFunc(test.want, gotRes, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -656,7 +656,6 @@ func Test_backoff_Do(t *testing.T) {
 			if err := test.checkFunc(test.want, gotRes, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -267,7 +267,7 @@ func Test_backoff_Do(t *testing.T) {
 				return nil, false, err
 			}
 			return test{
-				name: "return nil response and nil error when function returns (nil, false, error)",
+				name: "return nil response and error when function returns (nil, false, error) and not retriable",
 				args: args{
 					ctx: ctx,
 					f:   f,
@@ -283,7 +283,7 @@ func Test_backoff_Do(t *testing.T) {
 				return nil, true, nil
 			}
 			return test{
-				name: "return nil response and nil error when function returns (nil, true, nil)",
+				name: "return nil response and nil error when function returns (nil, true, nil) and not retriable",
 				args: args{
 					ctx: ctx,
 					f:   f,
@@ -298,7 +298,7 @@ func Test_backoff_Do(t *testing.T) {
 				return nil, false, err
 			}
 			return test{
-				name: "return response and error when function return (nil, true, error) and maxRetryCount = 0",
+				name: "return nil response and error when function return (nil, true, error) and maxRetryCount = 0",
 				args: args{
 					ctx: ctx,
 					f:   f,


### PR DESCRIPTION
Signed-off-by: vankichi <kyukawa315@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:
I created the test for `internal/backoff`
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
