### PR TITLE
Fix typo & missed schema definition

### DIFF
--- a/charts/vald-helm-operator/crds/valdrelease.yaml
+++ b/charts/vald-helm-operator/crds/valdrelease.yaml
@@ -520,7 +520,7 @@ spec:
                                       type: integer
                                     successThreshold:
                                       type: integer
-                                    timetoutSeconds:
+                                    timeoutSeconds:
                                       type: integer
                                 port:
                                   type: integer
@@ -567,19 +567,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -661,19 +661,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -736,19 +736,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -808,19 +808,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -916,19 +916,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -988,19 +988,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -1127,19 +1127,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     tls:
                                       type: object
@@ -1234,6 +1234,8 @@ spec:
                                   type: string
                                 retry_count:
                                   type: integer
+                            restore_backoff_enabled:
+                              type: boolean
                             watch_enabled:
                               type: boolean
                         enabled:
@@ -1482,7 +1484,7 @@ spec:
                                           type: integer
                                         successThreshold:
                                           type: integer
-                                        timetoutSeconds:
+                                        timeoutSeconds:
                                           type: integer
                                     port:
                                       type: integer
@@ -1529,19 +1531,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -1623,19 +1625,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -1698,19 +1700,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -1770,19 +1772,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -1878,19 +1880,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -1950,19 +1952,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -2141,19 +2143,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     tls:
                                       type: object
@@ -2420,7 +2422,7 @@ spec:
                                       type: integer
                                     successThreshold:
                                       type: integer
-                                    timetoutSeconds:
+                                    timeoutSeconds:
                                       type: integer
                                 port:
                                   type: integer
@@ -2467,19 +2469,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -2561,19 +2563,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -2636,19 +2638,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -2708,19 +2710,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -2816,19 +2818,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -2888,19 +2890,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -3025,19 +3027,19 @@ spec:
                                   type: boolean
                                 ip_transparent:
                                   type: boolean
-                                net_cork:
-                                  type: boolean
-                                net_defer_accept:
-                                  type: boolean
-                                net_fast_open:
-                                  type: boolean
-                                net_no_delay:
-                                  type: boolean
-                                net_quick_ack:
-                                  type: boolean
                                 reuse_addr:
                                   type: boolean
                                 reuse_port:
+                                  type: boolean
+                                tcp_cork:
+                                  type: boolean
+                                tcp_defer_accept:
+                                  type: boolean
+                                tcp_fast_open:
+                                  type: boolean
+                                tcp_no_delay:
+                                  type: boolean
+                                tcp_quick_ack:
                                   type: boolean
                             tls:
                               type: object
@@ -3356,7 +3358,7 @@ spec:
                                       type: integer
                                     successThreshold:
                                       type: integer
-                                    timetoutSeconds:
+                                    timeoutSeconds:
                                       type: integer
                                 port:
                                   type: integer
@@ -3403,19 +3405,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -3497,19 +3499,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -3572,19 +3574,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -3644,19 +3646,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -3752,19 +3754,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -3824,19 +3826,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -4073,19 +4075,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         tls:
                                           type: object
@@ -4229,19 +4231,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         tls:
                                           type: object
@@ -4594,7 +4596,7 @@ spec:
                                           type: integer
                                         successThreshold:
                                           type: integer
-                                        timetoutSeconds:
+                                        timeoutSeconds:
                                           type: integer
                                     port:
                                       type: integer
@@ -4641,19 +4643,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -4735,19 +4737,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -4810,19 +4812,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -4882,19 +4884,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -4990,19 +4992,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -5062,19 +5064,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -5304,19 +5306,19 @@ spec:
                                                   type: boolean
                                                 ip_transparent:
                                                   type: boolean
-                                                net_cork:
-                                                  type: boolean
-                                                net_defer_accept:
-                                                  type: boolean
-                                                net_fast_open:
-                                                  type: boolean
-                                                net_no_delay:
-                                                  type: boolean
-                                                net_quick_ack:
-                                                  type: boolean
                                                 reuse_addr:
                                                   type: boolean
                                                 reuse_port:
+                                                  type: boolean
+                                                tcp_cork:
+                                                  type: boolean
+                                                tcp_defer_accept:
+                                                  type: boolean
+                                                tcp_fast_open:
+                                                  type: boolean
+                                                tcp_no_delay:
+                                                  type: boolean
+                                                tcp_quick_ack:
                                                   type: boolean
                                             tls:
                                               type: object
@@ -5468,19 +5470,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         tls:
                                           type: object
@@ -5627,19 +5629,19 @@ spec:
                                                   type: boolean
                                                 ip_transparent:
                                                   type: boolean
-                                                net_cork:
-                                                  type: boolean
-                                                net_defer_accept:
-                                                  type: boolean
-                                                net_fast_open:
-                                                  type: boolean
-                                                net_no_delay:
-                                                  type: boolean
-                                                net_quick_ack:
-                                                  type: boolean
                                                 reuse_addr:
                                                   type: boolean
                                                 reuse_port:
+                                                  type: boolean
+                                                tcp_cork:
+                                                  type: boolean
+                                                tcp_defer_accept:
+                                                  type: boolean
+                                                tcp_fast_open:
+                                                  type: boolean
+                                                tcp_no_delay:
+                                                  type: boolean
+                                                tcp_quick_ack:
                                                   type: boolean
                                             tls:
                                               type: object
@@ -6010,7 +6012,7 @@ spec:
                                           type: integer
                                         successThreshold:
                                           type: integer
-                                        timetoutSeconds:
+                                        timeoutSeconds:
                                           type: integer
                                     port:
                                       type: integer
@@ -6057,19 +6059,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -6151,19 +6153,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -6226,19 +6228,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -6298,19 +6300,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -6406,19 +6408,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -6478,19 +6480,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -6722,19 +6724,19 @@ spec:
                                                   type: boolean
                                                 ip_transparent:
                                                   type: boolean
-                                                net_cork:
-                                                  type: boolean
-                                                net_defer_accept:
-                                                  type: boolean
-                                                net_fast_open:
-                                                  type: boolean
-                                                net_no_delay:
-                                                  type: boolean
-                                                net_quick_ack:
-                                                  type: boolean
                                                 reuse_addr:
                                                   type: boolean
                                                 reuse_port:
+                                                  type: boolean
+                                                tcp_cork:
+                                                  type: boolean
+                                                tcp_defer_accept:
+                                                  type: boolean
+                                                tcp_fast_open:
+                                                  type: boolean
+                                                tcp_no_delay:
+                                                  type: boolean
+                                                tcp_quick_ack:
                                                   type: boolean
                                             tls:
                                               type: object
@@ -6878,19 +6880,19 @@ spec:
                                                   type: boolean
                                                 ip_transparent:
                                                   type: boolean
-                                                net_cork:
-                                                  type: boolean
-                                                net_defer_accept:
-                                                  type: boolean
-                                                net_fast_open:
-                                                  type: boolean
-                                                net_no_delay:
-                                                  type: boolean
-                                                net_quick_ack:
-                                                  type: boolean
                                                 reuse_addr:
                                                   type: boolean
                                                 reuse_port:
