### PR TITLE
remove nil check in Error() method in internal/errors

### DIFF
--- a/internal/errors/blob_test.go
+++ b/internal/errors/blob_test.go
@@ -24,6 +24,149 @@ import (
 	"go.uber.org/goleak"
 )
 
+func TestNewErrBlobNoSuchBucket(t *testing.T) {
+	type args struct {
+		err  error
+		name string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return Wrapped blob nno such bucket error when err is session error, name is not empty",
+			args: args{
+				err:  New("session error"),
+				name: "vald-backup",
+			},
+			want: want{
+				want: New("bucket vald-backup not found: session error"),
+			},
+		},
+		{
+			name: "return Wrapped blob nno such bucket error when err is nil, name is not empty",
+			args: args{
+				name: "vald-backup",
+			},
+			want: want{
+				want: New("bucket vald-backup not found"),
+			},
+		},
+		{
+			name: "return Wrapped blob nno such bucket error when err is session error, name is empty",
+			args: args{
+				err: New("session error"),
+			},
+			want: want{
+				want: New("bucket  not found: session error"),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := NewErrBlobNoSuchBucket(test.args.err, test.args.name)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestNewErrBlobNoSuchKey(t *testing.T) {
+	type args struct {
+		err error
+		key string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return Wrapped blob nno such bucket error when err is session error, key is not empty",
+			args: args{
+				err: New("session error"),
+				key: "vald-agent-ngt-0",
+			},
+			want: want{
+				want: New("key vald-agent-ngt-0 not found: session error"),
+			},
+		},
+		{
+			name: "return Wrapped blob nno such bucket error when err is nil, key is not empty",
+			args: args{
+				key: "vald-agent-ngt-0",
+			},
+			want: want{
+				want: New("key vald-agent-ngt-0 not found"),
+			},
+		},
+		{
+			name: "return Wrapped blob nno such bucket error when err is session error, key is empty",
+			args: args{
+				err: New("session error"),
+			},
+			want: want{
+				want: New("key  not found: session error"),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := NewErrBlobNoSuchKey(test.args.err, test.args.key)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
 func TestErrBlobNoSuchBucket_Error(t *testing.T) {
 	type fields struct {
 		err error

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -79,6 +79,11 @@ var (
 		return Wrapf(err, "failed to output %s logs", str)
 	}
 
+	// ErrErrorIsNil represents a function to generate an error that given name's error object is nil.
+	ErrErrorIsNil = func(name string) error {
+		return Errorf("error object is nil: %s", name)
+	}
+
 	// New represents a function to generate the new error with a message.
 	// When the message is nil, it will return nil instead of an error.
 	New = func(msg string) error {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -175,8 +175,8 @@ var (
 	// As represents errors.As.
 	As = errors.As
 
-	// errNilCustomError represents a function to generate an error that given name's error object is nil.
-	errNilCustomError = func(name string) string {
-		return fmt.Sprintf("custom error object is nil: %s", name)
+	// errExpectedErrIsNil represents a function to generate an error that given name's error object is nil.
+	errExpectedErrIsNil = func(n string) error {
+		return Errorf("expected err is nil: %s", n)
 	}
 )

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -79,11 +79,6 @@ var (
 		return Wrapf(err, "failed to output %s logs", str)
 	}
 
-	// ErrErrorIsNil represents a function to generate an error that given name's error object is nil.
-	ErrErrorIsNil = func(name string) error {
-		return Errorf("error object is nil: %s", name)
-	}
-
 	// New represents a function to generate the new error with a message.
 	// When the message is nil, it will return nil instead of an error.
 	New = func(msg string) error {
@@ -179,4 +174,9 @@ var (
 
 	// As represents errors.As.
 	As = errors.As
+
+	// errNilCustomError represents a function to generate an error that given name's error object is nil.
+	errNilCustomError = func(name string) string {
+		return fmt.Sprintf("custom error object is nil: %s", name)
+	}
 )

--- a/internal/errors/filter_test.go
+++ b/internal/errors/filter_test.go
@@ -1,0 +1,82 @@
+//
+// Copyright (C) 2019-2021 vdaas.org vald team <vald@vdaas.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package errors provides error types and function
+package errors
+
+import (
+	"testing"
+)
+
+func TestErrTargetFilterNotFound(t *testing.T) {
+	type args struct {
+		addr string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "returns an ErrTargetFilterNotFound error when addr is localhost",
+			args: args{
+				addr: "localhost",
+			},
+			want: want{
+				want: New("target filter not found addr: localhost"),
+			},
+		},
+		{
+			name: "returns an ErrTargetFilterNotFound error when addr is empty",
+			args: args{},
+			want: want{
+				want: New("target filter not found addr: "),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrTargetFilterNotFound(test.args.addr)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/errors/info_test.go
+++ b/internal/errors/info_test.go
@@ -1,0 +1,128 @@
+//
+// Copyright (C) 2019-2021 vdaas.org vald team <vald@vdaas.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package errors provides error types and function
+package errors
+
+import (
+	"testing"
+)
+
+func TestErrFailedToInitInfo(t *testing.T) {
+	type args struct {
+		err error
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return an ErrFailedToInitInfo error when err is not empty",
+			args: args{
+				err: New("invalid argument"),
+			},
+			want: want{
+				want: New("failed to init info: invalid argument"),
+			},
+		},
+		{
+			name: "return an ErrFailedToInitInfo error when err is empty",
+			args: args{},
+			want: want{
+				want: New("failed to init info"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrFailedToInitInfo(test.args.err)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestErrRuntimeFuncNil(t *testing.T) {
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return an ErrFailedToInitInfo error when err is not empty",
+			want: want{
+				want: New("runtime function is nil"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrRuntimeFuncNil()
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/errors/net_test.go
+++ b/internal/errors/net_test.go
@@ -260,3 +260,63 @@ func TestErrNoPortAvailable(t *testing.T) {
 		})
 	}
 }
+
+func TestErrLookupIPAddrNotFound(t *testing.T) {
+	type args struct {
+		host string
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return an ErrLookupIPAddrNotFound error when host is localhost",
+			args: args{
+				host: "localhost",
+			},
+			want: want{
+				want: New("failed to lookup ip addrs for host: localhost"),
+			},
+		},
+		{
+			name: "return an ErrLookupIPAddrNotFound error when host is empty",
+			args: args{},
+			want: want{
+				want: New("failed to lookup ip addrs for host: "),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrLookupIPAddrNotFound(test.args.host)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/errors/ngt_test.go
+++ b/internal/errors/ngt_test.go
@@ -367,6 +367,79 @@ func TestErrDimensionLimitExceed(t *testing.T) {
 	}
 }
 
+func TestErrIncompatibleDimensionSize(t *testing.T) {
+	type args struct {
+		req int
+		dim int
+	}
+	type want struct {
+		want error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(args)
+		afterFunc  func(args)
+	}
+	defaultCheckFunc := func(w want, got error) error {
+		if !Is(got, w.want) {
+			return Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return an ErrIncompatibleDimensionSize error when req is 640 and dim is 720",
+			args: args{
+				req: 640,
+				dim: 720,
+			},
+			want: want{
+				want: New("incompatible dimension size detected\trequested: 640,\tconfigured: 720"),
+			},
+		},
+		{
+			name: "return an ErrIncompatibleDimensionSize error when req is empty and dim is 720",
+			args: args{
+				dim: 720,
+			},
+			want: want{
+				want: New("incompatible dimension size detected\trequested: 0,\tconfigured: 720"),
+			},
+		},
+		{
+			name: "return an ErrIncompatibleDimensionSize error when req is 640 and dim is 720",
+			args: args{
+				req: 640,
+			},
+			want: want{
+				want: New("incompatible dimension size detected\trequested: 640,\tconfigured: 0"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			if test.beforeFunc != nil {
+				test.beforeFunc(test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(test.args)
+			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
+
+			got := ErrIncompatibleDimensionSize(test.args.req, test.args.dim)
+			if err := test.checkFunc(test.want, got); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
 func TestErrUnsupportedObjectType(t *testing.T) {
 	type want struct {
 		want error

--- a/internal/errors/ngt_test.go
+++ b/internal/errors/ngt_test.go
@@ -410,7 +410,7 @@ func TestErrIncompatibleDimensionSize(t *testing.T) {
 			},
 		},
 		{
-			name: "return an ErrIncompatibleDimensionSize error when req is 640 and dim is 720",
+			name: "return an ErrIncompatibleDimensionSize error when req is 640"
 			args: args{
 				req: 640,
 			},

--- a/internal/errors/ngt_test.go
+++ b/internal/errors/ngt_test.go
@@ -410,7 +410,7 @@ func TestErrIncompatibleDimensionSize(t *testing.T) {
 			},
 		},
 		{
-			name: "return an ErrIncompatibleDimensionSize error when req is 640"
+			name: "return an ErrIncompatibleDimensionSize error when req is 640",
 			args: args{
 				req: 640,
 			},

--- a/internal/errors/option.go
+++ b/internal/errors/option.go
@@ -49,9 +49,6 @@ func NewErrInvalidOption(name string, val interface{}, errs ...error) error {
 
 // Error returns a string of ErrInvalidOption.err.
 func (e *ErrInvalidOption) Error() string {
-	if e.err == nil {
-		return ""
-	}
 	return e.err.Error()
 }
 
@@ -95,9 +92,6 @@ func NewErrCriticalOption(name string, val interface{}, errs ...error) error {
 
 // Error returns a string of ErrCriticalOption.err.
 func (e *ErrCriticalOption) Error() string {
-	if e.err == nil {
-		return ""
-	}
 	return e.err.Error()
 }
 

--- a/internal/errors/option.go
+++ b/internal/errors/option.go
@@ -15,6 +15,8 @@
 //
 package errors
 
+import "reflect"
+
 // ErrInvalidOption represents the invalid option error.
 type ErrInvalidOption struct {
 	err    error
@@ -49,6 +51,9 @@ func NewErrInvalidOption(name string, val interface{}, errs ...error) error {
 
 // Error returns a string of ErrInvalidOption.err.
 func (e *ErrInvalidOption) Error() string {
+	if e.err == nil {
+		return ErrErrorIsNil(reflect.TypeOf(e).Elem().Name()).Error()
+	}
 	return e.err.Error()
 }
 
@@ -92,6 +97,9 @@ func NewErrCriticalOption(name string, val interface{}, errs ...error) error {
 
 // Error returns a string of ErrCriticalOption.err.
 func (e *ErrCriticalOption) Error() string {
+	if e.err == nil {
+		return ErrErrorIsNil(reflect.TypeOf(e).Elem().Name()).Error()
+	}
 	return e.err.Error()
 }
 

--- a/internal/errors/option.go
+++ b/internal/errors/option.go
@@ -50,7 +50,7 @@ func NewErrInvalidOption(name string, val interface{}, errs ...error) error {
 // Error returns a string of ErrInvalidOption.err.
 func (e *ErrInvalidOption) Error() string {
 	if e.err == nil {
-		return errNilCustomError("ErrInvalidOption")
+		e.err = errExpectedErrIsNil("ErrInvalidOption")
 	}
 	return e.err.Error()
 }
@@ -96,7 +96,7 @@ func NewErrCriticalOption(name string, val interface{}, errs ...error) error {
 // Error returns a string of ErrCriticalOption.err.
 func (e *ErrCriticalOption) Error() string {
 	if e.err == nil {
-		return errNilCustomError("ErrCriticalOption")
+		e.err = errExpectedErrIsNil("ErrCriticalOption")
 	}
 	return e.err.Error()
 }

--- a/internal/errors/option.go
+++ b/internal/errors/option.go
@@ -15,8 +15,6 @@
 //
 package errors
 
-import "reflect"
-
 // ErrInvalidOption represents the invalid option error.
 type ErrInvalidOption struct {
 	err    error
@@ -52,7 +50,7 @@ func NewErrInvalidOption(name string, val interface{}, errs ...error) error {
 // Error returns a string of ErrInvalidOption.err.
 func (e *ErrInvalidOption) Error() string {
 	if e.err == nil {
-		return ErrErrorIsNil(reflect.TypeOf(e).Elem().Name()).Error()
+		return errNilCustomError("ErrInvalidOption")
 	}
 	return e.err.Error()
 }
@@ -98,7 +96,7 @@ func NewErrCriticalOption(name string, val interface{}, errs ...error) error {
 // Error returns a string of ErrCriticalOption.err.
 func (e *ErrCriticalOption) Error() string {
 	if e.err == nil {
-		return ErrErrorIsNil(reflect.TypeOf(e).Elem().Name()).Error()
+		return errNilCustomError("ErrCriticalOption")
 	}
 	return e.err.Error()
 }

--- a/internal/errors/option_test.go
+++ b/internal/errors/option_test.go
@@ -204,13 +204,6 @@ func TestErrInvalidOption_Error(t *testing.T) {
 
 	tests := []test{
 		{
-			name:   "return empty string when e.err is nil.",
-			fields: fields{},
-			want: want{
-				want: "",
-			},
-		},
-		{
 			name: "return empty string when e.err is not nil.",
 			fields: fields{
 				err: New("invalid option. name: WithPort, val: 8080"),
@@ -497,13 +490,6 @@ func TestErrCriticalOption_Error(t *testing.T) {
 	}
 
 	tests := []test{
-		{
-			name:   "return empty string when e.err is nil",
-			fields: fields{},
-			want: want{
-				want: "",
-			},
-		},
 		{
 			name: "return empty string when e.err is not nil",
 			fields: fields{

--- a/internal/errors/option_test.go
+++ b/internal/errors/option_test.go
@@ -204,12 +204,19 @@ func TestErrInvalidOption_Error(t *testing.T) {
 
 	tests := []test{
 		{
-			name: "return empty string when e.err is not nil.",
+			name: "return string when e.err is not nil.",
 			fields: fields{
 				err: New("invalid option. name: WithPort, val: 8080"),
 			},
 			want: want{
 				want: "invalid option. name: WithPort, val: 8080",
+			},
+		},
+		{
+			name:   "return string when e.err is nil.",
+			fields: fields{},
+			want: want{
+				want: "custom error object is nil: ErrInvalidOption",
 			},
 		},
 	}
@@ -491,12 +498,19 @@ func TestErrCriticalOption_Error(t *testing.T) {
 
 	tests := []test{
 		{
-			name: "return empty string when e.err is not nil",
+			name: "return string when e.err is not nil",
 			fields: fields{
 				err: New("invalid option. name: WithPort, val: 8080"),
 			},
 			want: want{
 				want: "invalid option. name: WithPort, val: 8080",
+			},
+		},
+		{
+			name:   "return string when e.err is nil",
+			fields: fields{},
+			want: want{
+				want: "custom error object is nil: ErrCriticalOption",
 			},
 		},
 	}

--- a/internal/errors/option_test.go
+++ b/internal/errors/option_test.go
@@ -216,7 +216,7 @@ func TestErrInvalidOption_Error(t *testing.T) {
 			name:   "return string when e.err is nil.",
 			fields: fields{},
 			want: want{
-				want: "custom error object is nil: ErrInvalidOption",
+				want: "expected err is nil: ErrInvalidOption",
 			},
 		},
 	}
@@ -510,7 +510,7 @@ func TestErrCriticalOption_Error(t *testing.T) {
 			name:   "return string when e.err is nil",
 			fields: fields{},
 			want: want{
-				want: "custom error object is nil: ErrCriticalOption",
+				want: "expected err is nil: ErrCriticalOption",
 			},
 		},
 	}

--- a/internal/errors/redis.go
+++ b/internal/errors/redis.go
@@ -73,10 +73,7 @@ type ErrRedisNotFoundIdentity struct {
 
 // Error returns the string of ErrRedisNotFoundIdentity.error.
 func (e *ErrRedisNotFoundIdentity) Error() string {
-	if e.err != nil {
-		return e.err.Error()
-	}
-	return ""
+	return e.err.Error()
 }
 
 // Unwrap returns the error value of ErrRedisNotFoundIdentity.

--- a/internal/errors/redis.go
+++ b/internal/errors/redis.go
@@ -17,10 +17,6 @@
 // Package errors provides error types and function
 package errors
 
-import (
-	"reflect"
-)
-
 var (
 
 	// ErrRedisInvalidKVVKPrefix represents a function to generate an error that kv index and vk prefix are invalid.
@@ -78,7 +74,7 @@ type ErrRedisNotFoundIdentity struct {
 // Error returns the string of ErrRedisNotFoundIdentity.error.
 func (e *ErrRedisNotFoundIdentity) Error() string {
 	if e.err == nil {
-		return ErrErrorIsNil(reflect.TypeOf(e).Elem().Name()).Error()
+		return errNilCustomError("ErrRedisNotFoundIdentity")
 	}
 	return e.err.Error()
 }

--- a/internal/errors/redis.go
+++ b/internal/errors/redis.go
@@ -74,7 +74,7 @@ type ErrRedisNotFoundIdentity struct {
 // Error returns the string of ErrRedisNotFoundIdentity.error.
 func (e *ErrRedisNotFoundIdentity) Error() string {
 	if e.err == nil {
-		return errNilCustomError("ErrRedisNotFoundIdentity")
+		e.err = errExpectedErrIsNil("ErrRedisNotFoundIdentity")
 	}
 	return e.err.Error()
 }

--- a/internal/errors/redis.go
+++ b/internal/errors/redis.go
@@ -17,6 +17,10 @@
 // Package errors provides error types and function
 package errors
 
+import (
+	"reflect"
+)
+
 var (
 
 	// ErrRedisInvalidKVVKPrefix represents a function to generate an error that kv index and vk prefix are invalid.
@@ -73,6 +77,9 @@ type ErrRedisNotFoundIdentity struct {
 
 // Error returns the string of ErrRedisNotFoundIdentity.error.
 func (e *ErrRedisNotFoundIdentity) Error() string {
+	if e.err == nil {
+		return ErrErrorIsNil(reflect.TypeOf(e).Elem().Name()).Error()
+	}
 	return e.err.Error()
 }
 

--- a/internal/errors/redis_test.go
+++ b/internal/errors/redis_test.go
@@ -752,13 +752,6 @@ func TestErrRedisNotFoundIdentity_Error(t *testing.T) {
 				want: "Not found identity",
 			},
 		},
-		{
-			name:   "Success when err is nil",
-			fields: fields{},
-			want: want{
-				want: "",
-			},
-		},
 	}
 
 	for _, test := range tests {

--- a/internal/errors/redis_test.go
+++ b/internal/errors/redis_test.go
@@ -752,6 +752,13 @@ func TestErrRedisNotFoundIdentity_Error(t *testing.T) {
 				want: "Not found identity",
 			},
 		},
+		{
+			name:   "Success when err is nil",
+			fields: fields{},
+			want: want{
+				want: "custom error object is nil: ErrRedisNotFoundIdentity",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/errors/redis_test.go
+++ b/internal/errors/redis_test.go
@@ -756,7 +756,7 @@ func TestErrRedisNotFoundIdentity_Error(t *testing.T) {
 			name:   "Success when err is nil",
 			fields: fields{},
 			want: want{
-				want: "custom error object is nil: ErrRedisNotFoundIdentity",
+				want: "expected err is nil: ErrRedisNotFoundIdentity",
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: vankichi <kyukawa315@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
This PR includes:
- Remove nil check in `Error()` method in each `internal/errors` files.
- Add test for improve `internal/errors`'s test coverage

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [x] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
