### PR TITLE
[WIP] Refactor rebalancer controller: change recovery job logic

### DIFF
--- a/charts/vald-helm-operator/crds/valdrelease.yaml
+++ b/charts/vald-helm-operator/crds/valdrelease.yaml
@@ -15806,6 +15806,8 @@ spec:
                           type: string
                         agent_namespace:
                           type: string
+                        agent_port:
+                          type: number
                         agent_resource_type:
                           type: string
                         job:

--- a/charts/vald-helm-operator/crds/valdrelease.yaml
+++ b/charts/vald-helm-operator/crds/valdrelease.yaml
@@ -1215,6 +1215,8 @@ spec:
                               type: string
                             filename_suffix:
                               type: string
+                            kvsdb_filename_suffix:
+                              type: string
                             post_stop_timeout:
                               type: string
                             restore_backoff:

--- a/charts/vald/templates/rebalancer/jobconfigmap.yaml
+++ b/charts/vald/templates/rebalancer/jobconfigmap.yaml
@@ -77,7 +77,7 @@ data:
       compress:
         {{- toYaml $sidecar.compress | nindent 8 }}
       filename_suffix:
-        {{- toYaml $sidecar.filename_suffix | nindent 8 }}
+        {{- toYaml $sidecar.kvsdb_filename_suffix | nindent 8 }}
       target_agent_name: {{ .Values.rebalancer.rebalancer.job.target_agent_name }}
       rate: {{ .Values.rebalancer.rebalancer.job.rate }}
       parallelism: {{ .Values.rebalancer.rebalancer.job.parallelism }}

--- a/charts/vald/templates/rebalancer/jobconfigmap.yaml
+++ b/charts/vald/templates/rebalancer/jobconfigmap.yaml
@@ -77,6 +77,8 @@ data:
       compress:
         {{- toYaml $sidecar.compress | nindent 8 }}
       filename_suffix:
+        {{- toYaml $sidecar.filename_suffix | nindent 8 }}
+      kvsdb_filename_suffix:
         {{- toYaml $sidecar.kvsdb_filename_suffix | nindent 8 }}
       target_agent_name: {{ .Values.rebalancer.rebalancer.job.target_agent_name }}
       rate: {{ .Values.rebalancer.rebalancer.job.rate }}

--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -2719,6 +2719,9 @@ agent:
       # @schema {"name": "agent.sidecar.config.filename_suffix", "type": "string"}
       # agent.sidecar.config.filename_suffix -- suffix for backup filename
       filename_suffix: ".tar.gz"
+      # @schema {"name": "agent.sidecar.config.kvsdb_filename_suffix", "type": "string"}
+      # agent.sidecar.config.kvsdb_filename_suffix -- suffix for kvsdb backup filename
+      kvsdb_filename_suffix: "-kvsdb.tar.gz"
       # @schema {"name": "agent.sidecar.config.blob_storage", "type": "object"}
       blob_storage:
         # @schema {"name": "agent.sidecar.config.blob_storage.storage_type", "type": "string", "enum": ["s3", "cloud_storage"]}

--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -4979,6 +4979,9 @@ rebalancer:
     # @schema {"name": "rebalancer.rebalancer.agent_name", "type": "string"}
     # rebalancer.rebalancer.agent_name -- name of target agent
     agent_name: "vald-agent-ngt"
+    # @schema {"name": "rebalancer.rebalancer.agent_port", "type": "number"}
+    # rebalancer.rebalancer.agent_port -- port of target agent
+    agent_port: 8081
     # @schema {"name": "rebalancer.rebalancer.agent_namespace", "type": "string"}
     # rebalancer.rebalancer.agent_namespace -- namespace of target agent
     agent_namespace: _MY_POD_NAMESPACE_