+                                                  type: boolean
+                                                tcp_cork:
+                                                  type: boolean
+                                                tcp_defer_accept:
+                                                  type: boolean
+                                                tcp_fast_open:
+                                                  type: boolean
+                                                tcp_no_delay:
+                                                  type: boolean
+                                                tcp_quick_ack:
                                                   type: boolean
                                             tls:
                                               type: object
@@ -6939,7 +6941,7 @@ spec:
                             index_replica:
                               type: integer
                               minimum: 1
-                            node_namespace:
+                            node_name:
                               type: string
                         hpa:
                           type: object
@@ -7250,7 +7252,7 @@ spec:
                                           type: integer
                                         successThreshold:
                                           type: integer
-                                        timetoutSeconds:
+                                        timeoutSeconds:
                                           type: integer
                                     port:
                                       type: integer
@@ -7297,19 +7299,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -7391,19 +7393,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -7466,19 +7468,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -7538,19 +7540,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -7646,19 +7648,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -7718,19 +7720,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -7957,19 +7959,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         tls:
                                           type: object
@@ -8118,19 +8120,19 @@ spec:
                                                   type: boolean
                                                 ip_transparent:
                                                   type: boolean
-                                                net_cork:
-                                                  type: boolean
-                                                net_defer_accept:
-                                                  type: boolean
-                                                net_fast_open:
-                                                  type: boolean
-                                                net_no_delay:
-                                                  type: boolean
-                                                net_quick_ack:
-                                                  type: boolean
                                                 reuse_addr:
                                                   type: boolean
                                                 reuse_port:
+                                                  type: boolean
+                                                tcp_cork:
+                                                  type: boolean
+                                                tcp_defer_accept:
+                                                  type: boolean
+                                                tcp_fast_open:
+                                                  type: boolean
+                                                tcp_no_delay:
+                                                  type: boolean
+                                                tcp_quick_ack:
                                                   type: boolean
                                             tls:
                                               type: object
@@ -8487,7 +8489,7 @@ spec:
                                           type: integer
                                         successThreshold:
                                           type: integer
-                                        timetoutSeconds:
+                                        timeoutSeconds:
                                           type: integer
                                     port:
                                       type: integer
@@ -8534,19 +8536,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -8628,19 +8630,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -8703,19 +8705,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -8775,19 +8777,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -8883,19 +8885,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -8955,19 +8957,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -9199,19 +9201,19 @@ spec:
                                                   type: boolean
                                                 ip_transparent:
                                                   type: boolean
-                                                net_cork:
-                                                  type: boolean
-                                                net_defer_accept:
-                                                  type: boolean
-                                                net_fast_open:
-                                                  type: boolean
-                                                net_no_delay:
-                                                  type: boolean
-                                                net_quick_ack:
-                                                  type: boolean
                                                 reuse_addr:
                                                   type: boolean
                                                 reuse_port:
+                                                  type: boolean
+                                                tcp_cork:
+                                                  type: boolean
+                                                tcp_defer_accept:
+                                                  type: boolean
+                                                tcp_fast_open:
+                                                  type: boolean
+                                                tcp_no_delay:
+                                                  type: boolean
+                                                tcp_quick_ack:
                                                   type: boolean
                                             tls:
                                               type: object
@@ -9358,19 +9360,19 @@ spec:
                                                   type: boolean
                                                 ip_transparent:
                                                   type: boolean
-                                                net_cork:
-                                                  type: boolean
-                                                net_defer_accept:
-                                                  type: boolean
-                                                net_fast_open:
-                                                  type: boolean
-                                                net_no_delay:
-                                                  type: boolean
-                                                net_quick_ack:
-                                                  type: boolean
                                                 reuse_addr:
                                                   type: boolean
                                                 reuse_port:
+                                                  type: boolean
+                                                tcp_cork:
+                                                  type: boolean
+                                                tcp_defer_accept:
+                                                  type: boolean
+                                                tcp_fast_open:
+                                                  type: boolean
+                                                tcp_no_delay:
+                                                  type: boolean
+                                                tcp_quick_ack:
                                                   type: boolean
                                             tls:
                                               type: object
@@ -9514,19 +9516,19 @@ spec:
                                                   type: boolean
                                                 ip_transparent:
                                                   type: boolean
-                                                net_cork:
-                                                  type: boolean
-                                                net_defer_accept:
-                                                  type: boolean
-                                                net_fast_open:
-                                                  type: boolean
-                                                net_no_delay:
-                                                  type: boolean
-                                                net_quick_ack:
-                                                  type: boolean
                                                 reuse_addr:
                                                   type: boolean
                                                 reuse_port:
+                                                  type: boolean
+                                                tcp_cork:
+                                                  type: boolean
+                                                tcp_defer_accept:
+                                                  type: boolean
+                                                tcp_fast_open:
+                                                  type: boolean
+                                                tcp_no_delay:
+                                                  type: boolean
+                                                tcp_quick_ack:
                                                   type: boolean
                                             tls:
                                               type: object
@@ -9680,19 +9682,19 @@ spec:
                                                   type: boolean
                                                 ip_transparent:
                                                   type: boolean
-                                                net_cork:
-                                                  type: boolean
-                                                net_defer_accept:
-                                                  type: boolean
-                                                net_fast_open:
-                                                  type: boolean
-                                                net_no_delay:
-                                                  type: boolean
-                                                net_quick_ack:
-                                                  type: boolean
                                                 reuse_addr:
                                                   type: boolean
                                                 reuse_port:
+                                                  type: boolean
+                                                tcp_cork:
+                                                  type: boolean
+                                                tcp_defer_accept:
+                                                  type: boolean
+                                                tcp_fast_open:
+                                                  type: boolean
+                                                tcp_no_delay:
+                                                  type: boolean
+                                                tcp_quick_ack:
                                                   type: boolean
                                             tls:
                                               type: object
@@ -9740,7 +9742,7 @@ spec:
                                   type: boolean
                                 expired_cache_check_duration:
                                   type: string
-                            node_namespace:
+                            node_name:
                               type: string
                         hpa:
                           type: object
@@ -10051,7 +10053,7 @@ spec:
                                           type: integer
                                         successThreshold:
                                           type: integer
-                                        timetoutSeconds:
+                                        timeoutSeconds:
                                           type: integer
                                     port:
                                       type: integer
@@ -10098,19 +10100,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -10192,19 +10194,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -10267,19 +10269,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -10339,19 +10341,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -10447,19 +10449,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -10519,19 +10521,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -10595,6 +10597,9 @@ spec:
                           items:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
+                initializer:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 manager:
                   type: object
                   properties:
@@ -10738,19 +10743,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     tls:
                                       type: object
@@ -10954,19 +10959,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     tls:
                                       type: object
@@ -11252,7 +11257,7 @@ spec:
                                           type: integer
                                         successThreshold:
                                           type: integer
-                                        timetoutSeconds:
+                                        timeoutSeconds:
                                           type: integer
                                     port:
                                       type: integer
@@ -11299,19 +11304,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -11393,19 +11398,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -11468,19 +11473,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -11540,19 +11545,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -11648,19 +11653,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -11720,19 +11725,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -11950,19 +11955,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         tls:
                                           type: object
@@ -12375,19 +12380,19 @@ spec:
                                                   type: boolean
                                                 ip_transparent:
                                                   type: boolean
