### PR TITLE
Implement pkg/agent/core/ngt/handler/grpc/option test

### DIFF
--- a/pkg/agent/core/ngt/handler/grpc/handler_test.go
+++ b/pkg/agent/core/ngt/handler/grpc/handler_test.go
@@ -38,16 +38,20 @@ func TestNew(t *testing.T) {
 	}
 	type want struct {
 		want Server
+		err  error
 	}
 	type test struct {
 		name       string
 		args       args
 		want       want
-		checkFunc  func(want, Server) error
+		checkFunc  func(want, Server, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
-	defaultCheckFunc := func(w want, got Server) error {
+	defaultCheckFunc := func(w want, got Server, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
 		if !reflect.DeepEqual(got, w.want) {
 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
 		}
@@ -96,8 +100,8 @@ func TestNew(t *testing.T) {
 				test.checkFunc = defaultCheckFunc
 			}
 
-			got := New(test.args.opts...)
-			if err := test.checkFunc(test.want, got); err != nil {
+			got, err := New(test.args.opts...)
+			if err := test.checkFunc(test.want, got, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
 		})

--- a/pkg/agent/core/ngt/handler/grpc/handler_test.go
+++ b/pkg/agent/core/ngt/handler/grpc/handler_test.go
@@ -50,7 +50,7 @@ func TestNew(t *testing.T) {
 	}
 	defaultCheckFunc := func(w want, got Server, err error) error {
 		if !errors.Is(err, w.err) {
-			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant_error: \"%#v\"", err, w.err)
 		}
 		if !reflect.DeepEqual(got, w.want) {
 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)

--- a/pkg/agent/core/ngt/handler/grpc/option.go
+++ b/pkg/agent/core/ngt/handler/grpc/option.go
@@ -27,6 +27,7 @@ import (
 	"github.com/vdaas/vald/pkg/agent/core/ngt/service"
 )
 
+// Option represents the functional option for server.
 type Option func(*server) error
 
 var defaultOptions = []Option{
@@ -42,6 +43,7 @@ var defaultOptions = []Option{
 	WithErrGroup(errgroup.Get()),
 }
 
+// WithIP returns the option to set the IP for server.
 func WithIP(ip string) Option {
 	return func(s *server) error {
 		if len(ip) == 0 {
@@ -52,6 +54,7 @@ func WithIP(ip string) Option {
 	}
 }
 
+// WithName returns the option to set the name for server.
 func WithName(name string) Option {
 	return func(s *server) error {
 		if len(name) == 0 {
@@ -62,6 +65,7 @@ func WithName(name string) Option {
 	}
 }
 
+// WithNGT returns the option to set the NGT service for server.
 func WithNGT(n service.NGT) Option {
 	return func(s *server) error {
 		if n == nil {
@@ -72,6 +76,7 @@ func WithNGT(n service.NGT) Option {
 	}
 }
 
+// WithStreamConcurrency returns the option to set the stream concurrency for server.
 func WithStreamConcurrency(c int) Option {
 	return func(s *server) error {
 		if c <= 0 {
@@ -82,6 +87,7 @@ func WithStreamConcurrency(c int) Option {
 	}
 }
 
+// WithErrGroup returns the option to set the error group for server.
 func WithErrGroup(eg errgroup.Group) Option {
 	return func(s *server) error {
 		if eg == nil {

--- a/pkg/agent/core/ngt/handler/grpc/option.go
+++ b/pkg/agent/core/ngt/handler/grpc/option.go
@@ -21,12 +21,13 @@ import (
 	"os"
 
 	"github.com/vdaas/vald/internal/errgroup"
+	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/log"
 	"github.com/vdaas/vald/internal/net"
 	"github.com/vdaas/vald/pkg/agent/core/ngt/service"
 )
 
-type Option func(*server)
+type Option func(*server) error
 
 var defaultOptions = []Option{
 	WithName(func() string {
@@ -42,39 +43,51 @@ var defaultOptions = []Option{
 }
 
 func WithIP(ip string) Option {
-	return func(s *server) {
-		if len(ip) != 0 {
-			s.ip = ip
+	return func(s *server) error {
+		if len(ip) == 0 {
+			return errors.NewErrInvalidOption("ip", ip)
 		}
+		s.ip = ip
+		return nil
 	}
 }
 
 func WithName(name string) Option {
-	return func(s *server) {
-		if len(name) != 0 {
-			s.name = name
+	return func(s *server) error {
+		if len(name) == 0 {
+			return errors.NewErrInvalidOption("name", name)
 		}
+		s.name = name
+		return nil
 	}
 }
 
 func WithNGT(n service.NGT) Option {
-	return func(s *server) {
+	return func(s *server) error {
+		if n == nil {
+			return errors.NewErrInvalidOption("ngt", n)
+		}
 		s.ngt = n
+		return nil
 	}
 }
 
 func WithStreamConcurrency(c int) Option {
-	return func(s *server) {
-		if c != 0 {
-			s.streamConcurrency = c
+	return func(s *server) error {
+		if c <= 0 {
+			return errors.NewErrInvalidOption("streamConcurrency", c)
 		}
+		s.streamConcurrency = c
+		return nil
 	}
 }
 
 func WithErrGroup(eg errgroup.Group) Option {
-	return func(s *server) {
-		if eg != nil {
-			s.eg = eg
+	return func(s *server) error {
+		if eg == nil {
+			return errors.NewErrInvalidOption("errGroup", eg)
 		}
+		s.eg = eg
+		return nil
 	}
 }

--- a/pkg/agent/core/ngt/handler/grpc/option_test.go
+++ b/pkg/agent/core/ngt/handler/grpc/option_test.go
@@ -59,7 +59,7 @@ func TestWithIP(t *testing.T) {
 
 	defaultCheckFunc := func(w want, obj *T, err error) error {
 		if !errors.Is(err, w.err) {
-			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant_error: \"%#v\"", err, w.err)
 		}
 		if !reflect.DeepEqual(obj, w.obj) {
 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
@@ -136,7 +136,7 @@ func TestWithName(t *testing.T) {
 	}
 	defaultCheckFunc := func(w want, obj *T, err error) error {
 		if !errors.Is(err, w.err) {
-			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant_error: \"%#v\"", err, w.err)
 		}
 		if !reflect.DeepEqual(obj, w.obj) {
 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
@@ -212,7 +212,7 @@ func TestWithNGT(t *testing.T) {
 
 	defaultCheckFunc := func(w want, obj *T, err error) error {
 		if !errors.Is(err, w.err) {
-			return errors.Errorf("got_error: \"%s\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+			return errors.Errorf("got_error: \"%s\",\n\t\t\t\twant_error: \"%#v\"", err, w.err)
 		}
 		if !reflect.DeepEqual(obj, w.obj) {
 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
@@ -295,7 +295,7 @@ func TestWithStreamConcurrency(t *testing.T) {
 
 	defaultCheckFunc := func(w want, obj *T, err error) error {
 		if !errors.Is(err, w.err) {
-			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant_error: \"%#v\"", err, w.err)
 		}
 		if !reflect.DeepEqual(obj, w.obj) {
 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
@@ -385,7 +385,7 @@ func TestWithErrGroup(t *testing.T) {
 
 	defaultCheckFunc := func(w want, obj *T, err error) error {
 		if !errors.Is(err, w.err) {
-			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant_error: \"%#v\"", err, w.err)
 		}
 		if !reflect.DeepEqual(obj, w.obj) {
 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)

--- a/pkg/agent/core/ngt/handler/grpc/option_test.go
+++ b/pkg/agent/core/ngt/handler/grpc/option_test.go
@@ -18,87 +18,77 @@
 package grpc
 
 import (
+	"os"
+	"reflect"
 	"testing"
 
+	"github.com/vdaas/vald/internal/config"
 	"github.com/vdaas/vald/internal/errgroup"
+	"github.com/vdaas/vald/internal/errors"
+	"github.com/vdaas/vald/internal/info"
+	"github.com/vdaas/vald/internal/log"
+	"github.com/vdaas/vald/internal/log/logger"
 	"github.com/vdaas/vald/pkg/agent/core/ngt/service"
 	"go.uber.org/goleak"
 )
 
+func TestMain(m *testing.M) {
+	log.Init(log.WithLoggerType(logger.NOP.String()))
+	info.Init("")
+	os.Exit(m.Run())
+}
+
 func TestWithIP(t *testing.T) {
 	t.Parallel()
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = server
 	type args struct {
 		ip string
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           ip: "",
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           ip: "",
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set success when ip is not empty",
+			args: args{
+				ip: "192.168.1.1",
+			},
+			want: want{
+				obj: &T{
+					ip: "192.168.1.1",
+				},
+			},
+		},
+		{
+			name: "set fail when ip is empty",
+			args: args{
+				ip: "",
+			},
+			want: want{
+				obj: new(T),
+				err: errors.NewErrInvalidOption("ip", ""),
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -113,109 +103,68 @@ func TestWithIP(t *testing.T) {
 				defer test.afterFunc(test.args)
 			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			   got := WithIP(test.args.ip)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithIP(test.args.ip)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithIP(test.args.ip)
+			obj := new(T)
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithName(t *testing.T) {
 	t.Parallel()
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = server
 	type args struct {
 		name string
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
-
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
+		}
+		return nil
+	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           name: "",
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           name: "",
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set success when name is not empty",
+			args: args{
+				name: "agent handler",
+			},
+			want: want{
+				obj: &T{
+					name: "agent handler",
+				},
+			},
+		},
+		{
+			name: "set fail when name is empty",
+			args: args{
+				name: "",
+			},
+			want: want{
+				obj: new(T),
+				err: errors.NewErrInvalidOption("name", ""),
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -229,110 +178,82 @@ func TestWithName(t *testing.T) {
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithName(test.args.name)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithName(test.args.name)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithName(test.args.name)
+			obj := new(T)
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithNGT(t *testing.T) {
 	t.Parallel()
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = server
 	type args struct {
 		n service.NGT
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%s\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
+		}
+		return nil
+	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           n: nil,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           n: nil,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		func() test {
+			n, err := service.New(&config.NGT{
+				Dimension:    1024,
+				DistanceType: "cos",
+				ObjectType:   "uint8",
+				VQueue:       &config.VQueue{},
+			})
+			if err != nil {
+				panic(err)
+			}
+			return test{
+				name: "set success when ngt is not nil",
+				args: args{
+					n: n,
+				},
+				want: want{
+					obj: &T{
+						ngt: n,
+					},
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "set fail when ngt is nil",
+				args: args{
+					n: nil,
+				},
+				want: want{
+					obj: new(T),
+					err: errors.NewErrInvalidOption("ngt", nil),
+				},
+			}
+		}(),
 	}
 
 	for _, tc := range tests {
@@ -346,110 +267,83 @@ func TestWithNGT(t *testing.T) {
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithNGT(test.args.n)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithNGT(test.args.n)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithNGT(test.args.n)
+			obj := new(T)
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithStreamConcurrency(t *testing.T) {
 	t.Parallel()
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = server
 	type args struct {
 		c int
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
+		}
+		return nil
+	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           c: 0,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           c: 0,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		{
+			name: "set success when streamConcurrency > 0",
+			args: args{
+				c: 100,
+			},
+			want: want{
+				obj: &T{
+					streamConcurrency: 100,
+				},
+			},
+		},
+		{
+			name: "set fail when streamConcurrency < 0",
+			args: args{
+				c: -500,
+			},
+			want: want{
+				obj: &T{
+					streamConcurrency: 0,
+				},
+				err: errors.NewErrInvalidOption("streamConcurrency", -500),
+			},
+		},
+		{
+			name: "set fail when streamConcurrency  0",
+			args: args{
+				c: 0,
+			},
+			want: want{
+				obj: &T{
+					streamConcurrency: 0,
+				},
+				err: errors.NewErrInvalidOption("streamConcurrency", 0),
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -463,110 +357,76 @@ func TestWithStreamConcurrency(t *testing.T) {
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithStreamConcurrency(test.args.c)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithStreamConcurrency(test.args.c)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithStreamConcurrency(test.args.c)
+			obj := new(T)
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithErrGroup(t *testing.T) {
 	t.Parallel()
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = server
 	type args struct {
 		eg errgroup.Group
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
+		}
+		return nil
+	}
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           eg: nil,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           eg: nil,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		func() test {
+			eg := errgroup.Get()
+			return test{
+				name: "set success when eg is not nil",
+				args: args{
+					eg: eg,
+				},
+				want: want{
+					obj: &T{
+						eg: eg,
+					},
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "set fail when eg is nil",
+				args: args{
+					eg: nil,
+				},
+				want: want{
+					obj: &T{
+						eg: nil,
+					},
+					err: errors.NewErrInvalidOption("errGroup", nil),
+				},
+			}
+		}(),
 	}
 
 	for _, tc := range tests {
@@ -580,32 +440,15 @@ func TestWithErrGroup(t *testing.T) {
 			if test.afterFunc != nil {
 				defer test.afterFunc(test.args)
 			}
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-
-			   got := WithErrGroup(test.args.eg)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithErrGroup(test.args.eg)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithErrGroup(test.args.eg)
+			obj := new(T)
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }

--- a/pkg/agent/core/ngt/handler/grpc/option_test.go
+++ b/pkg/agent/core/ngt/handler/grpc/option_test.go
@@ -223,6 +223,7 @@ func TestWithNGT(t *testing.T) {
 		{
 			name: "set success when ngt is not nil",
 			beforeFunc: func(t *testing.T, args *args, w *want) {
+				t.Helper()
 				n, err := service.New(&config.NGT{
 					Dimension:    1024,
 					DistanceType: "cos",

--- a/pkg/agent/core/ngt/handler/grpc/option_test.go
+++ b/pkg/agent/core/ngt/handler/grpc/option_test.go
@@ -86,7 +86,7 @@ func TestWithIP(t *testing.T) {
 			},
 			want: want{
 				obj: new(T),
-				err: errors.NewErrInvalidOption("ip", ""),
+				err: errors.New("invalid option, name: ip, val: "),
 			},
 		},
 	}
@@ -162,7 +162,7 @@ func TestWithName(t *testing.T) {
 			},
 			want: want{
 				obj: new(T),
-				err: errors.NewErrInvalidOption("name", ""),
+				err: errors.New("invalid option, name: name, val: "),
 			},
 		},
 	}
@@ -245,7 +245,7 @@ func TestWithNGT(t *testing.T) {
 			},
 			want: want{
 				obj: new(T),
-				err: errors.NewErrInvalidOption("ngt", nil),
+				err: errors.New("invalid option, name: ngt, val: <nil>"),
 			},
 		},
 	}
@@ -323,7 +323,7 @@ func TestWithStreamConcurrency(t *testing.T) {
 				obj: &T{
 					streamConcurrency: 0,
 				},
-				err: errors.NewErrInvalidOption("streamConcurrency", -500),
+				err: errors.New("invalid option, name: streamConcurrency, val: -500"),
 			},
 		},
 		{
@@ -335,7 +335,7 @@ func TestWithStreamConcurrency(t *testing.T) {
 				obj: &T{
 					streamConcurrency: 0,
 				},
-				err: errors.NewErrInvalidOption("streamConcurrency", 0),
+				err: errors.New("invalid option, name: streamConcurrency, val: 0"),
 			},
 		},
 	}
@@ -417,7 +417,7 @@ func TestWithErrGroup(t *testing.T) {
 					obj: &T{
 						eg: nil,
 					},
-					err: errors.NewErrInvalidOption("errGroup", nil),
+					err: errors.New("invalid option, name: errGroup, val: <nil>"),
 				},
 			}
 		}(),

--- a/pkg/agent/core/ngt/usecase/agentd.go
+++ b/pkg/agent/core/ngt/usecase/agentd.go
@@ -68,10 +68,13 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	if err != nil {
 		return nil, err
 	}
-	g := handler.New(
+	g, err := handler.New(
 		handler.WithNGT(ngt),
 		handler.WithStreamConcurrency(cfg.Server.GetGRPCStreamConcurrency()),
 	)
+	if err != nil {
+		return nil, err
+	}
 	eg := errgroup.Get()
 
 	grpcServerOptions := []server.Option{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR implements pkg/agent/core/ngt/handler/grpc/option test.
This PR also refactor the implement of the option to return error base on the guideline here.
https://github.com/vdaas/vald/blob/master/docs/contributing/coding-style.md#functional-option

<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly.