--- a/internal/config/rebalancer.go
+++ b/internal/config/rebalancer.go
@@ -25,6 +25,7 @@ type RebalanceController struct {
 	RebalanceJobNamespace  string  `yaml:"rebalance_job_namespace" json:"rebalance_job_namespace"`
 	RebalanceJobTemplate   string  `yaml:"rebalance_job_template" json:"rebalance_job_template"`
 	AgentName              string  `yaml:"agent_name" json:"agent_name"`
+	AgentPort              int     `yaml:"agent_port" json:"agent_port"`
 	AgentNamespace         string  `yaml:"agent_namespace" json:"agent_namespace"`
 	AgentResourceType      string  `yaml:"agent_resource_type" json:"agent_resource_type"`
 	ReconcileCheckDuration string  `yaml:"reconcile_check_duration" json:"reconcile_check_duration"`

--- a/internal/config/sidecar.go
+++ b/internal/config/sidecar.go
@@ -43,6 +43,9 @@ type AgentSidecar struct {
 	// FilenameSuffix represent suffix of backup filename
 	FilenameSuffix string `yaml:"filename_suffix" json:"filename_suffix"`
 
+	// KvsdbFilenameSuffix represent suffix of kvsdb backup filename
+	KvsdbFilenameSuffix string `yaml:"kvsdb_filename_suffix" json:"kvsdb_filename_suffix"`
+
 	// BlobStorage represent blob storage configurations
 	BlobStorage *Blob `yaml:"blob_storage" json:"blob_storage"`
 
@@ -67,6 +70,7 @@ func (s *AgentSidecar) Bind() *AgentSidecar {
 	s.PostStopTimeout = GetActualValue(s.PostStopTimeout)
 	s.Filename = GetActualValue(s.Filename)
 	s.FilenameSuffix = GetActualValue(s.FilenameSuffix)
+	s.KvsdbFilenameSuffix = GetActualValue(s.KvsdbFilenameSuffix)
 
 	if s.BlobStorage != nil {
 		s.BlobStorage = s.BlobStorage.Bind()

--- a/pkg/agent/sidecar/service/observer/observer.go
+++ b/pkg/agent/sidecar/service/observer/observer.go
@@ -176,6 +176,10 @@ func (o *observer) PostStop(ctx context.Context) (err error) {
 			return nil
 		}
 
+		err = o.kvsBackup(ctx)
+		if err != nil {
+			return errors.Wrap(o.backup(ctx), err.Error())
+		}
 		return o.backup(ctx)
 	}
 

--- a/pkg/agent/sidecar/service/observer/observer.go
+++ b/pkg/agent/sidecar/service/observer/observer.go
@@ -705,7 +705,7 @@ func (o *observer) kvsBackup(ctx context.Context) (err error) {
 			}
 		}()
 
-		d, err := ctxio.NewReaderWithContext(ctx, data)
+		d, err := io.NewReaderWithContext(ctx, data)
 		if err != nil {
 			return err
 		}
@@ -717,7 +717,7 @@ func (o *observer) kvsBackup(ctx context.Context) (err error) {
 		return nil
 	}))
 
-	prr, err := ctxio.NewReaderWithContext(ctx, pr)
+	prr, err := io.NewReaderWithContext(ctx, pr)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/sidecar/service/observer/observer.go
+++ b/pkg/agent/sidecar/service/observer/observer.go
@@ -319,7 +319,6 @@ func (o *observer) startBackupLoop(ctx context.Context) (<-chan error, error) {
 					err = nil
 				}
 			}
-
 		}
 	}))
 
@@ -335,6 +334,12 @@ func (o *observer) onWrite(ctx context.Context, name string) error {
 	}()
 
 	log.Infof("[rebalance controller] onWrite event. name: %s", name)