-                                                net_cork:
-                                                  type: boolean
-                                                net_defer_accept:
-                                                  type: boolean
-                                                net_fast_open:
-                                                  type: boolean
-                                                net_no_delay:
-                                                  type: boolean
-                                                net_quick_ack:
-                                                  type: boolean
                                                 reuse_addr:
                                                   type: boolean
                                                 reuse_port:
+                                                  type: boolean
+                                                tcp_cork:
+                                                  type: boolean
+                                                tcp_defer_accept:
+                                                  type: boolean
+                                                tcp_fast_open:
+                                                  type: boolean
+                                                tcp_no_delay:
+                                                  type: boolean
+                                                tcp_quick_ack:
                                                   type: boolean
                                             tls:
                                               type: object
@@ -12492,7 +12497,7 @@ spec:
                                           type: integer
                                         successThreshold:
                                           type: integer
-                                        timetoutSeconds:
+                                        timeoutSeconds:
                                           type: integer
                                     port:
                                       type: integer
@@ -12539,19 +12544,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -12633,19 +12638,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -12708,19 +12713,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -12780,19 +12785,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -12888,19 +12893,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -12960,19 +12965,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -13228,19 +13233,19 @@ spec:
                                                   type: boolean
                                                 ip_transparent:
                                                   type: boolean
-                                                net_cork:
-                                                  type: boolean
-                                                net_defer_accept:
-                                                  type: boolean
-                                                net_fast_open:
-                                                  type: boolean
-                                                net_no_delay:
-                                                  type: boolean
-                                                net_quick_ack:
-                                                  type: boolean
                                                 reuse_addr:
                                                   type: boolean
                                                 reuse_port:
+                                                  type: boolean
+                                                tcp_cork:
+                                                  type: boolean
+                                                tcp_defer_accept:
+                                                  type: boolean
+                                                tcp_fast_open:
+                                                  type: boolean
+                                                tcp_no_delay:
+                                                  type: boolean
+                                                tcp_quick_ack:
                                                   type: boolean
                                             tls:
                                               type: object
@@ -13384,19 +13389,19 @@ spec:
                                                   type: boolean
                                                 ip_transparent:
                                                   type: boolean
-                                                net_cork:
-                                                  type: boolean
-                                                net_defer_accept:
-                                                  type: boolean
-                                                net_fast_open:
-                                                  type: boolean
-                                                net_no_delay:
-                                                  type: boolean
-                                                net_quick_ack:
-                                                  type: boolean
                                                 reuse_addr:
                                                   type: boolean
                                                 reuse_port:
+                                                  type: boolean
+                                                tcp_cork:
+                                                  type: boolean
+                                                tcp_defer_accept:
+                                                  type: boolean
+                                                tcp_fast_open:
+                                                  type: boolean
+                                                tcp_no_delay:
+                                                  type: boolean
+                                                tcp_quick_ack:
                                                   type: boolean
                                             tls:
                                               type: object
@@ -13651,6 +13656,9 @@ spec:
                               type: boolean
                             value:
                               type: integer
+                        podSecurityContext:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         progressDeadlineSeconds:
                           type: integer
                         replicas:
@@ -13713,7 +13721,7 @@ spec:
                                           type: integer
                                         successThreshold:
                                           type: integer
-                                        timetoutSeconds:
+                                        timeoutSeconds:
                                           type: integer
                                     port:
                                       type: integer
@@ -13760,19 +13768,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -13854,19 +13862,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -13929,19 +13937,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -14001,19 +14009,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -14109,19 +14117,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -14181,19 +14189,19 @@ spec:
                                               type: boolean
                                             ip_transparent:
                                               type: boolean
-                                            net_cork:
-                                              type: boolean
-                                            net_defer_accept:
-                                              type: boolean
-                                            net_fast_open:
-                                              type: boolean
-                                            net_no_delay:
-                                              type: boolean
-                                            net_quick_ack:
-                                              type: boolean
                                             reuse_addr:
                                               type: boolean
                                             reuse_port:
+                                              type: boolean
+                                            tcp_cork:
+                                              type: boolean
+                                            tcp_defer_accept:
+                                              type: boolean
+                                            tcp_fast_open:
+                                              type: boolean
+                                            tcp_no_delay:
+                                              type: boolean
+                                            tcp_quick_ack:
                                               type: boolean
                                         socket_path:
                                           type: string
@@ -14257,9 +14265,6 @@ spec:
                           items:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
-                mangaer:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
                 meta:
                   type: object
                   properties:
@@ -14400,19 +14405,19 @@ spec:
                                       type: boolean
                                     ip_transparent:
                                       type: boolean
-                                    net_cork:
-                                      type: boolean
-                                    net_defer_accept:
-                                      type: boolean
-                                    net_fast_open:
-                                      type: boolean
-                                    net_no_delay:
-                                      type: boolean
-                                    net_quick_ack:
-                                      type: boolean
                                     reuse_addr:
                                       type: boolean
                                     reuse_port:
+                                      type: boolean
+                                    tcp_cork:
+                                      type: boolean
+                                    tcp_defer_accept:
+                                      type: boolean
+                                    tcp_fast_open:
+                                      type: boolean
+                                    tcp_no_delay:
+                                      type: boolean
+                                    tcp_quick_ack:
                                       type: boolean
                                 tls:
                                   type: object
@@ -14807,19 +14812,19 @@ spec:
                                       type: boolean
                                     ip_transparent:
                                       type: boolean
-                                    net_cork:
-                                      type: boolean
-                                    net_defer_accept:
-                                      type: boolean
-                                    net_fast_open:
-                                      type: boolean
-                                    net_no_delay:
-                                      type: boolean
-                                    net_quick_ack:
-                                      type: boolean
                                     reuse_addr:
                                       type: boolean
                                     reuse_port:
+                                      type: boolean
+                                    tcp_cork:
+                                      type: boolean
+                                    tcp_defer_accept:
+                                      type: boolean
+                                    tcp_fast_open:
+                                      type: boolean
+                                    tcp_no_delay:
+                                      type: boolean
+                                    tcp_quick_ack:
                                       type: boolean
                                 tls:
                                   type: object
@@ -14942,7 +14947,7 @@ spec:
                                       type: integer
                                     successThreshold:
                                       type: integer
-                                    timetoutSeconds:
+                                    timeoutSeconds:
                                       type: integer
                                 port:
                                   type: integer
@@ -14989,19 +14994,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -15083,19 +15088,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -15158,19 +15163,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -15230,19 +15235,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -15338,19 +15343,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string
@@ -15410,19 +15415,19 @@ spec:
                                           type: boolean
                                         ip_transparent:
                                           type: boolean
-                                        net_cork:
-                                          type: boolean
-                                        net_defer_accept:
-                                          type: boolean
-                                        net_fast_open:
-                                          type: boolean
-                                        net_no_delay:
-                                          type: boolean
-                                        net_quick_ack:
-                                          type: boolean
                                         reuse_addr:
                                           type: boolean
                                         reuse_port:
