### PR TITLE
Bugfix index count problem of ngt

### DIFF
--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -647,9 +647,10 @@ func (n *ngt) saveIndex(ctx context.Context) (err error) {
 
 	eg, ctx := errgroup.New(ctx)
 
+	kvsLen := n.Len()
 	eg.Go(safety.RecoverFunc(func() (err error) {
 		if n.path != "" {
-			m := make(map[string]uint32, n.kvs.Len())
+			m := make(map[string]uint32, kvsLen)
 			var mu sync.Mutex
 			n.kvs.Range(ctx, func(key string, id uint32) bool {
 				mu.Lock()
@@ -701,7 +702,7 @@ func (n *ngt) saveIndex(ctx context.Context) (err error) {
 		&metadata.Metadata{
 			IsInvalid: false,
 			NGT: &metadata.NGT{
-				IndexCount: n.Len(),
+				IndexCount: kvsLen,
 			},
 		},
 	)

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -647,6 +647,8 @@ func (n *ngt) saveIndex(ctx context.Context) (err error) {
 
 	eg, ctx := errgroup.New(ctx)
 
+	// we want to ensure the acutal kvs size between kvsdb and metadata,
+	// so we create thie counter to count the actual kvs size instead of using kvs.Len()
 	var kvsLen uint64
 
 	eg.Go(safety.RecoverFunc(func() (err error) {

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -434,6 +434,7 @@ func (n *ngt) insert(uuid string, vec []float32, t int64, validation bool) (err 
 		err = errors.ErrUUIDNotFound(0)
 		return err
 	}
+	log.Debugf("[rebalancer] Insert vector, uuid: %s", uuid)
 	if validation && !n.vq.DVExists(uuid) {
 		// if delete schedule exists we can insert new vector
 		_, ok := n.kvs.Get(uuid)
@@ -502,6 +503,7 @@ func (n *ngt) delete(uuid string, t int64) (err error) {
 		err = errors.ErrUUIDNotFound(0)
 		return err
 	}
+	log.Debugf("[rebalancer] Delete vector, uuid: %s", uuid)
 	_, ok := n.kvs.Get(uuid)
 	if !ok && !n.vq.IVExists(uuid) {
 		return errors.ErrObjectIDNotFound(uuid)
@@ -558,6 +560,7 @@ func (n *ngt) CreateIndex(ctx context.Context, poolSize uint32) (err error) {
 	if n.IsIndexing() || n.IsSaving() {
 		return nil
 	}
+	log.Debugf("[rebalancer] IVQLen: %d, DVQLen: %d, IVCLen: %d, DVCLen: %d", n.vq.IVQLen(), n.vq.DVQLen(), n.vq.IVCLen(), n.vq.DVCLen())
 	ic := n.vq.IVQLen() + n.vq.DVQLen()
 	if ic == 0 {
 		return errors.ErrUncommittedIndexNotFound

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -647,14 +647,16 @@ func (n *ngt) saveIndex(ctx context.Context) (err error) {
 
 	eg, ctx := errgroup.New(ctx)
 
-	kvsLen := n.Len()
+	var kvsLen uint64
+
 	eg.Go(safety.RecoverFunc(func() (err error) {
 		if n.path != "" {
-			m := make(map[string]uint32, kvsLen)
+			m := make(map[string]uint32, n.Len())
 			var mu sync.Mutex
 			n.kvs.Range(ctx, func(key string, id uint32) bool {
 				mu.Lock()
 				m[key] = id
+				kvsLen++
 				mu.Unlock()
 				return true
 			})

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -434,7 +434,6 @@ func (n *ngt) insert(uuid string, vec []float32, t int64, validation bool) (err 
 		err = errors.ErrUUIDNotFound(0)
 		return err
 	}
-	log.Debugf("[rebalancer] Insert vector, uuid: %s", uuid)
 	if validation && !n.vq.DVExists(uuid) {
 		// if delete schedule exists we can insert new vector
 		_, ok := n.kvs.Get(uuid)
@@ -503,7 +502,6 @@ func (n *ngt) delete(uuid string, t int64) (err error) {
 		err = errors.ErrUUIDNotFound(0)
 		return err
 	}
-	log.Debugf("[rebalancer] Delete vector, uuid: %s", uuid)
 	_, ok := n.kvs.Get(uuid)
 	if !ok && !n.vq.IVExists(uuid) {
 		return errors.ErrObjectIDNotFound(uuid)
@@ -560,7 +558,6 @@ func (n *ngt) CreateIndex(ctx context.Context, poolSize uint32) (err error) {
 	if n.IsIndexing() || n.IsSaving() {
 		return nil
 	}
-	log.Debugf("[rebalancer] IVQLen: %d, DVQLen: %d, IVCLen: %d, DVCLen: %d", n.vq.IVQLen(), n.vq.DVQLen(), n.vq.IVCLen(), n.vq.DVCLen())
 	ic := n.vq.IVQLen() + n.vq.DVQLen()
 	if ic == 0 {
 		return errors.ErrUncommittedIndexNotFound

--- a/pkg/agent/core/ngt/service/vqueue/queue.go
+++ b/pkg/agent/core/ngt/service/vqueue/queue.go
@@ -275,7 +275,6 @@ func (v *vqueue) addDelete(d key) {
 
 func (v *vqueue) flushAndRangeInsert(f func(uuid string, vector []float32) bool) {
 	v.imu.Lock()
-	log.Debugf("[rebalancer] flushAndRangeInsert uii len: %d", len(v.uii))
 	uii := make([]index, len(v.uii))
 	copy(uii, v.uii)
 	v.uii = v.uii[:0]
@@ -286,7 +285,6 @@ func (v *vqueue) flushAndRangeInsert(f func(uuid string, vector []float32) bool)
 	})
 	dup := make(map[string]bool, len(uii)/2)
 	for i, idx := range uii {
-		log.Debugf("[rebalancer] flushAndRangeInsert Insert to ngt, udim, uuid: %s, date: %d", idx.uuid, idx.date)
 		if _, ok := v.udim.Load(idx.uuid); ok {
 			v.imu.Lock()
 			v.uii = append(v.uii, idx)
@@ -310,7 +308,6 @@ func (v *vqueue) flushAndRangeInsert(f func(uuid string, vector []float32) bool)
 
 func (v *vqueue) flushAndRangeDelete(f func(uuid string) bool) {
 	v.dmu.Lock()
-	log.Debugf("[rebalancer] flushAndRangeDelete udk len: %d", len(v.udk))
 	udk := make([]key, len(v.udk))
 	copy(udk, v.udk)
 	v.udk = v.udk[:0]
@@ -321,7 +318,6 @@ func (v *vqueue) flushAndRangeDelete(f func(uuid string) bool) {
 	dup := make(map[string]bool, len(udk)/2)
 	udm := make(map[string]int64, len(udk))
 	for i, idx := range udk {
-		log.Debugf("[rebalancer] flushAndRangeDelete Delete from ngt, udim, uuid: %s, date: %d", idx.uuid, idx.date)
 		if !dup[idx.uuid] {
 			dup[idx.uuid] = true
 			if !f(idx.uuid) {
@@ -343,14 +339,12 @@ func (v *vqueue) flushAndRangeDelete(f func(uuid string) bool) {
 	// For this reason, the data is deleted from the Insert Queue only when retrieving data from the Delete Queue.
 	// we should check insert vqueue if insert vqueue exists and delete operation date is newer than insert operation date then we should remove insert vqueue's data.
 	v.imu.Lock()
-	log.Debugf("[rebalancer] flushAndRangeDelete uii len: %d", len(v.uii))
 	for i, idx := range v.uii {
 		// check same uuid & operation date
 		// if date is equal, it may update operation we shouldn't remove at that time
 		date, exists := udm[idx.uuid]
 		if exists && date > idx.date {
 			dl = append(dl, i)
-			log.Debugf("[rebalancer] flushAndRangeDelete delete from insert queue, uuid: %s , i: %d", idx.uuid, i)
 		}
 	}
 	v.imu.Unlock()

--- a/pkg/agent/core/ngt/service/vqueue/queue.go
+++ b/pkg/agent/core/ngt/service/vqueue/queue.go
@@ -275,6 +275,7 @@ func (v *vqueue) addDelete(d key) {
 
 func (v *vqueue) flushAndRangeInsert(f func(uuid string, vector []float32) bool) {
 	v.imu.Lock()
+	log.Debugf("[rebalancer] flushAndRangeInsert uii len: %d", len(v.uii))
 	uii := make([]index, len(v.uii))
 	copy(uii, v.uii)
 	v.uii = v.uii[:0]
@@ -285,6 +286,7 @@ func (v *vqueue) flushAndRangeInsert(f func(uuid string, vector []float32) bool)
 	})
 	dup := make(map[string]bool, len(uii)/2)
 	for i, idx := range uii {
+		log.Debugf("[rebalancer] flushAndRangeInsert Insert to ngt, udim, uuid: %s, date: %d", idx.uuid, idx.date)
 		// if duplicated data exists current loop's data is old due to the uii's sort order
 		if !dup[idx.uuid] {
 			dup[idx.uuid] = true
@@ -301,6 +303,7 @@ func (v *vqueue) flushAndRangeInsert(f func(uuid string, vector []float32) bool)
 
 func (v *vqueue) flushAndRangeDelete(f func(uuid string) bool) {
 	v.dmu.Lock()
+	log.Debugf("[rebalancer] flushAndRangeDelete udk len: %d", len(v.udk))
 	udk := make([]key, len(v.udk))
 	copy(udk, v.udk)
 	v.udk = v.udk[:0]
@@ -311,6 +314,7 @@ func (v *vqueue) flushAndRangeDelete(f func(uuid string) bool) {
 	dup := make(map[string]bool, len(udk)/2)
 	udm := make(map[string]int64, len(udk))
 	for i, idx := range udk {
+		log.Debugf("[rebalancer] flushAndRangeDelete Delete from ngt, udim, uuid: %s, date: %d", idx.uuid, idx.date)
 		if !dup[idx.uuid] {
 			dup[idx.uuid] = true
 			if !f(idx.uuid) {
@@ -332,12 +336,14 @@ func (v *vqueue) flushAndRangeDelete(f func(uuid string) bool) {
 	// For this reason, the data is deleted from the Insert Queue only when retrieving data from the Delete Queue.
 	// we should check insert vqueue if insert vqueue exists and delete operation date is newer than insert operation date then we should remove insert vqueue's data.
 	v.imu.Lock()
+	log.Debugf("[rebalancer] flushAndRangeDelete uii len: %d", len(v.uii))
 	for i, idx := range v.uii {
 		// check same uuid & operation date
 		// if date is equal, it may update operation we shouldn't remove at that time
 		date, exists := udm[idx.uuid]
 		if exists && date > idx.date {
 			dl = append(dl, i)
+			log.Debugf("[rebalancer] flushAndRangeDelete delete from insert queue, uuid: %s , i: %d", idx.uuid, i)
 		}
 	}
 	v.imu.Unlock()

--- a/pkg/agent/core/ngt/service/vqueue/queue.go
+++ b/pkg/agent/core/ngt/service/vqueue/queue.go
@@ -285,6 +285,8 @@ func (v *vqueue) flushAndRangeInsert(f func(uuid string, vector []float32) bool)
 	})
 	dup := make(map[string]bool, len(uii)/2)
 	for i, idx := range uii {
+		// if the same uuid is detected in the delete map during insert phase, which means the data is not processed in the delete phase.
+		// we need to add it back to insert map to process it in next create index process.
 		if _, ok := v.udim.Load(idx.uuid); ok {
 			v.imu.Lock()
 			v.uii = append(v.uii, idx)

--- a/pkg/agent/core/ngt/service/vqueue/queue.go
+++ b/pkg/agent/core/ngt/service/vqueue/queue.go
@@ -287,6 +287,13 @@ func (v *vqueue) flushAndRangeInsert(f func(uuid string, vector []float32) bool)
 	dup := make(map[string]bool, len(uii)/2)
 	for i, idx := range uii {
 		log.Debugf("[rebalancer] flushAndRangeInsert Insert to ngt, udim, uuid: %s, date: %d", idx.uuid, idx.date)
+		if _, ok := v.udim.Load(idx.uuid); ok {
+			v.imu.Lock()
+			v.uii = append(v.uii, idx)
+			v.imu.Unlock()
+			continue
+		}
+
 		// if duplicated data exists current loop's data is old due to the uii's sort order
 		if !dup[idx.uuid] {
 			dup[idx.uuid] = true

--- a/pkg/agent/core/ngt/service/vqueue/queue_test.go
+++ b/pkg/agent/core/ngt/service/vqueue/queue_test.go
@@ -101,6 +101,7 @@ func TestNew(t *testing.T) {
 			if err := test.checkFunc(test.want, got, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
@@ -160,11 +161,11 @@ func Test_vqueue_Start(t *testing.T) {
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -191,11 +192,11 @@ func Test_vqueue_Start(t *testing.T) {
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -250,6 +251,7 @@ func Test_vqueue_Start(t *testing.T) {
 			if err := test.checkFunc(test.want, got, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
@@ -309,11 +311,11 @@ func Test_vqueue_PushInsert(t *testing.T) {
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -342,11 +344,11 @@ func Test_vqueue_PushInsert(t *testing.T) {
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -401,6 +403,7 @@ func Test_vqueue_PushInsert(t *testing.T) {
 			if err := test.checkFunc(test.want, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
@@ -458,11 +461,11 @@ func Test_vqueue_PushDelete(t *testing.T) {
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -490,11 +493,11 @@ func Test_vqueue_PushDelete(t *testing.T) {
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -549,6 +552,7 @@ func Test_vqueue_PushDelete(t *testing.T) {
 			if err := test.checkFunc(test.want, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
@@ -576,7 +580,8 @@ func Test_vqueue_RangePopInsert(t *testing.T) {
 		iBufSize         int
 		dBufSize         int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
@@ -601,11 +606,11 @@ func Test_vqueue_RangePopInsert(t *testing.T) {
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -633,11 +638,11 @@ func Test_vqueue_RangePopInsert(t *testing.T) {
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -719,7 +724,8 @@ func Test_vqueue_RangePopDelete(t *testing.T) {
 		iBufSize         int
 		dBufSize         int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
@@ -744,11 +750,11 @@ func Test_vqueue_RangePopDelete(t *testing.T) {
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -776,11 +782,11 @@ func Test_vqueue_RangePopDelete(t *testing.T) {
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -894,11 +900,11 @@ func Test_vqueue_GetVector(t *testing.T) {
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -925,11 +931,11 @@ func Test_vqueue_GetVector(t *testing.T) {
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -984,6 +990,7 @@ func Test_vqueue_GetVector(t *testing.T) {
 			if err := test.checkFunc(test.want, got, got1); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
@@ -1039,11 +1046,11 @@ func Test_vqueue_IVExists(t *testing.T) {
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -1070,11 +1077,11 @@ func Test_vqueue_IVExists(t *testing.T) {
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -1129,6 +1136,7 @@ func Test_vqueue_IVExists(t *testing.T) {
 			if err := test.checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
@@ -1184,11 +1192,11 @@ func Test_vqueue_DVExists(t *testing.T) {
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -1215,11 +1223,11 @@ func Test_vqueue_DVExists(t *testing.T) {
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -1274,6 +1282,7 @@ func Test_vqueue_DVExists(t *testing.T) {
 			if err := test.checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
@@ -1300,7 +1309,8 @@ func Test_vqueue_addInsert(t *testing.T) {
 		iBufSize         int
 		dBufSize         int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
@@ -1324,11 +1334,11 @@ func Test_vqueue_addInsert(t *testing.T) {
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -1355,11 +1365,11 @@ func Test_vqueue_addInsert(t *testing.T) {
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -1440,7 +1450,8 @@ func Test_vqueue_addDelete(t *testing.T) {
 		iBufSize         int
 		dBufSize         int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
@@ -1464,11 +1475,11 @@ func Test_vqueue_addDelete(t *testing.T) {
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -1495,11 +1506,11 @@ func Test_vqueue_addDelete(t *testing.T) {
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -1558,7 +1569,10 @@ func Test_vqueue_addDelete(t *testing.T) {
 	}
 }
 
-func Test_vqueue_flushAndLoadInsert(t *testing.T) {
+func Test_vqueue_flushAndRangeInsert(t *testing.T) {
+	type args struct {
+		f func(uuid string, vector []float32) bool
+	}
 	type fields struct {
 		ich              chan index
 		uii              []index
@@ -1578,20 +1592,17 @@ func Test_vqueue_flushAndLoadInsert(t *testing.T) {
 		dBufSize         int
 	}
 	type want struct {
-		wantUii []index
 	}
 	type test struct {
 		name       string
+		args       args
 		fields     fields
 		want       want
-		checkFunc  func(want, []index) error
-		beforeFunc func()
-		afterFunc  func()
+		checkFunc  func(want) error
+		beforeFunc func(args)
+		afterFunc  func(args)
 	}
-	defaultCheckFunc := func(w want, gotUii []index) error {
-		if !reflect.DeepEqual(gotUii, w.wantUii) {
-			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", gotUii, w.wantUii)
-		}
+	defaultCheckFunc := func(w want) error {
 		return nil
 	}
 	tests := []test{
@@ -1599,14 +1610,17 @@ func Test_vqueue_flushAndLoadInsert(t *testing.T) {
 		/*
 		   {
 		       name: "test_case_1",
+		       args: args {
+		           f: nil,
+		       },
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -1627,14 +1641,17 @@ func Test_vqueue_flushAndLoadInsert(t *testing.T) {
 		   func() test {
 		       return test {
 		           name: "test_case_2",
+		           args: args {
+		           f: nil,
+		           },
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -1658,10 +1675,10 @@ func Test_vqueue_flushAndLoadInsert(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(test.args)
 			}
 			if test.checkFunc == nil {
 				test.checkFunc = defaultCheckFunc
@@ -1685,15 +1702,18 @@ func Test_vqueue_flushAndLoadInsert(t *testing.T) {
 				dBufSize:         test.fields.dBufSize,
 			}
 
-			gotUii := v.flushAndLoadInsert()
-			if err := test.checkFunc(test.want, gotUii); err != nil {
+			v.flushAndRangeInsert(test.args.f)
+			if err := test.checkFunc(test.want); err != nil {
 				tt.Errorf("error = %v", err)
 			}
 		})
 	}
 }
 
-func Test_vqueue_flushAndLoadDelete(t *testing.T) {
+func Test_vqueue_flushAndRangeDelete(t *testing.T) {
+	type args struct {
+		f func(uuid string) bool
+	}
 	type fields struct {
 		ich              chan index
 		uii              []index
@@ -1713,20 +1733,17 @@ func Test_vqueue_flushAndLoadDelete(t *testing.T) {
 		dBufSize         int
 	}
 	type want struct {
-		wantUdk []key
 	}
 	type test struct {
 		name       string
+		args       args
 		fields     fields
 		want       want
-		checkFunc  func(want, []key) error
-		beforeFunc func()
-		afterFunc  func()
+		checkFunc  func(want) error
+		beforeFunc func(args)
+		afterFunc  func(args)
 	}
-	defaultCheckFunc := func(w want, gotUdk []key) error {
-		if !reflect.DeepEqual(gotUdk, w.wantUdk) {
-			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", gotUdk, w.wantUdk)
-		}
+	defaultCheckFunc := func(w want) error {
 		return nil
 	}
 	tests := []test{
@@ -1734,14 +1751,17 @@ func Test_vqueue_flushAndLoadDelete(t *testing.T) {
 		/*
 		   {
 		       name: "test_case_1",
+		       args: args {
+		           f: nil,
+		       },
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -1762,14 +1782,17 @@ func Test_vqueue_flushAndLoadDelete(t *testing.T) {
 		   func() test {
 		       return test {
 		           name: "test_case_2",
+		           args: args {
+		           f: nil,
+		           },
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -1793,10 +1816,10 @@ func Test_vqueue_flushAndLoadDelete(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(test.args)
 			}
 			if test.checkFunc == nil {
 				test.checkFunc = defaultCheckFunc
@@ -1820,8 +1843,8 @@ func Test_vqueue_flushAndLoadDelete(t *testing.T) {
 				dBufSize:         test.fields.dBufSize,
 			}
 
-			gotUdk := v.flushAndLoadDelete()
-			if err := test.checkFunc(test.want, gotUdk); err != nil {
+			v.flushAndRangeDelete(test.args.f)
+			if err := test.checkFunc(test.want); err != nil {
 				tt.Errorf("error = %v", err)
 			}
 		})
@@ -1872,11 +1895,11 @@ func Test_vqueue_IVQLen(t *testing.T) {
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -1900,11 +1923,11 @@ func Test_vqueue_IVQLen(t *testing.T) {
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -1959,6 +1982,7 @@ func Test_vqueue_IVQLen(t *testing.T) {
 			if err := test.checkFunc(test.want, gotL); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
@@ -2007,11 +2031,11 @@ func Test_vqueue_DVQLen(t *testing.T) {
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -2035,11 +2059,11 @@ func Test_vqueue_DVQLen(t *testing.T) {
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -2094,6 +2118,7 @@ func Test_vqueue_DVQLen(t *testing.T) {
 			if err := test.checkFunc(test.want, gotL); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
@@ -2142,11 +2167,11 @@ func Test_vqueue_IVCLen(t *testing.T) {
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -2170,11 +2195,11 @@ func Test_vqueue_IVCLen(t *testing.T) {
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -2229,6 +2254,7 @@ func Test_vqueue_IVCLen(t *testing.T) {
 			if err := test.checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
@@ -2277,11 +2303,11 @@ func Test_vqueue_DVCLen(t *testing.T) {
 		       fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -2305,11 +2331,11 @@ func Test_vqueue_DVCLen(t *testing.T) {
 		           fields: fields {
 		           ich: nil,
 		           uii: nil,
-		           imu: sync.Mutex{},
+		           imu: nil,
 		           uiim: uiim{},
 		           dch: nil,
 		           udk: nil,
-		           dmu: sync.Mutex{},
+		           dmu: nil,
 		           udim: udim{},
 		           eg: nil,
 		           finalizingInsert: nil,
@@ -2364,6 +2390,7 @@ func Test_vqueue_DVCLen(t *testing.T) {
 			if err := test.checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

In this PR, we fixed the following problems in vald agent:
1. When `saveIndex()` runs, the kvs index count and metadata.json index count may be different due to the timing of executing the `kvs.Len()`. We fixed to reference the kvs len variable to the same variable.
2. When creating index runs, the timing of removing from the kvs and the internal vqueue is different, which may cause the inconsistency problem of kvs&vqueue. We changed by passing the callback function to the vqueue to remove the kvs&vqueue data at the same time to avoid the above problem.
3. If the vector is updated during delete phase of createIndex operation, the vector will be inserted in insert phase of createIndex operation and the vector will be removed in the next createIndex operation.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16.4
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
