### PR TITLE
Fix time condition of agent & lb gateway

### DIFF
--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -445,9 +445,12 @@ func (n *ngt) insert(uuid string, vec []float32, t int64, validation bool) (err 
 }
 
 func (n *ngt) InsertMultiple(vecs map[string][]float32) (err error) {
-	t := time.Now().UnixNano()
+	return n.insertMultiple(vecs, time.Now().UnixNano())
+}
+
+func (n *ngt) insertMultiple(vecs map[string][]float32, now int64) (err error) {
 	for uuid, vec := range vecs {
-		ierr := n.insert(uuid, vec, t, true)
+		ierr := n.insert(uuid, vec, now, true)
 		if ierr != nil {
 			if err != nil {
 				err = errors.Wrap(ierr, err.Error())
@@ -481,11 +484,13 @@ func (n *ngt) UpdateMultiple(vecs map[string][]float32) (err error) {
 			uuids = append(uuids, uuid)
 		}
 	}
-	err = n.DeleteMultiple(uuids...)
+	now := time.Now().UnixNano()
+	err = n.deleteMultiple(uuids, now)
 	if err != nil {
 		return err
 	}
-	return n.InsertMultiple(vecs)
+	now++
+	return n.insertMultiple(vecs, now)
 }
 
 func (n *ngt) Delete(uuid string) (err error) {
@@ -505,9 +510,12 @@ func (n *ngt) delete(uuid string, t int64) (err error) {
 }
 
 func (n *ngt) DeleteMultiple(uuids ...string) (err error) {
-	t := time.Now().UnixNano()
+	return n.deleteMultiple(uuids, time.Now().UnixNano())
+}
+
+func (n *ngt) deleteMultiple(uuids []string, now int64) (err error) {
 	for _, uuid := range uuids {
-		ierr := n.delete(uuid, t)
+		ierr := n.delete(uuid, now)
 		if ierr != nil {
 			if err != nil {
 				err = errors.Wrap(ierr, err.Error())

--- a/pkg/agent/core/ngt/service/vqueue/queue.go
+++ b/pkg/agent/core/ngt/service/vqueue/queue.go
@@ -242,7 +242,7 @@ func (v *vqueue) GetVector(uuid string) ([]float32, bool) {
 		return vec.vector, true
 	}
 	// data exists both queue, compare data timestamp if insert queue timestamp is newer than delete one, this function returns exists(true)
-	if di < vec.date {
+	if di <= vec.date {
 		return vec.vector, true
 	}
 	return nil, false

--- a/pkg/agent/core/ngt/service/vqueue/queue.go
+++ b/pkg/agent/core/ngt/service/vqueue/queue.go
@@ -260,7 +260,8 @@ func (v *vqueue) IVExists(uuid string) bool {
 		return true
 	}
 	// data exists both queue, compare data timestamp if insert queue timestamp is newer than delete one, this function returns exists(true)
-	return di < vec.date
+	// However, if insert and delete are sent by the update instruction, the timestamp will be the same
+	return di <= vec.date
 }
 
 func (v *vqueue) DVExists(uuid string) bool {

--- a/pkg/gateway/lb/handler/grpc/handler.go
+++ b/pkg/gateway/lb/handler/grpc/handler.go
@@ -1217,6 +1217,7 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (res *
 		}
 		return nil, err
 	}
+	now++
 	ireq := &payload.Insert_Request{
 		Vector: req.GetVector(),
 		Config: &payload.Insert_Config{
@@ -1375,6 +1376,7 @@ func (s *server) MultiUpdate(ctx context.Context, reqs *payload.Update_MultiRequ
 				Timestamp:            n,
 			},
 		})
+		n++
 		rreqs = append(rreqs, &payload.Remove_Request{
 			Id: &payload.Object_ID{
 				Id: vec.GetVector().GetId(),


### PR DESCRIPTION
Signed-off-by: hlts2 <hiroto.funakoshi.hiroto@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

- WHY

In gateway, when the Update request is sent, the same time is used for Remove and Insert.
https://github.com/vdaas/vald/blob/master/pkg/gateway/lb/handler/grpc/handler.go#L1185

When checking IVExists of Vqueue, the existence is confirmed by the condition of [`vi < vec.date`](https://github.com/vdaas/vald/blob/929f29fd8a822c1167223416c96bb694662302a8/pkg/agent/core/ngt/service/vqueue/queue.go#L263), However, for a pod whose UUID has been removed, it will always be false when an insert is performed on that pod.


- WHAT

1. Fix to `vi <= vec.date` condition of GetVector, IVExits method agent/vqueue
2.  increment now of InsertMultiplue, DeleteMultiple (agent/ngt) 
2. increment now when lb gateway send Update request to agent


### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16.4
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