+                                          type: boolean
+                                        tcp_cork:
+                                          type: boolean
+                                        tcp_defer_accept:
+                                          type: boolean
+                                        tcp_fast_open:
+                                          type: boolean
+                                        tcp_no_delay:
+                                          type: boolean
+                                        tcp_quick_ack:
                                           type: boolean
                                     socket_path:
                                       type: string

--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -1227,7 +1227,7 @@ gateway:
       # @schema {"name": "gateway.vald.gateway_config.agent_namespace", "type": "string"}
       # gateway.vald.gateway_config.agent_namespace -- agent namespace
       agent_namespace: _MY_POD_NAMESPACE_
-      # @schema {"name": "gateway.vald.gateway_config.node_namespace", "type": "string"}
+      # @schema {"name": "gateway.vald.gateway_config.node_name", "type": "string"}
       # gateway.vald.gateway_config.node_name -- node name
       node_name: "" # _MY_NODE_NAME_
       # @schema {"name": "gateway.vald.gateway_config.index_replica", "type": "integer", "minimum": 1}
@@ -1754,7 +1754,7 @@ gateway:
       # @schema {"name": "gateway.lb.gateway_config.agent_namespace", "type": "string"}
       # gateway.lb.gateway_config.agent_namespace -- agent namespace
       agent_namespace: _MY_POD_NAMESPACE_
-      # @schema {"name": "gateway.lb.gateway_config.node_namespace", "type": "string"}
+      # @schema {"name": "gateway.lb.gateway_config.node_name", "type": "string"}
       # gateway.lb.gateway_config.node_name -- node name
       node_name: "" # _MY_NODE_NAME_
       # @schema {"name": "gateway.lb.gateway_config.index_replica", "type": "integer", "minimum": 1}
@@ -3991,7 +3991,7 @@ manager:
     # @schema {"name": "manager.index.terminationGracePeriodSeconds", "type": "integer", "minimum": 0}
     # manager.index.terminationGracePeriodSeconds -- duration in seconds pod needs to terminate gracefully
     terminationGracePeriodSeconds: 30
-    # @schema {"name": "mangaer.index.podSecurityContext", "type": "object"}
+    # @schema {"name": "manager.index.podSecurityContext", "type": "object"}
     # manager.index.podSecurityContext -- security context for pod
     podSecurityContext:
       runAsUser: 1002
@@ -4701,6 +4701,7 @@ meta:
         # meta.cassandra.config.host_filter.white_list -- list of white_list which allows each connection
         white_list: []
 
+# @schema {"name": "initializer", "type": "object"}
 initializer:
   mysql:
     # initializer.mysql.enabled -- mysql initializer job enabled

--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -99,26 +99,26 @@ defaults:
             # @schema {"name": "defaults.server_config.servers.rest.server.socket_option.reuse_addr", "type": "boolean"}
             # defaults.server_config.servers.rest.server.socket_option.reuse_addr -- server listen socket option for reuse_addr functionality
             reuse_addr: true
-            # @schema {"name": "defaults.server_config.servers.rest.server.socket_option.net_fast_open", "type": "boolean"}
-            # defaults.server_config.servers.rest.server.socket_option.reuse_port -- server listen socket option for tcp_fast_open functionality
+            # @schema {"name": "defaults.server_config.servers.rest.server.socket_option.tcp_fast_open", "type": "boolean"}
+            # defaults.server_config.servers.rest.server.socket_option.tcp_fast_open -- server listen socket option for tcp_fast_open functionality
             tcp_fast_open: true
-            # @schema {"name": "defaults.server_config.servers.rest.server.socket_option.net_no_delay", "type": "boolean"}
-            # defaults.server_config.servers.rest.server.socket_option.reuse_port -- server listen socket option for tcp_no_delay functionality
+            # @schema {"name": "defaults.server_config.servers.rest.server.socket_option.tcp_no_delay", "type": "boolean"}
+            # defaults.server_config.servers.rest.server.socket_option.tcp_no_delay -- server listen socket option for tcp_no_delay functionality
             tcp_no_delay: true
-            # @schema {"name": "defaults.server_config.servers.rest.server.socket_option.net_cork", "type": "boolean"}
-            # defaults.server_config.servers.rest.server.socket_option.reuse_port -- server listen socket option for tcp_cork functionality
+            # @schema {"name": "defaults.server_config.servers.rest.server.socket_option.tcp_cork", "type": "boolean"}
+            # defaults.server_config.servers.rest.server.socket_option.tcp_cork -- server listen socket option for tcp_cork functionality
             tcp_cork: false
-            # @schema {"name": "defaults.server_config.servers.rest.server.socket_option.net_quick_ack", "type": "boolean"}
-            # defaults.server_config.servers.rest.server.socket_option.reuse_port -- server listen socket option for tcp_quick_ack functionality
+            # @schema {"name": "defaults.server_config.servers.rest.server.socket_option.tcp_quick_ack", "type": "boolean"}
+            # defaults.server_config.servers.rest.server.socket_option.tcp_quick_ack -- server listen socket option for tcp_quick_ack functionality
             tcp_quick_ack: true
-            # @schema {"name": "defaults.server_config.servers.rest.server.socket_option.net_defer_accept", "type": "boolean"}
-            # defaults.server_config.servers.rest.server.socket_option.reuse_port -- server listen socket option for tcp_defer_accept functionality
+            # @schema {"name": "defaults.server_config.servers.rest.server.socket_option.tcp_defer_accept", "type": "boolean"}
+            # defaults.server_config.servers.rest.server.socket_option.tcp_defer_accept -- server listen socket option for tcp_defer_accept functionality
             tcp_defer_accept: true
             # @schema {"name": "defaults.server_config.servers.rest.server.socket_option.ip_transparent", "type": "boolean"}
-            # defaults.server_config.servers.rest.server.socket_option.reuse_port -- server listen socket option for ip_transparent functionality
+            # defaults.server_config.servers.rest.server.socket_option.ip_transparent -- server listen socket option for ip_transparent functionality
             ip_transparent: false
             # @schema {"name": "defaults.server_config.servers.rest.server.socket_option.ip_recover_destination_addr", "type": "boolean"}
-            # defaults.server_config.servers.rest.server.socket_option.reuse_port -- server listen socket option for ip_recover_destination_addr functionality
+            # defaults.server_config.servers.rest.server.socket_option.ip_recover_destination_addr -- server listen socket option for ip_recover_destination_addr functionality
             ip_recover_destination_addr: false
       # @schema {"name": "defaults.server_config.servers.grpc", "type": "object"}
       grpc:
@@ -210,19 +210,19 @@ defaults:
             reuse_port: true
             # defaults.server_config.servers.grpc.server.socket_option.reuse_addr -- server listen socket option for reuse_addr functionality
             reuse_addr: true
-            # defaults.server_config.servers.grpc.server.socket_option.reuse_port -- server listen socket option for tcp_fast_open functionality
+            # defaults.server_config.servers.grpc.server.socket_option.tcp_fast_open -- server listen socket option for tcp_fast_open functionality
             tcp_fast_open: true
-            # defaults.server_config.servers.grpc.server.socket_option.reuse_port -- server listen socket option for tcp_no_delay functionality
+            # defaults.server_config.servers.grpc.server.socket_option.tcp_no_delay -- server listen socket option for tcp_no_delay functionality
             tcp_no_delay: true
