### PR TITLE
change params for passing test of internal/backoff

### DIFF
--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -298,7 +298,7 @@ func Test_backoff_Do(t *testing.T) {
 				return nil, false, err
 			}
 			return test{
-				name: "return nil response and error when function return (nil, true, error) and maxRetryCount = 0",
+				name: "return nil response and error when function return (nil, false, error) and maxRetryCount = 0",
 				args: args{
 					ctx: ctx,
 					f:   f,
@@ -427,7 +427,7 @@ func Test_backoff_Do(t *testing.T) {
 				return str, true, err
 			}
 			return test{
-				name: "return response and error when function return (string, false, error) and maxRetryCount = 1, errLog is true",
+				name: "return response and error when function return (string, true, error) and maxRetryCount = 1, errLog is true",
 				args: args{
 					ctx: ctx,
 					f:   f,
@@ -457,7 +457,7 @@ func Test_backoff_Do(t *testing.T) {
 				return str, true, err
 			}
 			return test{
-				name: "return nil response and error when function returns (string, false, error) and context will be closed due to timelimit",
+				name: "return nil response and error when function returns (string, true, error) and context will be closed due to timelimit",
 				args: args{
 					ctx: ctx,
 					f:   f,
@@ -468,10 +468,10 @@ func Test_backoff_Do(t *testing.T) {
 					initialDuration:       0,
 					jittedInitialDuration: 0,
 					jitterLimit:           0,
-					durationLimit:         10,
+					durationLimit:         0,
 					maxDuration:           0,
 					maxRetryCount:         1,
-					backoffTimeLimit:      1 * time.Microsecond,
+					backoffTimeLimit:      0,
 					errLog:                true,
 				},
 				want: want{
@@ -487,7 +487,7 @@ func Test_backoff_Do(t *testing.T) {
 				return str, true, err
 			}
 			return test{
-				name: "return nil response and error when function returns (string, false, error) and calls cancel()",
+				name: "return nil response and error when function returns (string, true, error) and calls cancel()",
 				args: args{
 					ctx: ctx,
 					f:   f,
@@ -501,7 +501,7 @@ func Test_backoff_Do(t *testing.T) {
 					durationLimit:         10,
 					maxDuration:           0,
 					maxRetryCount:         1,
-					backoffTimeLimit:      1 * time.Microsecond,
+					backoffTimeLimit:      100 * time.Microsecond,
 					errLog:                true,
 				},
 				want: want{
@@ -550,7 +550,7 @@ func Test_backoff_Do(t *testing.T) {
 			f := func(context.Context) (interface{}, bool, error) {
 				cnt++
 				if cnt > 1 {
-					time.Sleep(10000 * time.Microsecond)
+					time.Sleep(1000 * time.Microsecond)
 				}
 				return str, true, err
 			}

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -521,7 +521,7 @@ func Test_backoff_Do(t *testing.T) {
 				return str, true, err
 			}
 			return test{
-				name: "return nil response and error when function calls cancel()",
+				name: "return nil response and error when function returns (string, true, error) and calls cancel() in 2nd times",
 				args: args{
 					ctx: ctx,
 					f:   f,

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -521,7 +521,7 @@ func Test_backoff_Do(t *testing.T) {
 				return str, true, err
 			}
 			return test{
-				name: "return response and error when function calls cancel()",
+				name: "return nil response and error when function calls cancel()",
 				args: args{
 					ctx: ctx,
 					f:   f,


### PR DESCRIPTION
Signed-off-by: vankichi <kyukawa315@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
I updated the parameter due to sometimes failing tests about `internal/backoff` pkg.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
