### PR TITLE
Redis: Fix invalid cluster client initialization option

### DIFF
--- a/internal/db/kvs/redis/redis.go
+++ b/internal/db/kvs/redis/redis.go
@@ -230,13 +230,6 @@ func (rc *redisClient) newClusterClient(ctx context.Context) (c *redis.ClusterCl
 	} else {
 		c = redis.NewClusterClient(&redis.ClusterOptions{
 			Addrs: rc.addrs,
-			NewClient: func(opt *redis.Options) *redis.Client {
-				c, err := rc.newClient(ctx)
-				if err != nil {
-					return redis.NewClient(opt)
-				}
-				return c
-			},
 			Dialer:             rc.dialerFunc,
 			MaxRedirects:       rc.maxRedirects,
 			ReadOnly:           rc.readOnly,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
In the current code, on Redis cluster client initialization,
https://github.com/vdaas/vald/blob/53de600129c3718c8412700974bdbf2d4b2cbfe2/internal/db/kvs/redis/redis.go#L231-L239
the `opt` argument of the `NewClient` option is ignored when `rc.newClient(ctx)` returns no error. However, it is important to use `opt` for client initialization because `opt.Addr` is passed when a new clusterNode instance is created.
https://github.com/go-redis/redis/blob/f83600d1a5ac092f27dc672b9dda7cf7adde8bc1/cluster.go#L176-L189

So here, remove the invalid initialization code to fix the problem that occurs when Redis cluster is used.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Nothing

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local cluster.

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16.4
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