-            # defaults.server_config.servers.grpc.server.socket_option.reuse_port -- server listen socket option for tcp_cork functionality
+            # defaults.server_config.servers.grpc.server.socket_option.tcp_cork -- server listen socket option for tcp_cork functionality
             tcp_cork: false
-            # defaults.server_config.servers.grpc.server.socket_option.reuse_port -- server listen socket option for tcp_quick_ack functionality
+            # defaults.server_config.servers.grpc.server.socket_option.tcp_quick_ack -- server listen socket option for tcp_quick_ack functionality
             tcp_quick_ack: true
-            # defaults.server_config.servers.grpc.server.socket_option.reuse_port -- server listen socket option for tcp_defer_accept functionality
+            # defaults.server_config.servers.grpc.server.socket_option.tcp_defer_accept -- server listen socket option for tcp_defer_accept functionality
             tcp_defer_accept: true
-            # defaults.server_config.servers.grpc.server.socket_option.reuse_port -- server listen socket option for ip_transparent functionality
+            # defaults.server_config.servers.grpc.server.socket_option.ip_transparent -- server listen socket option for ip_transparent functionality
             ip_transparent: false
-            # defaults.server_config.servers.grpc.server.socket_option.reuse_port -- server listen socket option for ip_recover_destination_addr functionality
+            # defaults.server_config.servers.grpc.server.socket_option.ip_recover_destination_addr -- server listen socket option for ip_recover_destination_addr functionality
             ip_recover_destination_addr: false
           # @schema {"name": "defaults.server_config.servers.grpc.server.restart", "type": "boolean"}
           # defaults.server_config.servers.grpc.server.restart -- gRPC server restart
@@ -311,19 +311,19 @@ defaults:
             reuse_port: true
             # defaults.server_config.healths.liveness.server.socket_option.reuse_addr -- server listen socket option for reuse_addr functionality
             reuse_addr: true
-            # defaults.server_config.healths.liveness.server.socket_option.reuse_port -- server listen socket option for tcp_fast_open functionality
+            # defaults.server_config.healths.liveness.server.socket_option.tcp_fast_open -- server listen socket option for tcp_fast_open functionality
             tcp_fast_open: true
-            # defaults.server_config.healths.liveness.server.socket_option.reuse_port -- server listen socket option for tcp_no_delay functionality
+            # defaults.server_config.healths.liveness.server.socket_option.tcp_no_delay -- server listen socket option for tcp_no_delay functionality
             tcp_no_delay: true
-            # defaults.server_config.healths.liveness.server.socket_option.reuse_port -- server listen socket option for tcp_cork functionality
+            # defaults.server_config.healths.liveness.server.socket_option.tcp_cork -- server listen socket option for tcp_cork functionality
             tcp_cork: false
-            # defaults.server_config.healths.liveness.server.socket_option.reuse_port -- server listen socket option for tcp_quick_ack functionality
+            # defaults.server_config.healths.liveness.server.socket_option.tcp_quick_ack -- server listen socket option for tcp_quick_ack functionality
             tcp_quick_ack: true
-            # defaults.server_config.healths.liveness.server.socket_option.reuse_port -- server listen socket option for tcp_defer_accept functionality
+            # defaults.server_config.healths.liveness.server.socket_option.tcp_defer_accept -- server listen socket option for tcp_defer_accept functionality
             tcp_defer_accept: true
-            # defaults.server_config.healths.liveness.server.socket_option.reuse_port -- server listen socket option for ip_transparent functionality
+            # defaults.server_config.healths.liveness.server.socket_option.ip_transparent -- server listen socket option for ip_transparent functionality
             ip_transparent: false
-            # defaults.server_config.healths.liveness.server.socket_option.reuse_port -- server listen socket option for ip_recover_destination_addr functionality
+            # defaults.server_config.healths.liveness.server.socket_option.ip_recover_destination_addr -- server listen socket option for ip_recover_destination_addr functionality
             ip_recover_destination_addr: false
       # @schema {"name": "defaults.server_config.healths.readiness", "type": "object"}
       readiness:
@@ -407,19 +407,19 @@ defaults:
             reuse_port: true
             # defaults.server_config.healths.readiness.server.socket_option.reuse_addr -- server listen socket option for reuse_addr functionality
             reuse_addr: true
-            # defaults.server_config.healths.readiness.server.socket_option.reuse_port -- server listen socket option for tcp_fast_open functionality
+            # defaults.server_config.healths.readiness.server.socket_option.tcp_fast_oepn -- server listen socket option for tcp_fast_open functionality
             tcp_fast_open: true
-            # defaults.server_config.healths.readiness.server.socket_option.reuse_port -- server listen socket option for tcp_no_delay functionality
+            # defaults.server_config.healths.readiness.server.socket_option.tcp_no_delay -- server listen socket option for tcp_no_delay functionality
             tcp_no_delay: true
-            # defaults.server_config.healths.readiness.server.socket_option.reuse_port -- server listen socket option for tcp_cork functionality
+            # defaults.server_config.healths.readiness.server.socket_option.tcp_cork -- server listen socket option for tcp_cork functionality
             tcp_cork: false
-            # defaults.server_config.healths.readiness.server.socket_option.reuse_port -- server listen socket option for tcp_quick_ack functionality
+            # defaults.server_config.healths.readiness.server.socket_option.tcp_quick_ack -- server listen socket option for tcp_quick_ack functionality
             tcp_quick_ack: true
-            # defaults.server_config.healths.readiness.server.socket_option.reuse_port -- server listen socket option for tcp_defer_accept functionality
+            # defaults.server_config.healths.readiness.server.socket_option.tcp_defer_accept -- server listen socket option for tcp_defer_accept functionality
             tcp_defer_accept: true
-            # defaults.server_config.healths.readiness.server.socket_option.reuse_port -- server listen socket option for ip_transparent functionality
+            # defaults.server_config.healths.readiness.server.socket_option.ip_transparent -- server listen socket option for ip_transparent functionality
             ip_transparent: false
-            # defaults.server_config.healths.readiness.server.socket_option.reuse_port -- server listen socket option for ip_recover_destination_addr functionality
+            # defaults.server_config.healths.readiness.server.socket_option.ip_recover_destination_addr -- server listen socket option for ip_recover_destination_addr functionality
             ip_recover_destination_addr: false
     # @schema {"name": "defaults.server_config.metrics", "type": "object"}
     metrics:
@@ -477,19 +477,19 @@ defaults:
             reuse_port: true
             # defaults.server_config.metrics.pprof.server.socket_option.reuse_addr -- server listen socket option for reuse_addr functionality
             reuse_addr: true
-            # defaults.server_config.metrics.pprof.server.socket_option.reuse_port -- server listen socket option for tcp_fast_open functionality
+            # defaults.server_config.metrics.pprof.server.socket_option.tcp_fast_open -- server listen socket option for tcp_fast_open functionality
             tcp_fast_open: true
-            # defaults.server_config.metrics.pprof.server.socket_option.reuse_port -- server listen socket option for tcp_no_delay functionality
+            # defaults.server_config.metrics.pprof.server.socket_option.tcp_no_delay -- server listen socket option for tcp_no_delay functionality
             tcp_no_delay: true
