### PR TITLE
create internal/config/redis test

### DIFF
--- a/internal/config/redis.go
+++ b/internal/config/redis.go
@@ -100,7 +100,7 @@ func (r *Redis) Bind() *Redis {
 }
 
 // Opts creates the functional option list from the Redis.
-// If the error is ocurred, it will return no functional options and the error.
+// If the error occurs, it will return no functional options and the error.
 func (r *Redis) Opts() (opts []redis.Option, err error) {
 	nt := net.NetworkTypeFromString(r.Network)
 	if nt == 0 || nt == net.Unknown || strings.EqualFold(nt.String(), net.Unknown.String()) {

--- a/internal/config/redis.go
+++ b/internal/config/redis.go
@@ -27,6 +27,7 @@ import (
 	"github.com/vdaas/vald/internal/tls"
 )
 
+// Redis represents the configuration for redis cluster.
 type Redis struct {
 	Addrs                []string `json:"addrs,omitempty" yaml:"addrs"`
 	DB                   int      `json:"db,omitempty" yaml:"db"`
@@ -61,6 +62,7 @@ type Redis struct {
 	WriteTimeout         string   `json:"write_timeout,omitempty" yaml:"write_timeout"`
 }
 
+// Bind binds the actual data from the Redis receiver fields.
 func (r *Redis) Bind() *Redis {
 	if r.TLS != nil {
 		r.TLS.Bind()
@@ -74,7 +76,6 @@ func (r *Redis) Bind() *Redis {
 	}
 
 	r.Addrs = GetActualValues(r.Addrs)
-	r.DialTimeout = GetActualValue(r.DialTimeout)
 	r.DialTimeout = GetActualValue(r.DialTimeout)
 	r.IdleCheckFrequency = GetActualValue(r.IdleCheckFrequency)
 	r.IdleTimeout = GetActualValue(r.IdleTimeout)
@@ -98,6 +99,8 @@ func (r *Redis) Bind() *Redis {
 	return r
 }
 
+// Opts creates the functional option list from the Redis.
+// If the error is ocurred, it will return no functional options and the error.
 func (r *Redis) Opts() (opts []redis.Option, err error) {
 	nt := net.NetworkTypeFromString(r.Network)
 	if nt == 0 || nt == net.Unknown || strings.EqualFold(nt.String(), net.Unknown.String()) {

--- a/internal/config/redis.go
+++ b/internal/config/redis.go
@@ -126,6 +126,9 @@ func (r *Redis) Opts() (opts []redis.Option, err error) {
 		redis.WithPassword(r.Password),
 		redis.WithPoolSize(r.PoolSize),
 		redis.WithPoolTimeout(r.PoolTimeout),
+		// In the current implementation, we do not need to use the read only flag for redis usages.
+		// This implementation is to only align to the redis interface.
+		// We will remove this comment out if we need to use this.
 		// redis.WithReadOnlyFlag(readOnly bool) ,
 		redis.WithNetwork(r.Network),
 		redis.WithReadTimeout(r.ReadTimeout),

--- a/internal/config/redis_test.go
+++ b/internal/config/redis_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/vdaas/vald/internal/db/kvs/redis"
 	"github.com/vdaas/vald/internal/errors"
+	testdata "github.com/vdaas/vald/internal/test"
 	"go.uber.org/goleak"
 )
 
@@ -488,7 +489,8 @@ func TestRedis_Opts(t *testing.T) {
 			name: "return 26 []redis.Options and nil error when all parameters are set",
 			fields: fields{
 				Addrs: []string{
-					"redis.default.svc.cluster.local:6379",
+					"redis-01.default.svc.cluster.local:6379",
+					"redis-02.default.svc.cluster.local:6379",
 				},
 				DB:                   0,
 				DialTimeout:          "5s",
@@ -542,14 +544,17 @@ func TestRedis_Opts(t *testing.T) {
 					},
 				},
 				TLS: &TLS{
-					Enabled: false,
+					Enabled: true,
+					Cert:    testdata.GetTestdataPath("tls/dummyServer.crt"),
+					Key:     testdata.GetTestdataPath("tls/dummyServer.key"),
+					CA:      testdata.GetTestdataPath("tls/dummyCa.pem"),
 				},
 				Username:     "vald",
 				VKPrefix:     "",
 				WriteTimeout: "3s",
 			},
 			want: want{
-				wantOpts: make([]redis.Option, 26),
+				wantOpts: make([]redis.Option, 27),
 			},
 		},
 		{


### PR DESCRIPTION
Signed-off-by: vankichi <kyukawa315@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
I created the test for `internal/config/redis.go`.
grammar check has passed.

In `internal/config/redis.go`, I found `WithReadOnlyFlag()` is not used in `Opts()` method.
I'm not sure it is ok, please tell me how should I handle it ( @kpango or @rinx )

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
