### PR TITLE
Add benchmark for internal/timeutil/time.go

### DIFF
--- a/internal/timeutil/time_bench_test.go
+++ b/internal/timeutil/time_bench_test.go
@@ -1,0 +1,172 @@
+package timeutil
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func BenchmarkParse(b *testing.B) {
+	type args struct {
+		t string
+	}
+	type want struct {
+		want time.Duration
+		err  error
+	}
+	type test struct {
+		name string
+		args args
+		want want
+	}
+
+	tests := []test{
+		{
+			name: "when t is 10ms",
+			args: args{
+				t: "10ms",
+			},
+			want: want{
+				want: 10 * time.Millisecond,
+				err:  nil,
+			},
+		},
+		{
+			name: "when t is 100ms",
+			args: args{
+				t: "100ms",
+			},
+			want: want{
+				want: 100 * time.Millisecond,
+				err:  nil,
+			},
+		},
+		{
+			name: "when t is 1s",
+			args: args{
+				t: "1s",
+			},
+			want: want{
+				want: time.Second,
+				err:  nil,
+			},
+		},
+		{
+			name: "when t is 10s",
+			args: args{
+				t: "10s",
+			},
+			want: want{
+				want: 10 * time.Second,
+				err:  nil,
+			},
+		},
+		{
+			name: "when t is 100s",
+			args: args{
+				t: "100s",
+			},
+			want: want{
+				want: 100 * time.Second,
+				err:  nil,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					got, err := Parse(test.args.t)
+					if err != nil {
+						b.Error(err)
+					}
+					if !reflect.DeepEqual(test.want.want, got) {
+						b.Errorf("want: %v, but got: %v", test.want.want, got)
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkParseWithDefault(b *testing.B) {
+	type args struct {
+		t string
+		d time.Duration
+	}
+	type want struct {
+		want time.Duration
+	}
+	type test struct {
+		name string
+		args args
+		want want
+	}
+
+	tests := []test{
+		{
+			name: "when t is 10second",
+			args: args{
+				t: "10second",
+				d: 50 * time.Millisecond,
+			},
+			want: want{
+				want: 50 * time.Millisecond,
+			},
+		},
+		{
+			name: "when t is 100second",
+			args: args{
+				t: "100second",
+				d: 50 * time.Millisecond,
+			},
+			want: want{
+				want: 50 * time.Millisecond,
+			},
+		},
+		{
+			name: "when t is 1000second",
+			args: args{
+				t: "1000second",
+				d: 50 * time.Millisecond,
+			},
+			want: want{
+				want: 50 * time.Millisecond,
+			},
+		},
+		{
+			name: "when t is 10000second",
+			args: args{
+				t: "1000second",
+				d: 50 * time.Millisecond,
+			},
+			want: want{
+				want: 50 * time.Millisecond,
+			},
+		},
+		{
+			name: "when t is 100000second",
+			args: args{
+				t: "10000second",
+				d: 50 * time.Millisecond,
+			},
+			want: want{
+				want: 50 * time.Millisecond,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					got := ParseWithDefault(test.args.t, test.args.d)
+					if !reflect.DeepEqual(test.want.want, got) {
+						b.Errorf("want: %v, but got: %v", test.want.want, got)
+					}
+				}
+			})
+		})
+	}
+}

--- a/internal/timeutil/time_bench_test.go
+++ b/internal/timeutil/time_bench_test.go
@@ -1,7 +1,6 @@
 package timeutil
 
 import (
-	"reflect"
 	"testing"
 	"time"
 )
@@ -10,14 +9,9 @@ func BenchmarkParse(b *testing.B) {
 	type args struct {
 		t string
 	}
-	type want struct {
-		want time.Duration
-		err  error
-	}
 	type test struct {
 		name string
 		args args
-		want want
 	}
 
 	tests := []test{
@@ -26,19 +20,11 @@ func BenchmarkParse(b *testing.B) {
 			args: args{
 				t: "10ms",
 			},
-			want: want{
-				want: 10 * time.Millisecond,
-				err:  nil,
-			},
 		},
 		{
 			name: "when t is 100ms",
 			args: args{
 				t: "100ms",
-			},
-			want: want{
-				want: 100 * time.Millisecond,
-				err:  nil,
 			},
 		},
 		{
@@ -46,29 +32,17 @@ func BenchmarkParse(b *testing.B) {
 			args: args{
 				t: "1s",
 			},
-			want: want{
-				want: time.Second,
-				err:  nil,
-			},
 		},
 		{
 			name: "when t is 10s",
 			args: args{
 				t: "10s",
 			},
-			want: want{
-				want: 10 * time.Second,
-				err:  nil,
-			},
 		},
 		{
 			name: "when t is 100s",
 			args: args{
 				t: "100s",
-			},
-			want: want{
-				want: 100 * time.Second,
-				err:  nil,
 			},
 		},
 	}
@@ -80,9 +54,10 @@ func BenchmarkParse(b *testing.B) {
 					got, err := Parse(test.args.t)
 					if err != nil {
 						b.Error(err)
+						return
 					}
-					if !reflect.DeepEqual(test.want.want, got) {
-						b.Errorf("want: %v, but got: %v", test.want.want, got)
+					if got == 0 {
+						b.Error("got is 0")
 					}
 				}
 			})
@@ -95,13 +70,9 @@ func BenchmarkParseWithDefault(b *testing.B) {
 		t string
 		d time.Duration
 	}
-	type want struct {
-		want time.Duration
-	}
 	type test struct {
 		name string
 		args args
-		want want
 	}
 
 	tests := []test{
@@ -111,18 +82,12 @@ func BenchmarkParseWithDefault(b *testing.B) {
 				t: "10second",
 				d: 50 * time.Millisecond,
 			},
-			want: want{
-				want: 50 * time.Millisecond,
-			},
 		},
 		{
 			name: "when t is 100second",
 			args: args{
 				t: "100second",
 				d: 50 * time.Millisecond,
-			},
-			want: want{
-				want: 50 * time.Millisecond,
 			},
 		},
 		{
@@ -131,9 +96,6 @@ func BenchmarkParseWithDefault(b *testing.B) {
 				t: "1000second",
 				d: 50 * time.Millisecond,
 			},
-			want: want{
-				want: 50 * time.Millisecond,
-			},
 		},
 		{
 			name: "when t is 10000second",
@@ -141,18 +103,12 @@ func BenchmarkParseWithDefault(b *testing.B) {
 				t: "1000second",
 				d: 50 * time.Millisecond,
 			},
-			want: want{
-				want: 50 * time.Millisecond,
-			},
 		},
 		{
 			name: "when t is 100000second",
 			args: args{
 				t: "10000second",
 				d: 50 * time.Millisecond,
-			},
-			want: want{
-				want: 50 * time.Millisecond,
 			},
 		},
 	}
@@ -162,8 +118,8 @@ func BenchmarkParseWithDefault(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					got := ParseWithDefault(test.args.t, test.args.d)
-					if !reflect.DeepEqual(test.want.want, got) {
-						b.Errorf("want: %v, but got: %v", test.want.want, got)
+					if got == 0 {
+						b.Error("got is 0")
 					}
 				}
 			})

--- a/internal/timeutil/time_bench_test.go
+++ b/internal/timeutil/time_bench_test.go
@@ -77,35 +77,35 @@ func BenchmarkParseWithDefault(b *testing.B) {
 
 	tests := []test{
 		{
-			name: "t 10second",
+			name: "t 10second and 50*time.Millisecond",
 			args: args{
 				t: "10second",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "t 100second",
+			name: "t 100second and 50*time.Millisecond",
 			args: args{
 				t: "100second",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "t 1000second",
+			name: "t 1000second and 50*time.Millisecond",
 			args: args{
 				t: "1000second",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "t 10000second",
+			name: "t 10000second and 50*time.Millisecond",
 			args: args{
 				t: "1000second",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "t 100000second",
+			name: "t 100000second and 50*time.Millisecond",
 			args: args{
 				t: "10000second",
 				d: 50 * time.Millisecond,

--- a/internal/timeutil/time_bench_test.go
+++ b/internal/timeutil/time_bench_test.go
@@ -16,31 +16,31 @@ func BenchmarkParse(b *testing.B) {
 
 	tests := []test{
 		{
-			name: "when t is 10ms",
+			name: "t 10ms",
 			args: args{
 				t: "10ms",
 			},
 		},
 		{
-			name: "when t is 100ms",
+			name: "t 100ms",
 			args: args{
 				t: "100ms",
 			},
 		},
 		{
-			name: "when t is 1s",
+			name: "t 1s",
 			args: args{
 				t: "1s",
 			},
 		},
 		{
-			name: "when t is 10s",
+			name: "t 10s",
 			args: args{
 				t: "10s",
 			},
 		},
 		{
-			name: "when t is 100s",
+			name: "t 100s",
 			args: args{
 				t: "100s",
 			},
@@ -77,35 +77,35 @@ func BenchmarkParseWithDefault(b *testing.B) {
 
 	tests := []test{
 		{
-			name: "when t is 10second",
+			name: "t 10second",
 			args: args{
 				t: "10second",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "when t is 100second",
+			name: "t 100second",
 			args: args{
 				t: "100second",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "when t is 1000second",
+			name: "t 1000second",
 			args: args{
 				t: "1000second",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "when t is 10000second",
+			name: "t 10000second",
 			args: args{
 				t: "1000second",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "when t is 100000second",
+			name: "t 100000second",
 			args: args{
 				t: "10000second",
 				d: 50 * time.Millisecond,

--- a/internal/timeutil/time_bench_test.go
+++ b/internal/timeutil/time_bench_test.go
@@ -161,7 +161,7 @@ func BenchmarkParseWithDefault(b *testing.B) {
 		{
 			name: "t 1000month and d 50 millisecond",
 			args: args{
-				t: "10month",
+				t: "1000month",
 				d: 50 * time.Millisecond,
 			},
 		},

--- a/internal/timeutil/time_bench_test.go
+++ b/internal/timeutil/time_bench_test.go
@@ -13,7 +13,6 @@ func BenchmarkParse(b *testing.B) {
 		name string
 		args args
 	}
-
 	tests := []test{
 		{
 			name: "t 10ms",
@@ -46,7 +45,6 @@ func BenchmarkParse(b *testing.B) {
 			},
 		},
 	}
-
 	for _, test := range tests {
 		b.Run(test.name, func(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
@@ -74,45 +72,43 @@ func BenchmarkParseWithDefault(b *testing.B) {
 		name string
 		args args
 	}
-
 	tests := []test{
 		{
-			name: "t 10second and 50*time.Millisecond",
+			name: "t 10 second and d 50 millisecond",
 			args: args{
 				t: "10second",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "t 100second and 50*time.Millisecond",
+			name: "t 100 second and d 50 millisecond",
 			args: args{
 				t: "100second",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "t 1000second and 50*time.Millisecond",
+			name: "t 1000 second and d 50 millisecond",
 			args: args{
 				t: "1000second",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "t 10000second and 50*time.Millisecond",
+			name: "t 10000 second and d 50 millisecond",
 			args: args{
 				t: "1000second",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "t 100000second and 50*time.Millisecond",
+			name: "t 100000 second and d 50 millisecond",
 			args: args{
 				t: "10000second",
 				d: 50 * time.Millisecond,
 			},
 		},
 	}
-
 	for _, test := range tests {
 		b.Run(test.name, func(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {

--- a/internal/timeutil/time_bench_test.go
+++ b/internal/timeutil/time_bench_test.go
@@ -15,15 +15,21 @@ func BenchmarkParse(b *testing.B) {
 	}
 	tests := []test{
 		{
-			name: "t 10ms",
+			name: "t 1ns",
 			args: args{
-				t: "10ms",
+				t: "1ns",
 			},
 		},
 		{
-			name: "t 100ms",
+			name: "t 1µs",
 			args: args{
-				t: "100ms",
+				t: "1µs",
+			},
+		},
+		{
+			name: "t 1ms",
+			args: args{
+				t: "1ms",
 			},
 		},
 		{
@@ -33,15 +39,15 @@ func BenchmarkParse(b *testing.B) {
 			},
 		},
 		{
-			name: "t 10s",
+			name: "t 1m",
 			args: args{
-				t: "10s",
+				t: "1m",
 			},
 		},
 		{
-			name: "t 100s",
+			name: "t 1h",
 			args: args{
-				t: "100s",
+				t: "1h",
 			},
 		},
 	}
@@ -74,37 +80,96 @@ func BenchmarkParseWithDefault(b *testing.B) {
 	}
 	tests := []test{
 		{
-			name: "t 10 second and d 50 millisecond",
+			name: "t 1ns and d 50 millisecond",
 			args: args{
-				t: "10second",
+				t: "1ns",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "t 100 second and d 50 millisecond",
+			name: "t 1µs and d 50 millisecond",
 			args: args{
-				t: "100second",
+				t: "1µs",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "t 1000 second and d 50 millisecond",
+			name: "t 1ms and d 50 millisecond",
 			args: args{
-				t: "1000second",
+				t: "1ms",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "t 10000 second and d 50 millisecond",
+			name: "t 1s and d 50 millisecond",
 			args: args{
-				t: "1000second",
+				t: "1s",
 				d: 50 * time.Millisecond,
 			},
 		},
 		{
-			name: "t 100000 second and d 50 millisecond",
+			name: "t 1m and d 50 millisecond",
 			args: args{
-				t: "10000second",
+				t: "1m",
+				d: 50 * time.Millisecond,
+			},
+		},
+		{
+			name: "t 1h and d 50 millisecond",
+			args: args{
+				t: "1h",
+				d: 50 * time.Millisecond,
+			},
+		},
+
+		// The following are error pattern.
+		// So default value is returned.
+
+		// The length of t is 5.
+		{
+			name: "t 1days and d 50 millisecond",
+			args: args{
+				t: "1days",
+				d: 50 * time.Millisecond,
+			},
+		},
+		// The length of t is 6.
+		{
+			name: "t 1month and d 50 millisecond",
+			args: args{
+				t: "1month",
+				d: 50 * time.Millisecond,
+			},
+		},
+		// The length of t is 7.
+		{
+			name: "t 10month and d 50 millisecond",
+			args: args{
+				t: "10month",
+				d: 50 * time.Millisecond,
+			},
+		},
+		// The length of t is 8.
+		{
+			name: "t 100month and d 50 millisecond",
+			args: args{
+				t: "10month",
+				d: 50 * time.Millisecond,
+			},
+		},
+		// The length of t is 9.
+		{
+			name: "t 1000month and d 50 millisecond",
+			args: args{
+				t: "10month",
+				d: 50 * time.Millisecond,
+			},
+		},
+		// The length of t is 10.
+		{
+			name: "t 10000month and d 50 millisecond",
+			args: args{
+				t: "10month",
 				d: 50 * time.Millisecond,
 			},
 		},

--- a/internal/timeutil/time_bench_test.go
+++ b/internal/timeutil/time_bench_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright (C) 2019-2021 vdaas.org vald team <vald@vdaas.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package timeutil
 
 import (

--- a/internal/timeutil/time_bench_test.go
+++ b/internal/timeutil/time_bench_test.go
@@ -153,7 +153,7 @@ func BenchmarkParseWithDefault(b *testing.B) {
 		{
 			name: "t 100month and d 50 millisecond",
 			args: args{
-				t: "10month",
+				t: "100month",
 				d: 50 * time.Millisecond,
 			},
 		},

--- a/internal/timeutil/time_bench_test.go
+++ b/internal/timeutil/time_bench_test.go
@@ -169,7 +169,7 @@ func BenchmarkParseWithDefault(b *testing.B) {
 		{
 			name: "t 10000month and d 50 millisecond",
 			args: args{
-				t: "10month",
+				t: "10000month",
 				d: 50 * time.Millisecond,
 			},
 		},


### PR DESCRIPTION
Signed-off-by: hlts2 <hiroto.funakoshi.hiroto@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

I added a benchmark for `timeutil/time.go` with table-driven.

```
goos: linux
goarch: amd64
pkg: github.com/vdaas/vald/internal/timeutil
cpu: Intel(R) Core(TM) i7-6920HQ CPU @ 2.90GHz
BenchmarkParse/t_1ns-7        	123051638	         9.610 ns/op	       0 B/op	       0 allocs/op
BenchmarkParse/t_1µs-7        	100000000	        10.14 ns/op	       0 B/op	       0 allocs/op
BenchmarkParse/t_1ms-7        	94272541	        12.00 ns/op	       0 B/op	       0 allocs/op
BenchmarkParse/t_1s-7         	100000000	        10.12 ns/op	       0 B/op	       0 allocs/op
BenchmarkParse/t_1m-7         	100000000	        11.35 ns/op	       0 B/op	       0 allocs/op
BenchmarkParse/t_1h-7         	95456136	        12.64 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseWithDefault/t_1ns_and_d_50_millisecond-7         	144522436	         8.491 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseWithDefault/t_1µs_and_d_50_millisecond-7         	143124103	         8.882 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseWithDefault/t_1ms_and_d_50_millisecond-7         	100000000	        10.55 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseWithDefault/t_1s_and_d_50_millisecond-7          	137396325	         9.680 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseWithDefault/t_1m_and_d_50_millisecond-7          	117594116	         9.829 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseWithDefault/t_1h_and_d_50_millisecond-7          	99942590	        10.91 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseWithDefault/t_1days_and_d_50_millisecond-7       	 3074391	       392.0 ns/op	     336 B/op	       9 allocs/op
BenchmarkParseWithDefault/t_1month_and_d_50_millisecond-7      	 2906296	       410.0 ns/op	     368 B/op	       9 allocs/op
BenchmarkParseWithDefault/t_10month_and_d_50_millisecond-7     	 2822518	       442.3 ns/op	     368 B/op	       9 allocs/op
BenchmarkParseWithDefault/t_100month_and_d_50_millisecond-7    	 2812122	       427.2 ns/op	     384 B/op	       9 allocs/op
BenchmarkParseWithDefault/t_1000month_and_d_50_millisecond-7   	 2759754	       426.8 ns/op	     384 B/op	       9 allocs/op
BenchmarkParseWithDefault/t_10000month_and_d_50_millisecond-7  	 2839292	       460.2 ns/op	     384 B/op	       9 allocs/op
PASS
ok  	github.com/vdaas/vald/internal/timeutil	29.154s
```

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [x] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