-            # defaults.server_config.metrics.pprof.server.socket_option.reuse_port -- server listen socket option for tcp_cork functionality
+            # defaults.server_config.metrics.pprof.server.socket_option.tcp_cork -- server listen socket option for tcp_cork functionality
             tcp_cork: false
-            # defaults.server_config.metrics.pprof.server.socket_option.reuse_port -- server listen socket option for tcp_quick_ack functionality
+            # defaults.server_config.metrics.pprof.server.socket_option.tcp_quick_ack -- server listen socket option for tcp_quick_ack functionality
             tcp_quick_ack: true
-            # defaults.server_config.metrics.pprof.server.socket_option.reuse_port -- server listen socket option for tcp_defer_accept functionality
+            # defaults.server_config.metrics.pprof.server.socket_option.tcp_defer_accept -- server listen socket option for tcp_defer_accept functionality
             tcp_defer_accept: true
-            # defaults.server_config.metrics.pprof.server.socket_option.reuse_port -- server listen socket option for ip_transparent functionality
+            # defaults.server_config.metrics.pprof.server.socket_option.ip_transparent -- server listen socket option for ip_transparent functionality
             ip_transparent: false
-            # defaults.server_config.metrics.pprof.server.socket_option.reuse_port -- server listen socket option for ip_recover_destination_addr functionality
+            # defaults.server_config.metrics.pprof.server.socket_option.ip_recover_destination_addr -- server listen socket option for ip_recover_destination_addr functionality
             ip_recover_destination_addr: false
       # @schema {"name": "defaults.server_config.metrics.prometheus", "type": "object"}
       prometheus:
@@ -545,19 +545,19 @@ defaults:
             reuse_port: true
             # defaults.server_config.metrics.prometheus.server.socket_option.reuse_addr -- server listen socket option for reuse_addr functionality
             reuse_addr: true
-            # defaults.server_config.metrics.prometheus.server.socket_option.reuse_port -- server listen socket option for tcp_fast_open functionality
+            # defaults.server_config.metrics.prometheus.server.socket_option.tcp_fast_open -- server listen socket option for tcp_fast_open functionality
             tcp_fast_open: true
-            # defaults.server_config.metrics.prometheus.server.socket_option.reuse_port -- server listen socket option for tcp_no_delay functionality
+            # defaults.server_config.metrics.prometheus.server.socket_option.tcp_no_delay -- server listen socket option for tcp_no_delay functionality
             tcp_no_delay: true
-            # defaults.server_config.metrics.prometheus.server.socket_option.reuse_port -- server listen socket option for tcp_cork functionality
+            # defaults.server_config.metrics.prometheus.server.socket_option.tcp_cork -- server listen socket option for tcp_cork functionality
             tcp_cork: false
-            # defaults.server_config.metrics.prometheus.server.socket_option.reuse_port -- server listen socket option for tcp_quick_ack functionality
+            # defaults.server_config.metrics.prometheus.server.socket_option.tcp_quick_ack -- server listen socket option for tcp_quick_ack functionality
             tcp_quick_ack: true
-            # defaults.server_config.metrics.prometheus.server.socket_option.reuse_port -- server listen socket option for tcp_defer_accept functionality
+            # defaults.server_config.metrics.prometheus.server.socket_option.tcp_defer_accept -- server listen socket option for tcp_defer_accept functionality
             tcp_defer_accept: true
-            # defaults.server_config.metrics.prometheus.server.socket_option.reuse_port -- server listen socket option for ip_transparent functionality
+            # defaults.server_config.metrics.prometheus.server.socket_option.ip_transparent -- server listen socket option for ip_transparent functionality
             ip_transparent: false
-            # defaults.server_config.metrics.prometheus.server.socket_option.reuse_port -- server listen socket option for ip_recover_destination_addr functionality
+            # defaults.server_config.metrics.prometheus.server.socket_option.ip_recover_destination_addr -- server listen socket option for ip_recover_destination_addr functionality
             ip_recover_destination_addr: false
     # @schema {"name": "defaults.server_config.full_shutdown_duration", "type": "string"}
     # defaults.server_config.full_shutdown_duration -- server full shutdown duration
@@ -726,19 +726,19 @@ defaults:
             reuse_port: true
             # defaults.grpc.client.dial_option.net.socket_option.reuse_addr -- server listen socket option for reuse_addr functionality
             reuse_addr: true
-            # defaults.grpc.client.dial_option.net.socket_option.reuse_port -- server listen socket option for tcp_fast_open functionality
+            # defaults.grpc.client.dial_option.net.socket_option.tcp_fast_open -- server listen socket option for tcp_fast_open functionality
             tcp_fast_open: true
-            # defaults.grpc.client.dial_option.net.socket_option.reuse_port -- server listen socket option for tcp_no_delay functionality
+            # defaults.grpc.client.dial_option.net.socket_option.tcp_no_delay -- server listen socket option for tcp_no_delay functionality
             tcp_no_delay: true
-            # defaults.grpc.client.dial_option.net.socket_option.reuse_port -- server listen socket option for tcp_cork functionality
+            # defaults.grpc.client.dial_option.net.socket_option.tcp_cork -- server listen socket option for tcp_cork functionality
             tcp_cork: false
-            # defaults.grpc.client.dial_option.net.socket_option.reuse_port -- server listen socket option for tcp_quick_ack functionality
+            # defaults.grpc.client.dial_option.net.socket_option.tcp_quick_ack -- server listen socket option for tcp_quick_ack functionality
             tcp_quick_ack: true
-            # defaults.grpc.client.dial_option.net.socket_option.reuse_port -- server listen socket option for tcp_defer_accept functionality
+            # defaults.grpc.client.dial_option.net.socket_option.tcp_defer_accept -- server listen socket option for tcp_defer_accept functionality
             tcp_defer_accept: true
-            # defaults.grpc.client.dial_option.net.socket_option.reuse_port -- server listen socket option for ip_transparent functionality
+            # defaults.grpc.client.dial_option.net.socket_option.ip_transparent -- server listen socket option for ip_transparent functionality
             ip_transparent: false
-            # defaults.grpc.client.dial_option.net.socket_option.reuse_port -- server listen socket option for ip_recover_destination_addr functionality
+            # defaults.grpc.client.dial_option.net.socket_option.ip_recover_destination_addr -- server listen socket option for ip_recover_destination_addr functionality
             ip_recover_destination_addr: false
         # @schema {"name": "defaults.grpc.client.dial_option.keep_alive", "type": "object"}
         keep_alive:
@@ -2832,19 +2832,19 @@ agent:
             reuse_port: true
             # agent.sidecar.config.client.net.socket_option.reuse_addr -- server listen socket option for reuse_addr functionality
             reuse_addr: true
-            # agent.sidecar.config.client.net.socket_option.reuse_port -- server listen socket option for tcp_fast_open functionality
+            # agent.sidecar.config.client.net.socket_option.tcp_fast_open -- server listen socket option for tcp_fast_open functionality
             tcp_fast_open: true
-            # agent.sidecar.config.client.net.socket_option.reuse_port -- server listen socket option for tcp_no_delay functionality
+            # agent.sidecar.config.client.net.socket_option.tcp_no_delay -- server listen socket option for tcp_no_delay functionality
             tcp_no_delay: true
