### PR TITLE
Add test for pkg/agent/core/ngt/service/vqueue/option

### DIFF
--- a/pkg/agent/core/ngt/handler/grpc/option_test.go
+++ b/pkg/agent/core/ngt/handler/grpc/option_test.go
@@ -228,7 +228,12 @@ func TestWithNGT(t *testing.T) {
 					Dimension:    1024,
 					DistanceType: "cos",
 					ObjectType:   "uint8",
-					VQueue:       &config.VQueue{},
+					VQueue: &config.VQueue{
+						InsertBufferSize:     100,
+						InsertBufferPoolSize: 50,
+						DeleteBufferSize:     100,
+						DeleteBufferPoolSize: 50,
+					},
 				})
 				if err != nil {
 					t.Fatal(err)

--- a/pkg/agent/core/ngt/service/vqueue/option.go
+++ b/pkg/agent/core/ngt/service/vqueue/option.go
@@ -45,7 +45,7 @@ func WithErrGroup(eg errgroup.Group) Option {
 	}
 }
 
-// WithInsertBufferSize returns the option to set the size of insert buffer.
+// WithInsertBufferSize returns the option to set the size of the insert buffer.
 func WithInsertBufferSize(size int) Option {
 	return func(v *vqueue) error {
 		if size <= 0 {
@@ -57,7 +57,7 @@ func WithInsertBufferSize(size int) Option {
 	}
 }
 
-// WithDeleteBufferSize returns the option to set the size of delete buffer.
+// WithDeleteBufferSize returns the option to set the size of the delete buffer.
 func WithDeleteBufferSize(size int) Option {
 	return func(v *vqueue) error {
 		if size <= 0 {
@@ -69,7 +69,7 @@ func WithDeleteBufferSize(size int) Option {
 	}
 }
 
-// WithInsertBufferPoolSize returns the option to set the pool size of insert buffer.
+// WithInsertBufferPoolSize returns the option to set the pool size of the insert buffer.
 func WithInsertBufferPoolSize(size int) Option {
 	return func(v *vqueue) error {
 		if size <= 0 {
@@ -81,7 +81,7 @@ func WithInsertBufferPoolSize(size int) Option {
 	}
 }
 
-// WithDeleteBufferPoolSize returns the option to set the pool size of delete buffer.
+// WithDeleteBufferPoolSize returns the option to set the pool size of the delete buffer.
 func WithDeleteBufferPoolSize(size int) Option {
 	return func(v *vqueue) error {
 		if size <= 0 {

--- a/pkg/agent/core/ngt/service/vqueue/option.go
+++ b/pkg/agent/core/ngt/service/vqueue/option.go
@@ -19,8 +19,10 @@ package vqueue
 
 import (
 	"github.com/vdaas/vald/internal/errgroup"
+	"github.com/vdaas/vald/internal/errors"
 )
 
+// Option represents the functional option for vqueue.
 type Option func(n *vqueue) error
 
 var defaultOptions = []Option{
@@ -31,51 +33,61 @@ var defaultOptions = []Option{
 	WithInsertBufferSize(100),
 }
 
+// WithErrGroup returns the option to set the errgroup.
 func WithErrGroup(eg errgroup.Group) Option {
 	return func(v *vqueue) error {
-		if eg != nil {
-			v.eg = eg
+		if eg == nil {
+			return errors.NewErrInvalidOption("errgroup", eg)
 		}
+		v.eg = eg
 
 		return nil
 	}
 }
 
+// WithInsertBufferSize returns the option to set the size of insert buffer.
 func WithInsertBufferSize(size int) Option {
 	return func(v *vqueue) error {
-		if size > 0 {
-			v.ichSize = size
+		if size <= 0 {
+			return errors.NewErrInvalidOption("insertBufferSize", size)
 		}
+		v.ichSize = size
 
 		return nil
 	}
 }
 
+// WithDeleteBufferSize returns the option to set the size of delete buffer.
 func WithDeleteBufferSize(size int) Option {
 	return func(v *vqueue) error {
-		if size > 0 {
-			v.dchSize = size
+		if size <= 0 {
+			return errors.NewErrInvalidOption("deleteBufferSize", size)
 		}
+		v.dchSize = size
 
 		return nil
 	}
 }
 
+// WithInsertBufferPoolSize returns the option to set the pool size of insert buffer.
 func WithInsertBufferPoolSize(size int) Option {
 	return func(v *vqueue) error {
-		if size > 0 {
-			v.iBufSize = size
+		if size <= 0 {
+			return errors.NewErrInvalidOption("insertBufferPoolSize", size)
 		}
+		v.iBufSize = size
 
 		return nil
 	}
 }
 
+// WithDeleteBufferPoolSize returns the option to set the pool size of delete buffer.
 func WithDeleteBufferPoolSize(size int) Option {
 	return func(v *vqueue) error {
-		if size > 0 {
-			v.dBufSize = size
+		if size <= 0 {
+			return errors.NewErrInvalidOption("deleteBufferPoolSize", size)
 		}
+		v.dBufSize = size
 
 		return nil
 	}

--- a/pkg/agent/core/ngt/service/vqueue/option_test.go
+++ b/pkg/agent/core/ngt/service/vqueue/option_test.go
@@ -18,86 +18,68 @@
 package vqueue
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
 	"github.com/vdaas/vald/internal/errgroup"
+	"github.com/vdaas/vald/internal/errors"
 	"go.uber.org/goleak"
 )
 
 func TestWithErrGroup(t *testing.T) {
-	t.Parallel()
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = vqueue
 	type args struct {
 		eg errgroup.Group
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           eg: nil,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           eg: nil,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		func() test {
+			eg, _ := errgroup.New(context.Background())
+			return test{
+				name: "set success when the eg is not nil",
+				args: args{
+					eg: eg,
+				},
+				want: want{
+					obj: &T{
+						eg: eg,
+					},
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "set fails when the eg is nil",
+				args: args{},
+				want: want{
+					err: errors.NewErrInvalidOption("errgroup", nil),
+					obj: new(T),
+				},
+			}
+		}(),
 	}
 
 	for _, tc := range tests {
@@ -112,109 +94,87 @@ func TestWithErrGroup(t *testing.T) {
 				defer test.afterFunc(test.args)
 			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			   got := WithErrGroup(test.args.eg)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithErrGroup(test.args.eg)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithErrGroup(test.args.eg)
+			obj := new(T)
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithInsertBufferSize(t *testing.T) {
-	t.Parallel()
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = vqueue
 	type args struct {
 		size int
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           size: 0,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           size: 0,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		func() test {
+			return test{
+				name: "set success when size is 100",
+				args: args{
+					size: 100,
+				},
+				want: want{
+					obj: &T{
+						ichSize: 100,
+					},
+				},
+			}
+		}(),
+		func() test {
+			size := 0
+			return test{
+				name: "set fails when size is 0",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("insertBufferSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
+		func() test {
+			size := -1
+			return test{
+				name: "set fails when size is -1",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("insertBufferSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
 	}
 
 	for _, tc := range tests {
@@ -229,109 +189,87 @@ func TestWithInsertBufferSize(t *testing.T) {
 				defer test.afterFunc(test.args)
 			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			   got := WithInsertBufferSize(test.args.size)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithInsertBufferSize(test.args.size)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithInsertBufferSize(test.args.size)
+			obj := new(T)
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithDeleteBufferSize(t *testing.T) {
-	t.Parallel()
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = vqueue
 	type args struct {
 		size int
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           size: 0,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           size: 0,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		func() test {
+			return test{
+				name: "set success when size is 100",
+				args: args{
+					size: 100,
+				},
+				want: want{
+					obj: &T{
+						dchSize: 100,
+					},
+				},
+			}
+		}(),
+		func() test {
+			size := 0
+			return test{
+				name: "set fails when size is 0",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("deleteBufferSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
+		func() test {
+			size := -1
+			return test{
+				name: "set fails when size is 0",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("deleteBufferSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
 	}
 
 	for _, tc := range tests {
@@ -346,109 +284,87 @@ func TestWithDeleteBufferSize(t *testing.T) {
 				defer test.afterFunc(test.args)
 			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			   got := WithDeleteBufferSize(test.args.size)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithDeleteBufferSize(test.args.size)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithDeleteBufferSize(test.args.size)
+			obj := new(T)
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithInsertBufferPoolSize(t *testing.T) {
-	t.Parallel()
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = vqueue
 	type args struct {
 		size int
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           size: 0,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           size: 0,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		func() test {
+			return test{
+				name: "set success when size is 100",
+				args: args{
+					size: 100,
+				},
+				want: want{
+					obj: &T{
+						iBufSize: 100,
+					},
+				},
+			}
+		}(),
+		func() test {
+			size := 0
+			return test{
+				name: "set fails when size is 0",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("insertBufferPoolSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
+		func() test {
+			size := -1
+			return test{
+				name: "set fails when size is 0",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("insertBufferPoolSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
 	}
 
 	for _, tc := range tests {
@@ -463,109 +379,87 @@ func TestWithInsertBufferPoolSize(t *testing.T) {
 				defer test.afterFunc(test.args)
 			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			   got := WithInsertBufferPoolSize(test.args.size)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithInsertBufferPoolSize(test.args.size)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithInsertBufferPoolSize(test.args.size)
+			obj := new(T)
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }
 
 func TestWithDeleteBufferPoolSize(t *testing.T) {
-	t.Parallel()
-	// Change interface type to the type of object you are testing
-	type T = interface{}
+	type T = vqueue
 	type args struct {
 		size int
 	}
 	type want struct {
 		obj *T
-		// Uncomment this line if the option returns an error, otherwise delete it
-		// err error
+		err error
 	}
 	type test struct {
-		name string
-		args args
-		want want
-		// Use the first line if the option returns an error. otherwise use the second line
-		// checkFunc  func(want, *T, error) error
-		// checkFunc  func(want, *T) error
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, *T, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
 
-	// Uncomment this block if the option returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T, err error) error {
-	       if !errors.Is(err, w.err) {
-	           return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-	       }
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
-
-	// Uncomment this block if the option do not returns an error, otherwise delete it
-	/*
-	   defaultCheckFunc := func(w want, obj *T) error {
-	       if !reflect.DeepEqual(obj, w.obj) {
-	           return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
-	       }
-	       return nil
-	   }
-	*/
+	defaultCheckFunc := func(w want, obj *T, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if !reflect.DeepEqual(obj, w.obj) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", obj, w.obj)
+		}
+		return nil
+	}
 
 	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           size: 0,
-		       },
-		       want: want {
-		           obj: new(T),
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           size: 0,
-		           },
-		           want: want {
-		               obj: new(T),
-		           },
-		       }
-		   }(),
-		*/
+		func() test {
+			return test{
+				name: "set success when size is 100",
+				args: args{
+					size: 100,
+				},
+				want: want{
+					obj: &T{
+						dBufSize: 100,
+					},
+				},
+			}
+		}(),
+		func() test {
+			size := 0
+			return test{
+				name: "set fails when size is 0",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("deleteBufferPoolSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
+		func() test {
+			size := -1
+			return test{
+				name: "set fails when size is 0",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("deleteBufferPoolSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
 	}
 
 	for _, tc := range tests {
@@ -580,31 +474,15 @@ func TestWithDeleteBufferPoolSize(t *testing.T) {
 				defer test.afterFunc(test.args)
 			}
 
-			// Uncomment this block if the option returns an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
+			if test.checkFunc == nil {
+				test.checkFunc = defaultCheckFunc
+			}
 
-			   got := WithDeleteBufferPoolSize(test.args.size)
-			   obj := new(T)
-			   if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
-
-			// Uncomment this block if the option do not return an error, otherwise delete it
-			/*
-			   if test.checkFunc == nil {
-			       test.checkFunc = defaultCheckFunc
-			   }
-			   got := WithDeleteBufferPoolSize(test.args.size)
-			   obj := new(T)
-			   got(obj)
-			   if err := test.checkFunc(test.want, obj); err != nil {
-			       tt.Errorf("error = %v", err)
-			   }
-			*/
+			got := WithDeleteBufferPoolSize(test.args.size)
+			obj := new(T)
+			if err := test.checkFunc(test.want, obj, got(obj)); err != nil {
+				tt.Errorf("error = %v", err)
+			}
 		})
 	}
 }

--- a/pkg/agent/core/ngt/service/vqueue/option_test.go
+++ b/pkg/agent/core/ngt/service/vqueue/option_test.go
@@ -175,6 +175,19 @@ func TestWithInsertBufferSize(t *testing.T) {
 				},
 			}
 		}(),
+		func() test {
+			size := -100
+			return test{
+				name: "set fails when size is -100",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("insertBufferSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
 	}
 
 	for _, tc := range tests {
@@ -260,7 +273,20 @@ func TestWithDeleteBufferSize(t *testing.T) {
 		func() test {
 			size := -1
 			return test{
-				name: "set fails when size is 0",
+				name: "set fails when size is -1",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("deleteBufferSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
+		func() test {
+			size := -100
+			return test{
+				name: "set fails when size is -100",
 				args: args{
 					size: size,
 				},
@@ -355,7 +381,20 @@ func TestWithInsertBufferPoolSize(t *testing.T) {
 		func() test {
 			size := -1
 			return test{
-				name: "set fails when size is 0",
+				name: "set fails when size is -1",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("insertBufferPoolSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
+		func() test {
+			size := -100
+			return test{
+				name: "set fails when size is -100",
 				args: args{
 					size: size,
 				},
@@ -450,7 +489,20 @@ func TestWithDeleteBufferPoolSize(t *testing.T) {
 		func() test {
 			size := -1
 			return test{
-				name: "set fails when size is 0",
+				name: "set fails when size is -1",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("deleteBufferPoolSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
+		func() test {
+			size := -100
+			return test{
+				name: "set fails when size is -100",
 				args: args{
 					size: size,
 				},

--- a/pkg/agent/core/ngt/service/vqueue/option_test.go
+++ b/pkg/agent/core/ngt/service/vqueue/option_test.go
@@ -19,6 +19,7 @@ package vqueue
 
 import (
 	"context"
+	"math"
 	"reflect"
 	"testing"
 
@@ -137,14 +138,43 @@ func TestWithInsertBufferSize(t *testing.T) {
 
 	tests := []test{
 		func() test {
+			size := 100
 			return test{
 				name: "set success when size is 100",
 				args: args{
-					size: 100,
+					size: size,
 				},
 				want: want{
 					obj: &T{
 						ichSize: 100,
+					},
+				},
+			}
+		}(),
+		func() test {
+			size := 1
+			return test{
+				name: "set success when size is 1",
+				args: args{
+					size: size,
+				},
+				want: want{
+					obj: &T{
+						ichSize: size,
+					},
+				},
+			}
+		}(),
+		func() test {
+			size := math.MaxInt64
+			return test{
+				name: "set success when size is maximum value of int",
+				args: args{
+					size: size,
+				},
+				want: want{
+					obj: &T{
+						ichSize: size,
 					},
 				},
 			}
@@ -179,6 +209,19 @@ func TestWithInsertBufferSize(t *testing.T) {
 			size := -100
 			return test{
 				name: "set fails when size is -100",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("insertBufferSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
+		func() test {
+			size := math.MinInt64
+			return test{
+				name: "set success when size is minimum value of int",
 				args: args{
 					size: size,
 				},
@@ -245,14 +288,43 @@ func TestWithDeleteBufferSize(t *testing.T) {
 
 	tests := []test{
 		func() test {
+			size := 100
 			return test{
 				name: "set success when size is 100",
 				args: args{
-					size: 100,
+					size: size,
 				},
 				want: want{
 					obj: &T{
-						dchSize: 100,
+						dchSize: size,
+					},
+				},
+			}
+		}(),
+		func() test {
+			size := 1
+			return test{
+				name: "set success when size is 1",
+				args: args{
+					size: size,
+				},
+				want: want{
+					obj: &T{
+						dchSize: size,
+					},
+				},
+			}
+		}(),
+		func() test {
+			size := math.MaxInt64
+			return test{
+				name: "set success when size is maximum value of int",
+				args: args{
+					size: size,
+				},
+				want: want{
+					obj: &T{
+						dchSize: size,
 					},
 				},
 			}
@@ -287,6 +359,19 @@ func TestWithDeleteBufferSize(t *testing.T) {
 			size := -100
 			return test{
 				name: "set fails when size is -100",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("deleteBufferSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
+		func() test {
+			size := math.MinInt64
+			return test{
+				name: "set success when size is minimum value of int",
 				args: args{
 					size: size,
 				},
@@ -353,14 +438,43 @@ func TestWithInsertBufferPoolSize(t *testing.T) {
 
 	tests := []test{
 		func() test {
+			size := 100
 			return test{
 				name: "set success when size is 100",
 				args: args{
-					size: 100,
+					size: size,
 				},
 				want: want{
 					obj: &T{
-						iBufSize: 100,
+						iBufSize: size,
+					},
+				},
+			}
+		}(),
+		func() test {
+			size := 1
+			return test{
+				name: "set success when size is 1",
+				args: args{
+					size: size,
+				},
+				want: want{
+					obj: &T{
+						iBufSize: size,
+					},
+				},
+			}
+		}(),
+		func() test {
+			size := math.MaxInt64
+			return test{
+				name: "set success when size is maximum value of int",
+				args: args{
+					size: size,
+				},
+				want: want{
+					obj: &T{
+						iBufSize: size,
 					},
 				},
 			}
@@ -395,6 +509,19 @@ func TestWithInsertBufferPoolSize(t *testing.T) {
 			size := -100
 			return test{
 				name: "set fails when size is -100",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("insertBufferPoolSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
+		func() test {
+			size := math.MinInt64
+			return test{
+				name: "set success when size is minimum value of int",
 				args: args{
 					size: size,
 				},
@@ -461,14 +588,43 @@ func TestWithDeleteBufferPoolSize(t *testing.T) {
 
 	tests := []test{
 		func() test {
+			size := 100
 			return test{
 				name: "set success when size is 100",
 				args: args{
-					size: 100,
+					size: size,
 				},
 				want: want{
 					obj: &T{
-						dBufSize: 100,
+						dBufSize: size,
+					},
+				},
+			}
+		}(),
+		func() test {
+			size := 1
+			return test{
+				name: "set success when size is 1",
+				args: args{
+					size: size,
+				},
+				want: want{
+					obj: &T{
+						dBufSize: size,
+					},
+				},
+			}
+		}(),
+		func() test {
+			size := math.MaxInt64
+			return test{
+				name: "set success when size is maximum value of int",
+				args: args{
+					size: size,
+				},
+				want: want{
+					obj: &T{
+						dBufSize: size,
 					},
 				},
 			}
@@ -503,6 +659,19 @@ func TestWithDeleteBufferPoolSize(t *testing.T) {
 			size := -100
 			return test{
 				name: "set fails when size is -100",
+				args: args{
+					size: size,
+				},
+				want: want{
+					err: errors.NewErrInvalidOption("deleteBufferPoolSize", size),
+					obj: new(T),
+				},
+			}
+		}(),
+		func() test {
+			size := math.MinInt64
+			return test{
+				name: "set success when size is minimum value of int",
 				args: args{
 					size: size,
 				},

--- a/pkg/agent/core/ngt/service/vqueue/queue_test.go
+++ b/pkg/agent/core/ngt/service/vqueue/queue_test.go
@@ -19,6 +19,7 @@ package vqueue
 
 import (
 	"context"
+	"os"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -26,8 +27,15 @@ import (
 
 	"github.com/vdaas/vald/internal/errgroup"
 	"github.com/vdaas/vald/internal/errors"
+	"github.com/vdaas/vald/internal/log"
+	"github.com/vdaas/vald/internal/log/logger"
 	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	log.Init(log.WithLoggerType(logger.NOP.String()))
+	os.Exit(m.Run())
+}
 
 func TestNew(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Signed-off-by: hlts2 <hiroto.funakoshi.hiroto@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

I added test code for `pkg/agent/core/ngt/serice/vqueue/option.go` and godoc comment.
And I refactored based on a document of option error handling and fixed [ci fails error](https://github.com/vdaas/vald/runs/2596843952).

**gramer check passed**

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