+
+	/**
+	if name == "ngt.kvsdb" {
+		return o.requestKVSBackup(ctx)
+	}
+	**/
 
 	if name != o.metadataPath {
 		return nil
@@ -362,6 +367,12 @@ func (o *observer) onCreate(ctx context.Context, name string) error {
 	}()
 
 	log.Infof("[rebalance controller] onCreate event. name: %s", name)
+
+	/**
+	if name == "ngt.kvsdb" {
+		return o.requestKVSBackup(ctx)
+	}
+	**/
 
 	if name != o.metadataPath {
 		return nil

--- a/pkg/agent/sidecar/service/observer/observer.go
+++ b/pkg/agent/sidecar/service/observer/observer.go
@@ -40,6 +40,10 @@ import (
 	"github.com/vdaas/vald/pkg/agent/sidecar/service/storage"
 )
 
+const (
+	kvsFileName = "ngt-meta.kvsdb"
+)
+
 type StorageObserver interface {
 	Start(ctx context.Context) (<-chan error, error)
 	PostStop(ctx context.Context) error
@@ -645,7 +649,7 @@ func (o *observer) kvsBackup(ctx context.Context) (err error) {
 		}
 	}()
 
-	file := filepath.Join(o.dir, "ngt-meta.kvsdb")
+	file := filepath.Join(o.dir, kvsFileName)
 	fi, err := os.Stat(file)
 	if err != nil && os.IsNotExist(err) {
 		return err

--- a/pkg/agent/sidecar/service/observer/observer.go
+++ b/pkg/agent/sidecar/service/observer/observer.go
@@ -294,6 +294,7 @@ func (o *observer) startTicker(ctx context.Context) (<-chan error, error) {
 
 func (o *observer) startBackupLoop(ctx context.Context) (<-chan error, error) {
 	o.ch = make(chan struct{}, 1)
+	o.kvsch = make(chan struct{}, 1)
 
 	ech := make(chan error, 100)
 	o.eg.Go(safety.RecoverFunc(func() (err error) {

--- a/pkg/agent/sidecar/service/observer/observer.go
+++ b/pkg/agent/sidecar/service/observer/observer.go
@@ -58,7 +58,8 @@ type observer struct {
 	watchEnabled  bool
 	tickerEnabled bool
 
-	storage storage.Storage
+	storage      storage.Storage
+	kvsdbStorage storage.Storage
 
 	ch    chan struct{}
 	kvsch chan struct{}
@@ -335,12 +336,6 @@ func (o *observer) onWrite(ctx context.Context, name string) error {
 
 	log.Infof("[rebalance controller] onWrite event. name: %s", name)
 
-	/**
-	if name == "ngt.kvsdb" {
-		return o.requestKVSBackup(ctx)
-	}
-	**/
-
 	if name != o.metadataPath {
 		return nil
 	}
@@ -352,6 +347,7 @@ func (o *observer) onWrite(ctx context.Context, name string) error {
 	}
 
 	if ok {
+		o.requestKVSBackup(ctx)
 		return o.requestBackup(ctx)
 	}
 

--- a/pkg/agent/sidecar/service/observer/option.go
+++ b/pkg/agent/sidecar/service/observer/option.go
@@ -111,6 +111,15 @@ func WithBlobStorage(storage storage.Storage) Option {
 	}
 }
 
+func WithKvsdbBlobStorage(storage storage.Storage) Option {
+	return func(o *observer) error {
+		if storage != nil {
+			o.kvsdbStorage = storage
+		}
+		return nil
+	}
+}
+
 func WithHooks(hooks ...Hook) Option {
 	return func(o *observer) error {
 		if hooks == nil {

--- a/pkg/agent/sidecar/service/storage/storage.go
+++ b/pkg/agent/sidecar/service/storage/storage.go
@@ -191,6 +191,13 @@ func (b *bs) Reader(ctx context.Context) (r io.ReadCloser, err error) {
 	return r, nil
 }
 
+/**
+
+- agent-ngt-0.tar.gz
+- agent-ngt-0.kvsdb
+
+**/
+
 func (b *bs) Writer(ctx context.Context) (w io.WriteCloser, err error) {
 	w, err = b.bucket.Writer(ctx, b.filename+b.suffix)
 	if err != nil {

--- a/pkg/agent/sidecar/service/storage/storage.go
+++ b/pkg/agent/sidecar/service/storage/storage.go
@@ -191,13 +191,6 @@ func (b *bs) Reader(ctx context.Context) (r io.ReadCloser, err error) {
 	return r, nil
 }
 
-/**
-
-- agent-ngt-0.tar.gz
-- agent-ngt-0.kvsdb
-
-**/
-
 func (b *bs) Writer(ctx context.Context) (w io.WriteCloser, err error) {
 	w, err = b.bucket.Writer(ctx, b.filename+b.suffix)
 	if err != nil {

--- a/pkg/agent/sidecar/usecase/sidecar/sidecar.go
+++ b/pkg/agent/sidecar/usecase/sidecar/sidecar.go
@@ -154,7 +154,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		storage.WithType(cfg.AgentSidecar.BlobStorage.StorageType),
 		storage.WithBucketName(cfg.AgentSidecar.BlobStorage.Bucket),
 		storage.WithFilename(cfg.AgentSidecar.Filename),
-		storage.WithFilenameSuffix("-meta.kvsdb"), // cfg.AgentSidecar.KVSFileNameSuffix
+		storage.WithFilenameSuffix("-kvsdb.tar.gz"), // cfg.AgentSidecar.KVSFileNameSuffix
 		storage.WithS3SessionOpts(s3SessionOpts...),
 		storage.WithS3Opts(s3Opts...),
 	)

--- a/pkg/agent/sidecar/usecase/sidecar/sidecar.go
+++ b/pkg/agent/sidecar/usecase/sidecar/sidecar.go
@@ -154,7 +154,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		storage.WithType(cfg.AgentSidecar.BlobStorage.StorageType),
 		storage.WithBucketName(cfg.AgentSidecar.BlobStorage.Bucket),
 		storage.WithFilename(cfg.AgentSidecar.Filename),
-		storage.WithFilenameSuffix("-kvsdb.tar.gz"), // cfg.AgentSidecar.KVSFileNameSuffix
+		storage.WithFilenameSuffix(cfg.AgentSidecar.KvsdbFilenameSuffix),
 		storage.WithS3SessionOpts(s3SessionOpts...),
 		storage.WithS3Opts(s3Opts...),
 	)

--- a/pkg/agent/sidecar/usecase/sidecar/sidecar.go
+++ b/pkg/agent/sidecar/usecase/sidecar/sidecar.go
@@ -170,6 +170,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		observer.WithPostStopTimeout(cfg.AgentSidecar.PostStopTimeout),
 		observer.WithDir(cfg.AgentSidecar.WatchDir),
 		observer.WithBlobStorage(bs),
+		observer.WithKvsdbBlobStorage(kvsbs),
 	}
 
 	var metricsHook metrics.MetricsHook

--- a/pkg/rebalancer/storage/controller/service/rebalancer.go
+++ b/pkg/rebalancer/storage/controller/service/rebalancer.go
@@ -415,7 +415,7 @@ func (r *rebalancer) createJob(ctx context.Context, jobTpl job.Job, reason confi
 
 		agentAddr := net.JoinHostPort(p.IP, uint16(r.agentPort))
 
-		gc := grpc.New(grpc.WithAddrs(agentAddr), grpc.WithConnectionPoolSize(1))
+		gc := grpc.New(grpc.WithAddrs(agentAddr), grpc.WithConnectionPoolSize(1), grpc.WithInsecure(true), grpc.WithResolveDNS(false))
 		_, err = gc.StartConnectionMonitor(ctx)
 		if err != nil {
 			return err

--- a/pkg/rebalancer/storage/controller/service/rebalancer_option.go
+++ b/pkg/rebalancer/storage/controller/service/rebalancer_option.go
@@ -71,6 +71,13 @@ func WithAgentName(an string) RebalancerOption {
 	}
 }
 
+func WithAgentPort(port int) RebalancerOption {
+	return func(r *rebalancer) error {
+		r.agentPort = port
+		return nil
+	}
+}
+
 func WithAgentNamespace(ans string) RebalancerOption {
 	return func(r *rebalancer) error {
 		r.agentNamespace = ans

--- a/pkg/rebalancer/storage/controller/usecase/rebalanced.go
+++ b/pkg/rebalancer/storage/controller/usecase/rebalanced.go
@@ -55,6 +55,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 		service.WithJobNamespace(cfg.Rebalancer.RebalanceJobNamespace),
 		service.WithJobTemplate(cfg.Rebalancer.RebalanceJobTemplate),
 		service.WithAgentName(cfg.Rebalancer.AgentName),
+		service.WithAgentPort(cfg.Rebalancer.AgentPort),
 		service.WithAgentNamespace(cfg.Rebalancer.AgentNamespace),
 		service.WithAgentResourceType(cfg.Rebalancer.AgentResourceType),
 		service.WithReconcileCheckDuration(cfg.Rebalancer.ReconcileCheckDuration),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR change the recovery job create logic.
Instead of creating job instantly when detecting the statefulset decreased, 
we need to create the job when the decreased agent is completely finished and removed by k8s.
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
