### PR TITLE
Add internal/config/discoverer test

### DIFF
--- a/internal/config/discoverer.go
+++ b/internal/config/discoverer.go
@@ -17,7 +17,7 @@
 // Package config providers configuration type and load configuration logic
 package config
 
-// Discoverer represents Discoverer configuration.
+// Discoverer represents the Discoverer configurations.
 type Discoverer struct {
 	Name              string `json:"name" yaml:"name"`
 	Namespace         string `json:"namespace" yaml:"namespace"`
@@ -38,7 +38,7 @@ func (d *Discoverer) Bind() *Discoverer {
 	return d
 }
 
-// DiscovererClient represents DiscovererClient configuration.
+// DiscovererClient represents the DiscovererClient configurations.
 type DiscovererClient struct {
 	Duration           string      `json:"duration" yaml:"duration"`
 	Client             *GRPCClient `json:"client" yaml:"client"`

--- a/internal/config/discoverer.go
+++ b/internal/config/discoverer.go
@@ -17,6 +17,7 @@
 // Package config providers configuration type and load configuration logic
 package config
 
+// Discoverer represents Discoverer configuration.
 type Discoverer struct {
 	Name              string `json:"name" yaml:"name"`
 	Namespace         string `json:"namespace" yaml:"namespace"`
@@ -24,6 +25,7 @@ type Discoverer struct {
 	Net               *Net   `json:"net" yaml:"net"`
 }
 
+// Bind binds the actual data from the Discoverer receiver field.
 func (d *Discoverer) Bind() *Discoverer {
 	d.Name = GetActualValue(d.Name)
 	d.Namespace = GetActualValue(d.Namespace)
@@ -36,12 +38,14 @@ func (d *Discoverer) Bind() *Discoverer {
 	return d
 }
 
+// DiscovererClient represents DiscovererClient configuration.
 type DiscovererClient struct {
 	Duration           string      `json:"duration" yaml:"duration"`
 	Client             *GRPCClient `json:"client" yaml:"client"`
 	AgentClientOptions *GRPCClient `json:"agent_client_options" yaml:"agent_client_options"`
 }
 
+// Bind binds the actual data from the DiscovererClient receiver field.
 func (d *DiscovererClient) Bind() *DiscovererClient {
 	d.Duration = GetActualValue(d.Duration)
 	if d.Client != nil {

--- a/internal/config/discoverer_test.go
+++ b/internal/config/discoverer_test.go
@@ -207,9 +207,21 @@ func TestDiscovererClient_Bind(t *testing.T) {
 				},
 				want: want{
 					want: &DiscovererClient{
-						Duration:           "10ms",
-						Client:             new(GRPCClient).Bind(),
-						AgentClientOptions: new(GRPCClient).Bind(),
+						Duration: "10ms",
+						Client: &GRPCClient{
+							ConnectionPool: new(ConnectionPool),
+							DialOption: &DialOption{
+								Insecure: true,
+							},
+							TLS: new(TLS),
+						},
+						AgentClientOptions: &GRPCClient{
+							ConnectionPool: new(ConnectionPool),
+							DialOption: &DialOption{
+								Insecure: true,
+							},
+							TLS: new(TLS),
+						},
 					},
 				},
 			}

--- a/internal/config/discoverer_test.go
+++ b/internal/config/discoverer_test.go
@@ -90,17 +90,18 @@ func TestDiscoverer_Bind(t *testing.T) {
 			}
 		}(),
 		func() test {
+			suffix := "_FOR_TEST_DISCOVERER_BIND"
 			m := map[string]string{
-				"NAME_FOR_DISCOVERER_TEST":               "discoverer",
-				"NAMESPACE_FOR_DISCOVERER_TEST":          "vald",
-				"DISCOVERY_DURATION_FOR_DISCOVERER_TEST": "10ms",
+				"NAME" + suffix:               "discoverer",
+				"NAMESPACE" + suffix:          "vald",
+				"DISCOVERY_DURATION" + suffix: "10ms",
 			}
 			return test{
 				name: "return Discoverer when the bind successes and the data is loaded from the environment variable",
 				fields: fields{
-					Name:              "_NAME_FOR_DISCOVERER_TEST_",
-					Namespace:         "_NAMESPACE_FOR_DISCOVERER_TEST_",
-					DiscoveryDuration: "_DISCOVERY_DURATION_FOR_DISCOVERER_TEST_",
+					Name:              "_NAME" + suffix + "_",
+					Namespace:         "_NAMESPACE" + suffix + "_",
+					DiscoveryDuration: "_DISCOVERY_DURATION" + suffix + "_",
 				},
 				beforeFunc: func(t *testing.T) {
 					t.Helper()
@@ -159,6 +160,7 @@ func TestDiscoverer_Bind(t *testing.T) {
 }
 
 func TestDiscovererClient_Bind(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		Duration           string
 		Client             *GRPCClient
@@ -238,7 +240,7 @@ func TestDiscovererClient_Bind(t *testing.T) {
 			}
 		}(),
 		func() test {
-			key := "DURATION"
+			key := "DURATION_FOR_TEST_DISCOVERER_CLIENT_BIND"
 			val := "10ms"
 
 			return test{
@@ -279,6 +281,7 @@ func TestDiscovererClient_Bind(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc(tt)

--- a/internal/config/discoverer_test.go
+++ b/internal/config/discoverer_test.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -26,11 +27,11 @@ import (
 )
 
 func TestDiscoverer_Bind(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		Name              string
 		Namespace         string
 		DiscoveryDuration string
+		Net               *Net
 	}
 	type want struct {
 		want *Discoverer
@@ -40,8 +41,8 @@ func TestDiscoverer_Bind(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, *Discoverer) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, got *Discoverer) error {
 		if !reflect.DeepEqual(got, w.want) {
@@ -50,47 +51,92 @@ func TestDiscoverer_Bind(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           Name: "",
-		           Namespace: "",
-		           DiscoveryDuration: "",
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           Name: "",
-		           Namespace: "",
-		           DiscoveryDuration: "",
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+		func() test {
+			return test{
+				name: "return Discoverer when the bind successes",
+				fields: fields{
+					Name:              "discoverer",
+					Namespace:         "vald",
+					DiscoveryDuration: "10ms",
+				},
+				want: want{
+					want: &Discoverer{
+						Name:              "discoverer",
+						Namespace:         "vald",
+						DiscoveryDuration: "10ms",
+						Net:               new(Net),
+					},
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "return Discoverer when the bind successes and Net is not nil",
+				fields: fields{
+					Name:              "discoverer",
+					Namespace:         "vald",
+					DiscoveryDuration: "10ms",
+					Net:               new(Net),
+				},
+				want: want{
+					want: &Discoverer{
+						Name:              "discoverer",
+						Namespace:         "vald",
+						DiscoveryDuration: "10ms",
+						Net:               new(Net).Bind(),
+					},
+				},
+			}
+		}(),
+		func() test {
+			m := map[string]string{
+				"NAME":               "discoverer",
+				"NAMESPACE":          "vald",
+				"DISCOVERY_DURATION": "10ms",
+			}
+			return test{
+				name: "return Discoverer when the bind successes and the data is loaded from the environment variable",
+				fields: fields{
+					Name:              "_NAME_",
+					Namespace:         "_NAMESPACE_",
+					DiscoveryDuration: "_DISCOVERY_DURATION_",
+				},
+				beforeFunc: func(t *testing.T) {
+					t.Helper()
+					for key, val := range m {
+						if err := os.Setenv(key, val); err != nil {
+							t.Fatal(err)
+						}
+					}
+				},
+				afterFunc: func(t *testing.T) {
+					t.Helper()
+					for key := range m {
+						if err := os.Unsetenv(key); err != nil {
+							t.Fatal(err)
+						}
+					}
+				},
+				want: want{
+					want: &Discoverer{
+						Name:              "discoverer",
+						Namespace:         "vald",
+						DiscoveryDuration: "10ms",
+						Net:               new(Net),
+					},
+				},
+			}
+		}(),
 	}
 
-	for _, tc := range tests {
-		test := tc
+	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			tt.Parallel()
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			if test.checkFunc == nil {
 				test.checkFunc = defaultCheckFunc
@@ -110,7 +156,6 @@ func TestDiscoverer_Bind(t *testing.T) {
 }
 
 func TestDiscovererClient_Bind(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		Duration           string
 		Client             *GRPCClient
@@ -124,8 +169,8 @@ func TestDiscovererClient_Bind(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, *DiscovererClient) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, got *DiscovererClient) error {
 		if !reflect.DeepEqual(got, w.want) {
@@ -134,47 +179,81 @@ func TestDiscovererClient_Bind(t *testing.T) {
 		return nil
 	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       fields: fields {
-		           Duration: "",
-		           Client: GRPCClient{},
-		           AgentClientOptions: GRPCClient{},
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		   },
-		*/
+		func() test {
+			return test{
+				name: "return DiscovererClient when the bind successes",
+				fields: fields{
+					Duration: "10ms",
+				},
+				want: want{
+					want: &DiscovererClient{
+						Duration:           "10ms",
+						Client:             newGRPCClientConfig(),
+						AgentClientOptions: newGRPCClientConfig(),
+					},
+				},
+			}
+		}(),
+		func() test {
+			c := new(GRPCClient)
+			ac := new(GRPCClient)
 
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           fields: fields {
-		           Duration: "",
-		           Client: GRPCClient{},
-		           AgentClientOptions: GRPCClient{},
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		       }
-		   }(),
-		*/
+			return test{
+				name: "return DiscovererClient when the bind successes and Client and AgentClientOptions is not nil",
+				fields: fields{
+					Duration:           "10ms",
+					Client:             c,
+					AgentClientOptions: ac,
+				},
+				want: want{
+					want: &DiscovererClient{
+						Duration:           "10ms",
+						Client:             new(GRPCClient).Bind(),
+						AgentClientOptions: new(GRPCClient).Bind(),
+					},
+				},
+			}
+		}(),
+		func() test {
+			key := "DURATION"
+			val := "10ms"
+
+			return test{
+				name: "return DiscovererClient when the bind successes and the data is loaded from the environment variable",
+				fields: fields{
+					Duration: "_" + key + "_",
+				},
+				beforeFunc: func(t *testing.T) {
+					t.Helper()
+					if err := os.Setenv(key, val); err != nil {
+						t.Fatal(err)
+					}
+				},
+				afterFunc: func(t *testing.T) {
+					t.Helper()
+					if err := os.Unsetenv(key); err != nil {
+						t.Fatal(err)
+					}
+				},
+				want: want{
+					want: &DiscovererClient{
+						Duration:           "10ms",
+						Client:             newGRPCClientConfig(),
+						AgentClientOptions: newGRPCClientConfig(),
+					},
+				},
+			}
+		}(),
 	}
 
-	for _, tc := range tests {
-		test := tc
+	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			tt.Parallel()
-			defer goleak.VerifyNone(tt)
+			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			if test.checkFunc == nil {
 				test.checkFunc = defaultCheckFunc

--- a/internal/config/discoverer_test.go
+++ b/internal/config/discoverer_test.go
@@ -83,7 +83,7 @@ func TestDiscoverer_Bind(t *testing.T) {
 						Name:              "discoverer",
 						Namespace:         "vald",
 						DiscoveryDuration: "10ms",
-						Net:               new(Net).Bind(),
+						Net:               new(Net),
 					},
 				},
 			}

--- a/internal/config/discoverer_test.go
+++ b/internal/config/discoverer_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestDiscoverer_Bind(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		Name              string
 		Namespace         string
@@ -90,16 +91,16 @@ func TestDiscoverer_Bind(t *testing.T) {
 		}(),
 		func() test {
 			m := map[string]string{
-				"NAME":               "discoverer",
-				"NAMESPACE":          "vald",
-				"DISCOVERY_DURATION": "10ms",
+				"NAME_FOR_DISCOVERER_TEST":               "discoverer",
+				"NAMESPACE_FOR_DISCOVERER_TEST":          "vald",
+				"DISCOVERY_DURATION_FOR_DISCOVERER_TEST": "10ms",
 			}
 			return test{
 				name: "return Discoverer when the bind successes and the data is loaded from the environment variable",
 				fields: fields{
-					Name:              "_NAME_",
-					Namespace:         "_NAMESPACE_",
-					DiscoveryDuration: "_DISCOVERY_DURATION_",
+					Name:              "_NAME_FOR_DISCOVERER_TEST_",
+					Namespace:         "_NAMESPACE_FOR_DISCOVERER_TEST_",
+					DiscoveryDuration: "_DISCOVERY_DURATION_FOR_DISCOVERER_TEST_",
 				},
 				beforeFunc: func(t *testing.T) {
 					t.Helper()
@@ -129,9 +130,11 @@ func TestDiscoverer_Bind(t *testing.T) {
 		}(),
 	}
 
-	for _, test := range tests {
+	for _, tc := range tests {
+		test := tc
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc(tt)
 			}
@@ -187,9 +190,17 @@ func TestDiscovererClient_Bind(t *testing.T) {
 				},
 				want: want{
 					want: &DiscovererClient{
-						Duration:           "10ms",
-						Client:             newGRPCClientConfig(),
-						AgentClientOptions: newGRPCClientConfig(),
+						Duration: "10ms",
+						Client: &GRPCClient{
+							DialOption: &DialOption{
+								Insecure: true,
+							},
+						},
+						AgentClientOptions: &GRPCClient{
+							DialOption: &DialOption{
+								Insecure: true,
+							},
+						},
 					},
 				},
 			}
@@ -249,9 +260,17 @@ func TestDiscovererClient_Bind(t *testing.T) {
 				},
 				want: want{
 					want: &DiscovererClient{
-						Duration:           "10ms",
-						Client:             newGRPCClientConfig(),
-						AgentClientOptions: newGRPCClientConfig(),
+						Duration: "10ms",
+						Client: &GRPCClient{
+							DialOption: &DialOption{
+								Insecure: true,
+							},
+						},
+						AgentClientOptions: &GRPCClient{
+							DialOption: &DialOption{
+								Insecure: true,
+							},
+						},
 					},
 				},
 			}
@@ -260,7 +279,7 @@ func TestDiscovererClient_Bind(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			defer goleak.VerifyNone(tt, goleakIgnoreOptions...)
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
 				test.beforeFunc(tt)
 			}


### PR DESCRIPTION
Signed-off-by: hlts2 <hiroto.funakoshi.hiroto@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

I added test for `internal/config/discoverer` and godoc comment.

**gramer check passed**

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
