### PR TITLE
Implement safety bench code

### DIFF
--- a/internal/safety/safety_bench_test.go
+++ b/internal/safety/safety_bench_test.go
@@ -1,0 +1,140 @@
+package safety
+
+import (
+	"testing"
+
+	"github.com/vdaas/vald/internal/errors"
+)
+
+func BenchmarkRecoverFunc(b *testing.B) {
+	type args struct {
+		fn func() error
+	}
+	type test struct {
+		name string
+		args args
+	}
+	tests := []test{
+		{
+			name: "fn return error",
+			args: args{
+				fn: func() error {
+					return errors.New("fn err")
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					got := RecoverFunc(test.args.fn)
+					if got == nil {
+						b.Error("got is empty")
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkRecoverWithoutPanicFunc(b *testing.B) {
+	type args struct {
+		fn func() error
+	}
+	type test struct {
+		name string
+		args args
+	}
+	tests := []test{
+		{
+			name: "fn return error",
+			args: args{
+				fn: func() error {
+					return errors.New("fn err")
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					got := RecoverWithoutPanicFunc(test.args.fn)
+					if got == nil {
+						b.Error("got is empty")
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkRecoverWithoutPanicFunc_with_execution(b *testing.B) {
+	type args struct {
+		fn func() error
+	}
+	type test struct {
+		name string
+		args args
+	}
+	tests := []test{
+		{
+			name: "fn return error",
+			args: args{
+				fn: func() error {
+					return errors.New("fn err")
+				},
+			},
+		},
+		{
+			name: "fn panic runtime",
+			args: args{
+				fn: func() error {
+					_ = []string{}[10]
+					return nil
+				},
+			},
+		},
+		{
+			name: "fn panic string",
+			args: args{
+				fn: func() error {
+					panic("panic")
+				},
+			},
+		},
+		{
+			name: "fn panic error",
+			args: args{
+				fn: func() error {
+					panic(errors.Errorf("error"))
+				},
+			},
+		},
+		{
+			name: "fn panic int",
+			args: args{
+				fn: func() error {
+					panic(10)
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					got := RecoverWithoutPanicFunc(test.args.fn)
+					if got == nil {
+						b.Error("got is empty")
+					}
+					err := got()
+					if err == nil {
+						b.Error("err is nil")
+					}
+				}
+			})
+		})
+	}
+}

--- a/internal/safety/safety_bench_test.go
+++ b/internal/safety/safety_bench_test.go
@@ -55,38 +55,6 @@ func BenchmarkRecoverWithoutPanicFunc(b *testing.B) {
 				},
 			},
 		},
-	}
-	for _, test := range tests {
-		b.Run(test.name, func(b *testing.B) {
-			b.RunParallel(func(pb *testing.PB) {
-				for pb.Next() {
-					got := RecoverWithoutPanicFunc(test.args.fn)
-					if got == nil {
-						b.Error("got is empty")
-					}
-				}
-			})
-		})
-	}
-}
-
-func BenchmarkRecoverWithoutPanicFunc_with_execution(b *testing.B) {
-	type args struct {
-		fn func() error
-	}
-	type test struct {
-		name string
-		args args
-	}
-	tests := []test{
-		{
-			name: "fn return error func",
-			args: args{
-				fn: func() error {
-					return errors.New("fn err")
-				},
-			},
-		},
 		{
 			name: "fn panic runtime error func",
 			args: args{

--- a/internal/safety/safety_bench_test.go
+++ b/internal/safety/safety_bench_test.go
@@ -16,7 +16,7 @@ func BenchmarkRecoverFunc(b *testing.B) {
 	}
 	tests := []test{
 		{
-			name: "fn return error",
+			name: "fn return error func",
 			args: args{
 				fn: func() error {
 					return errors.New("fn err")
@@ -48,7 +48,7 @@ func BenchmarkRecoverWithoutPanicFunc(b *testing.B) {
 	}
 	tests := []test{
 		{
-			name: "fn return error",
+			name: "fn return error func",
 			args: args{
 				fn: func() error {
 					return errors.New("fn err")
@@ -80,7 +80,7 @@ func BenchmarkRecoverWithoutPanicFunc_with_execution(b *testing.B) {
 	}
 	tests := []test{
 		{
-			name: "fn return error",
+			name: "fn return error func",
 			args: args{
 				fn: func() error {
 					return errors.New("fn err")
@@ -88,7 +88,7 @@ func BenchmarkRecoverWithoutPanicFunc_with_execution(b *testing.B) {
 			},
 		},
 		{
-			name: "fn panic runtime",
+			name: "fn panic runtime error func",
 			args: args{
 				fn: func() error {
 					_ = []string{}[10]
@@ -97,7 +97,7 @@ func BenchmarkRecoverWithoutPanicFunc_with_execution(b *testing.B) {
 			},
 		},
 		{
-			name: "fn panic string",
+			name: "fn panic string func",
 			args: args{
 				fn: func() error {
 					panic("panic")
@@ -105,7 +105,7 @@ func BenchmarkRecoverWithoutPanicFunc_with_execution(b *testing.B) {
 			},
 		},
 		{
-			name: "fn panic error",
+			name: "fn panic error func",
 			args: args{
 				fn: func() error {
 					panic(errors.Errorf("error"))
@@ -113,7 +113,7 @@ func BenchmarkRecoverWithoutPanicFunc_with_execution(b *testing.B) {
 			},
 		},
 		{
-			name: "fn panic int",
+			name: "fn panic int func",
 			args: args{
 				fn: func() error {
 					panic(10)

--- a/internal/safety/safety_bench_test.go
+++ b/internal/safety/safety_bench_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright (C) 2019-2021 vdaas.org vald team <vald@vdaas.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package safety
 
 import (

--- a/internal/safety/safety_test.go
+++ b/internal/safety/safety_test.go
@@ -32,7 +32,7 @@ var goleakIgnoreOptions = []goleak.Option{
 }
 
 func TestMain(m *testing.M) {
-	log.Init()
+	log.Init(log.WithLoggerType("nop"))
 	info.Init("")
 	os.Exit(m.Run())
 }

--- a/internal/safety/safety_test.go
+++ b/internal/safety/safety_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/info"
 	"github.com/vdaas/vald/internal/log"
+	"github.com/vdaas/vald/internal/log/logger"
 	"go.uber.org/goleak"
 )
 
@@ -32,7 +33,7 @@ var goleakIgnoreOptions = []goleak.Option{
 }
 
 func TestMain(m *testing.M) {
-	log.Init(log.WithLoggerType("nop"))
+	log.Init(log.WithLoggerType(logger.NOP.String()))
 	info.Init("")
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Signed-off-by: kevindiu <kevin_diu@yahoo.com.hk>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR implements safety benchmark test.
Here is the benchmark result.
```
goos: darwin
goarch: amd64
pkg: github.com/vdaas/vald/internal/safety
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkRecoverFunc/fn_return_error_func-12         	134723181	         9.512 ns/op	      24 B/op	       1 allocs/op
BenchmarkRecoverWithoutPanicFunc/fn_return_error_func-12         	55744567	        19.84 ns/op	      40 B/op	       2 allocs/op
BenchmarkRecoverWithoutPanicFunc/fn_panic_runtime_error_func-12  	   38184	     30841 ns/op	   18041 B/op	     206 allocs/op
BenchmarkRecoverWithoutPanicFunc/fn_panic_string_func-12         	   38880	     31979 ns/op	   16919 B/op	     191 allocs/op
BenchmarkRecoverWithoutPanicFunc/fn_panic_error_func-12          	   36880	     33284 ns/op	   16869 B/op	     188 allocs/op
BenchmarkRecoverWithoutPanicFunc/fn_panic_int_func-12            	   36000	     36941 ns/op	   16902 B/op	     190 allocs/op
PASS
ok  	github.com/vdaas/vald/internal/safety	10.656s
```

After some try, seems the `TestMain()` in unit test will be executed before the benchmark function is executed, so I changed the `TestMain()` implementation to init `NOP` logger to avoid large amount of logging message to be printed.

Also there is a difference in `BenchmarkRecoverFunc()` and `BenchmarkRecoverWithoutPanicFunc()`.
Since `BenchmarkRecoverFunc()` will panic the runtime and it will stop the execution, the benchmark implementation of  `BenchmarkRecoverFunc()` will not execute the handler returned from the function.

<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [x] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