-            # agent.sidecar.config.client.net.socket_option.reuse_port -- server listen socket option for tcp_cork functionality
+            # agent.sidecar.config.client.net.socket_option.tcp_cork -- server listen socket option for tcp_cork functionality
             tcp_cork: false
-            # agent.sidecar.config.client.net.socket_option.reuse_port -- server listen socket option for tcp_quick_ack functionality
+            # agent.sidecar.config.client.net.socket_option.tcp_quick_ack -- server listen socket option for tcp_quick_ack functionality
             tcp_quick_ack: true
-            # agent.sidecar.config.client.net.socket_option.reuse_port -- server listen socket option for tcp_defer_accept functionality
+            # agent.sidecar.config.client.net.socket_option.tcp_defer_accept -- server listen socket option for tcp_defer_accept functionality
             tcp_defer_accept: true
-            # agent.sidecar.config.client.net.socket_option.reuse_port -- server listen socket option for ip_transparent functionality
+            # agent.sidecar.config.client.net.socket_option.ip_transparent -- server listen socket option for ip_transparent functionality
             ip_transparent: false
-            # agent.sidecar.config.client.net.socket_option.reuse_port -- server listen socket option for ip_recover_destination_addr functionality
+            # agent.sidecar.config.client.net.socket_option.ip_recover_destination_addr -- server listen socket option for ip_recover_destination_addr functionality
             ip_recover_destination_addr: false
         # @schema {"name": "agent.sidecar.config.client.transport", "type": "object"}
         transport:
@@ -3151,19 +3151,19 @@ discoverer:
         reuse_port: true
         # discoverer.discoverer.net.socket_option.reuse_addr -- server listen socket option for reuse_addr functionality
         reuse_addr: true
-        # discoverer.discoverer.net.socket_option.reuse_port -- server listen socket option for tcp_fast_open functionality
+        # discoverer.discoverer.net.socket_option.tcp_fast_open -- server listen socket option for tcp_fast_open functionality
         tcp_fast_open: true
-        # discoverer.discoverer.net.socket_option.reuse_port -- server listen socket option for tcp_no_delay functionality
+        # discoverer.discoverer.net.socket_option.tcp_no_delay -- server listen socket option for tcp_no_delay functionality
         tcp_no_delay: true
-        # discoverer.discoverer.net.socket_option.reuse_port -- server listen socket option for tcp_cork functionality
+        # discoverer.discoverer.net.socket_option.tcp_cork -- server listen socket option for tcp_cork functionality
         tcp_cork: false
-        # discoverer.discoverer.net.socket_option.reuse_port -- server listen socket option for tcp_quick_ack functionality
+        # discoverer.discoverer.net.socket_option.tcp_quick_ack -- server listen socket option for tcp_quick_ack functionality
         tcp_quick_ack: true
-        # discoverer.discoverer.net.socket_option.reuse_port -- server listen socket option for tcp_defer_accept functionality
+        # discoverer.discoverer.net.socket_option.tcp_defer_accept -- server listen socket option for tcp_defer_accept functionality
         tcp_defer_accept: true
-        # discoverer.discoverer.net.socket_option.reuse_port -- server listen socket option for ip_transparent functionality
+        # discoverer.discoverer.net.socket_option.ip_transparent -- server listen socket option for ip_transparent functionality
         ip_transparent: false
-        # discoverer.discoverer.net.socket_option.reuse_port -- server listen socket option for ip_recover_destination_addr functionality
+        # discoverer.discoverer.net.socket_option.ip_recover_destination_addr -- server listen socket option for ip_recover_destination_addr functionality
         ip_recover_destination_addr: false
   # @schema {"name": "discoverer.clusterRole", "type": "object"}
   clusterRole:
@@ -3732,19 +3732,19 @@ manager:
             reuse_port: true
             # manager.backup.mysql.config.net.socket_option.reuse_addr -- server listen socket option for reuse_addr functionality
             reuse_addr: true
-            # manager.backup.mysql.config.net.socket_option.reuse_port -- server listen socket option for tcp_fast_open functionality
+            # manager.backup.mysql.config.net.socket_option.tcp_fast_open -- server listen socket option for tcp_fast_open functionality
             tcp_fast_open: true
-            # manager.backup.mysql.config.net.socket_option.reuse_port -- server listen socket option for tcp_no_delay functionality
+            # manager.backup.mysql.config.net.socket_option.tcp_no_delay -- server listen socket option for tcp_no_delay functionality
             tcp_no_delay: true
-            # manager.backup.mysql.config.net.socket_option.reuse_port -- server listen socket option for tcp_cork functionality
+            # manager.backup.mysql.config.net.socket_option.tcp_cork -- server listen socket option for tcp_cork functionality
             tcp_cork: false
-            # manager.backup.mysql.config.net.socket_option.reuse_port -- server listen socket option for tcp_quick_ack functionality
+            # manager.backup.mysql.config.net.socket_option.tcp_quick_ack -- server listen socket option for tcp_quick_ack functionality
             tcp_quick_ack: true
-            # manager.backup.mysql.config.net.socket_option.reuse_port -- server listen socket option for tcp_defer_accept functionality
+            # manager.backup.mysql.config.net.socket_option.tcp_defer_accept -- server listen socket option for tcp_defer_accept functionality
             tcp_defer_accept: true
-            # manager.backup.mysql.config.net.socket_option.reuse_port -- server listen socket option for ip_transparent functionality
+            # manager.backup.mysql.config.net.socket_option.ip_transparent -- server listen socket option for ip_transparent functionality
             ip_transparent: false
-            # manager.backup.mysql.config.net.socket_option.reuse_port -- server listen socket option for ip_recover_destination_addr functionality
+            # manager.backup.mysql.config.net.socket_option.ip_recover_destination_addr -- server listen socket option for ip_recover_destination_addr functionality
             ip_recover_destination_addr: false
     # @schema {"name": "manager.backup.cassandra", "type": "object", "anchor": "cassandra"}
     cassandra:
@@ -3871,19 +3871,19 @@ manager:
             reuse_port: true
             # manager.backup.cassandra.config.net.socket_option.reuse_addr -- server listen socket option for reuse_addr functionality
             reuse_addr: true
-            # manager.backup.cassandra.config.net.socket_option.reuse_port -- server listen socket option for tcp_fast_open functionality
+            # manager.backup.cassandra.config.net.socket_option.tcp_fast_open -- server listen socket option for tcp_fast_open functionality
             tcp_fast_open: true
-            # manager.backup.cassandra.config.net.socket_option.reuse_port -- server listen socket option for tcp_no_delay functionality
+            # manager.backup.cassandra.config.net.socket_option.tcp_no_delay -- server listen socket option for tcp_no_delay functionality
             tcp_no_delay: true
-            # manager.backup.cassandra.config.net.socket_option.reuse_port -- server listen socket option for tcp_cork functionality
+            # manager.backup.cassandra.config.net.socket_option.tcp_cork -- server listen socket option for tcp_cork functionality
             tcp_cork: false
