### PR TITLE
Fix fails test in race condition

### DIFF
--- a/pkg/agent/core/ngt/service/kvs/kvs_test.go
+++ b/pkg/agent/core/ngt/service/kvs/kvs_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"math"
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -1422,13 +1423,16 @@ func Test_bidi_Range(t *testing.T) {
 					"4ec4-c85f-11ea-87d0": 10003,
 				}
 			)
+			var mu sync.Mutex
 
 			return test{
 				name: "rage get successes",
 				args: args{
 					ctx: context.Background(),
 					f: func(s string, u uint32) bool {
+						mu.Lock()
 						got[s] = u
+						mu.Unlock()
 						return true
 					},
 				},
@@ -1471,13 +1475,16 @@ func Test_bidi_Range(t *testing.T) {
 					"4ec4-c85f-11ea-87d0": 10003,
 				}
 			)
+			var mu sync.Mutex
 
 			return test{
 				name: "rage get successes when l of fields is 100",
 				args: args{
 					ctx: context.Background(),
 					f: func(s string, u uint32) bool {
+						mu.Lock()
 						got[s] = u
+						mu.Unlock()
 						return true
 					},
 				},
@@ -1520,13 +1527,16 @@ func Test_bidi_Range(t *testing.T) {
 					"4ec4-c85f-11ea-87d0": 10003,
 				}
 			)
+			var mu sync.Mutex
 
 			return test{
 				name: "rage get successes when l of fields is maximun value of uint64",
 				args: args{
 					ctx: context.Background(),
 					f: func(s string, u uint32) bool {
+						mu.Lock()
 						got[s] = u
+						mu.Unlock()
 						return true
 					},
 				},


### PR DESCRIPTION
Signed-off-by: hlts2 <hiroto.funakoshi.hiroto@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

I fixed the fails test in rance condition.

#### WHY

when we test with `-race` flag, the error occurs in `agent/core/ngt/service/kvs/kvs_test.go`.

#### WHAT

[x] added `sync.Mutex` in test code to prevent race condition.


### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16.4
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
