### PR TITLE
Use gofumpt as a default formatter

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -324,7 +324,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
           API_URL: ${{ github.event.issue.comments_url }}
   format:
-    name: Add license and run goimports
+    name: Add license and run gofumpt + goimports
     needs:
       - rebase
       - gentest
@@ -411,15 +411,13 @@ jobs:
 
           echo "Install format dependencies"
 
-          make goimports/install
+          make gofumpt/install goimports/install
           sudo make prettier/install
-          # sudo make dockfmt/install
 
           echo "Update license headers and format go codes/yaml"
 
-          make update/goimports
+          make format/go
           make format/yaml
-          # make format/docker
           make license
 
           git checkout go.mod go.sum

--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ tools/install: \
 	telepresence/install
 
 .PHONY: update
-## update deps, license, and run goimports
+## update deps, license, and run gofumpt, goimports
 update: \
 	clean \
 	proto/all \
@@ -362,12 +362,13 @@ update: \
 ## format go codes
 format: \
 	license \
-	update/goimports \
+	format/go \
 	format/yaml
 
-.PHONY: update/goimports
-## run goimports for all go files
-update/goimports:
+.PHONY: format/go
+## run gofumpt, goimports for all go files
+format/go:
+	find ./ -type d -name .git -prune -o -type f -regex '.*\.go' -print | xargs gofumpt -w
 	find ./ -type d -name .git -prune -o -type f -regex '.*\.go' -print | xargs goimports -w
 
 .PHONY: format/yaml
@@ -388,6 +389,7 @@ deps: \
 .PHONY: deps/install
 ## install dependencies
 deps/install: \
+	gofumpt/install \
 	goimports/install \
 	prettier/install \
 	go/deps
@@ -408,8 +410,11 @@ go/deps:
 
 .PHONY: goimports/install
 goimports/install:
-	go get -u golang.org/x/tools/cmd/goimports
-	# GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
+	go install golang.org/x/tools/cmd/goimports@latest
+
+.PHONY: gofumpt/install
+gofumpt/install:
+	go install mvdan.cc/gofumpt@latest
 
 .PHONY: prettier/install
 prettier/install:

--- a/docs/contributing/coding-style.md
+++ b/docs/contributing/coding-style.md
@@ -8,7 +8,7 @@ Please also read the [Contribution guideline](../contributing/contributing-guide
 
 ## Code Formatting and Naming Convension
 
-Code formatting and naming conventions affect coding readability and maintainability. Every developer has a different coding style, luckily Go provides tools to format source code and checking for the potential issue in the source code. We recommend using [goimports](https://github.com/golang/tools/tree/master/cmd/goimports) to format the source code in Vald, and [golangci-lint](https://github.com/golangci/golangci-lint) with `--enable-all` option. We suggest everyone install the plugin for your editor to format the code once you edit the code automatically, and  we suggest using `make update/goimports` command if you want to format the source code manually.
+Code formatting and naming conventions affect coding readability and maintainability. Every developer has a different coding style, luckily Go provides tools to format source code and checking for the potential issue in the source code. We recommend using [gofumpt](https://github.com/mvdan/gofumpt) and [goimports](https://github.com/golang/tools/tree/master/cmd/goimports) to format the source code in Vald, and [golangci-lint](https://github.com/golangci/golangci-lint) with `--enable-all` option. We suggest everyone install the plugin for your editor to format the code once you edit the code automatically, and  we suggest using `make format/go` command if you want to format the source code manually.
 
 But having tools to format source code doesn't mean you do not need to care the formatting of the code, for example:
 

--- a/hack/git/hooks/pre-commit
+++ b/hack/git/hooks/pre-commit
@@ -19,6 +19,12 @@ TMPDIR=`mktemp -d`
 if git diff HEAD^ --name-only | grep ".go$" > /dev/null; then
     cp go.mod ${TMPDIR}
     cp go.sum ${TMPDIR}
+
+    # gofumpt
+    echo "Run gofumpt..."
+    find ./ -type f -regex ".*\.go" | xargs gofumpt -w
+    echo "gofumpt finished."
+
     # goimports
     echo "Run goimports..."
     find ./ -type f -regex ".*\.go" | xargs goimports -w


### PR DESCRIPTION
Signed-off-by: Rintaro Okamura <rintaro.okamura@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
Use [gofumpt](https://github.com/mvdan/gofumpt) as a default formatter.

Because **this change may cause many conflicts in the opened PRs**, please take care about merging it into master. Requesting reviews by all committer to make agreement about it

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Nothing

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Nothing

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16.4
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [X] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