-            # manager.backup.cassandra.config.net.socket_option.reuse_port -- server listen socket option for tcp_quick_ack functionality
+            # manager.backup.cassandra.config.net.socket_option.tcp_quick_ack -- server listen socket option for tcp_quick_ack functionality
             tcp_quick_ack: true
-            # manager.backup.cassandra.config.net.socket_option.reuse_port -- server listen socket option for tcp_defer_accept functionality
+            # manager.backup.cassandra.config.net.socket_option.tcp_defer_accept -- server listen socket option for tcp_defer_accept functionality
             tcp_defer_accept: true
-            # manager.backup.cassandra.config.net.socket_option.reuse_port -- server listen socket option for ip_transparent functionality
+            # manager.backup.cassandra.config.net.socket_option.ip_transparent -- server listen socket option for ip_transparent functionality
             ip_transparent: false
-            # manager.backup.cassandra.config.net.socket_option.reuse_port -- server listen socket option for ip_recover_destination_addr functionality
+            # manager.backup.cassandra.config.net.socket_option.ip_recover_destination_addr -- server listen socket option for ip_recover_destination_addr functionality
             ip_recover_destination_addr: false
         # @schema {"name": "manager.backup.cassandra.config.enable_host_verification", "type": "boolean"}
         # manager.backup.cassandra.config.enable_host_verification -- host verification enabled
@@ -4521,19 +4521,19 @@ meta:
           reuse_port: true
           # meta.redis.config.net.socket_option.reuse_addr -- server listen socket option for reuse_addr functionality
           reuse_addr: true
-          # meta.redis.config.net.socket_option.reuse_port -- server listen socket option for tcp_fast_open functionality
+          # meta.redis.config.net.socket_option.tcp_fast_open -- server listen socket option for tcp_fast_open functionality
           tcp_fast_open: true
-          # meta.redis.config.net.socket_option.reuse_port -- server listen socket option for tcp_no_delay functionality
+          # meta.redis.config.net.socket_option.tcp_no_delay -- server listen socket option for tcp_no_delay functionality
           tcp_no_delay: true
-          # meta.redis.config.net.socket_option.reuse_port -- server listen socket option for tcp_cork functionality
+          # meta.redis.config.net.socket_option.tcp_cork -- server listen socket option for tcp_cork functionality
           tcp_cork: false
-          # meta.redis.config.net.socket_option.reuse_port -- server listen socket option for tcp_quick_ack functionality
+          # meta.redis.config.net.socket_option.tcp_quick_ack -- server listen socket option for tcp_quick_ack functionality
           tcp_quick_ack: true
-          # meta.redis.config.net.socket_option.reuse_port -- server listen socket option for tcp_defer_accept functionality
+          # meta.redis.config.net.socket_option.tcp_defer_accept -- server listen socket option for tcp_defer_accept functionality
           tcp_defer_accept: true
-          # meta.redis.config.net.socket_option.reuse_port -- server listen socket option for ip_transparent functionality
+          # meta.redis.config.net.socket_option.ip_transparent -- server listen socket option for ip_transparent functionality
           ip_transparent: false
-          # meta.redis.config.net.socket_option.reuse_port -- server listen socket option for ip_recover_destination_addr functionality
+          # meta.redis.config.net.socket_option.ip_recover_destination_addr -- server listen socket option for ip_recover_destination_addr functionality
           ip_recover_destination_addr: false
       # @schema {"name": "meta.redis.config.kv_prefix", "type": "string"}
       # meta.redis.config.kv_prefix -- KV prefix
@@ -4644,19 +4644,19 @@ meta:
           reuse_port: true
           # meta.cassandra.config.net.socket_option.reuse_addr -- server listen socket option for reuse_addr functionality
           reuse_addr: true
-          # meta.cassandra.config.net.socket_option.reuse_port -- server listen socket option for tcp_fast_open functionality
+          # meta.cassandra.config.net.socket_option.tcp_fast_open -- server listen socket option for tcp_fast_open functionality
           tcp_fast_open: true
-          # meta.cassandra.config.net.socket_option.reuse_port -- server listen socket option for tcp_no_delay functionality
+          # meta.cassandra.config.net.socket_option.tcp_no_delay -- server listen socket option for tcp_no_delay functionality
           tcp_no_delay: true
-          # meta.cassandra.config.net.socket_option.reuse_port -- server listen socket option for tcp_cork functionality
+          # meta.cassandra.config.net.socket_option.tcp_cork -- server listen socket option for tcp_cork functionality
           tcp_cork: false
-          # meta.cassandra.config.net.socket_option.reuse_port -- server listen socket option for tcp_quick_ack functionality
+          # meta.cassandra.config.net.socket_option.tcp_quick_ack -- server listen socket option for tcp_quick_ack functionality
           tcp_quick_ack: true
-          # meta.cassandra.config.net.socket_option.reuse_port -- server listen socket option for tcp_defer_accept functionality
+          # meta.cassandra.config.net.socket_option.tcp_defer_accept -- server listen socket option for tcp_defer_accept functionality
           tcp_defer_accept: true
-          # meta.cassandra.config.net.socket_option.reuse_port -- server listen socket option for ip_transparent functionality
+          # meta.cassandra.config.net.socket_option.ip_transparent -- server listen socket option for ip_transparent functionality
           ip_transparent: false
-          # meta.cassandra.config.net.socket_option.reuse_port -- server listen socket option for ip_recover_destination_addr functionality
+          # meta.cassandra.config.net.socket_option.ip_recover_destination_addr -- server listen socket option for ip_recover_destination_addr functionality
           ip_recover_destination_addr: false
       # meta.cassandra.config.enable_host_verification -- host verification enabled
       enable_host_verification: false

--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -259,7 +259,7 @@ defaults:
           # @schema {"name": "defaults.server_config.healths.liveness.livenessProbe.initialDelaySeconds", "type": "integer"}
           # defaults.server_config.healths.liveness.livenessProbe.initialDelaySeconds -- liveness probe initial delay seconds
           initialDelaySeconds: 5
-          # @schema {"name": "defaults.server_config.healths.liveness.livenessProbe.timetoutSeconds", "type": "integer"}
+          # @schema {"name": "defaults.server_config.healths.liveness.livenessProbe.timeoutSeconds", "type": "integer"}
           # defaults.server_config.healths.liveness.livenessProbe.timeoutSeconds -- liveness probe timeout seconds
           timeoutSeconds: 2
           # @schema {"name": "defaults.server_config.healths.liveness.livenessProbe.successThreshold", "type": "integer"}
@@ -2899,6 +2899,7 @@ agent:
             retry_count: 100
             # agent.sidecar.config.client.transport.backoff.enable_error_log -- backoff error log enabled
             enable_error_log: true
+      # @schema {"name": "agent.sidecar.config.restore_backoff_enabled", "type": "boolean"}
       # agent.sidecar.config.restore_backoff_enabled -- restore backoff enabled
       restore_backoff_enabled: false
       # @schema {"name": "agent.sidecar.config.restore_backoff", "alias": "backoff"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
Fixed CRD schema. There're many typos in the values.yaml.

To prevent a problem like this, a check workflow for CRD schema & values.yaml will be introduced in #1107.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Nothing

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Nothing

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
Signed-off-by: Rintaro Okamura <rintaro.okamura@gmail.com>