### PR TITLE
 add timestamp handler for agent timestamp controlled update

### DIFF
--- a/pkg/agent/core/ngt/handler/grpc/handler.go
+++ b/pkg/agent/core/ngt/handler/grpc/handler.go
@@ -556,7 +556,7 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (res *
 		return nil, err
 	}
 
-	err = s.ngt.Insert(vec.GetId(), vec.GetVector())
+	err = s.ngt.InsertWithTime(vec.GetId(), vec.GetVector(), req.GetConfig().GetTimestamp())
 	if err != nil {
 		var code trace.Status
 
@@ -817,7 +817,7 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (res *
 		}
 		return nil, err
 	}
-	err = s.ngt.Update(vec.GetId(), vec.GetVector())
+	err = s.ngt.UpdateWithTime(vec.GetId(), vec.GetVector(), req.GetConfig().GetTimestamp())
 	if err != nil {
 		var code trace.Status
 		if errors.Is(err, errors.ErrObjectIDNotFound(vec.GetId())) {
@@ -1125,11 +1125,17 @@ func (s *server) Upsert(ctx context.Context, req *payload.Upsert_Request) (loc *
 	if exists {
 		loc, err = s.Update(ctx, &payload.Update_Request{
 			Vector: req.GetVector(),
+			Config: &payload.Update_Config{
+				Timestamp: req.GetConfig().GetTimestamp(),
+			},
 		})
 		rtName = "/ngt.Update"
 	} else {
 		loc, err = s.Insert(ctx, &payload.Insert_Request{
 			Vector: req.GetVector(),
+			Config: &payload.Insert_Config{
+				Timestamp: req.GetConfig().GetTimestamp(),
+			},
 		})
 		rtName = "/ngt.Insert"
 	}
@@ -1312,7 +1318,7 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (res *
 	}()
 	id := req.GetId()
 	uuid := id.GetId()
-	err = s.ngt.Delete(uuid)
+	err = s.ngt.DeleteWithTime(uuid, req.GetConfig().GetTimestamp())
 	if err != nil {
 		var code trace.Status
 		if errors.Is(err, errors.ErrObjectIDNotFound(uuid)) {

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -49,11 +49,17 @@ type NGT interface {
 	Search(vec []float32, size uint32, epsilon, radius float32) ([]model.Distance, error)
 	SearchByID(uuid string, size uint32, epsilon, radius float32) ([]model.Distance, error)
 	Insert(uuid string, vec []float32) (err error)
+	InsertWithTime(uuid string, vec []float32, t int64) (err error)
 	InsertMultiple(vecs map[string][]float32) (err error)
+	InsertMultipleWithTime(vecs map[string][]float32, t int64) (err error)
 	Update(uuid string, vec []float32) (err error)
+	UpdateWithTime(uuid string, vec []float32, t int64) (err error)
 	UpdateMultiple(vecs map[string][]float32) (err error)
+	UpdateMultipleWithTime(vecs map[string][]float32, t int64) (err error)
 	Delete(uuid string) (err error)
+	DeleteWithTime(uuid string, t int64) (err error)
 	DeleteMultiple(uuids ...string) (err error)
+	DeleteMultipleWithTime(uuids []string, t int64) (err error)
 	GetObject(uuid string) (vec []float32, err error)
 	CreateIndex(ctx context.Context, poolSize uint32) (err error)
 	SaveIndex(ctx context.Context) (err error)
@@ -432,6 +438,13 @@ func (n *ngt) Insert(uuid string, vec []float32) (err error) {
 	return n.insert(uuid, vec, time.Now().UnixNano(), true)
 }
 
+func (n *ngt) InsertWithTime(uuid string, vec []float32, t int64) (err error) {
+	if t <= 0 {
+		t = time.Now().UnixNano()
+	}
+	return n.insert(uuid, vec, t, true)
+}
+
 func (n *ngt) insert(uuid string, vec []float32, t int64, validation bool) (err error) {
 	if len(uuid) == 0 {
 		err = errors.ErrUUIDNotFound(0)
@@ -451,6 +464,13 @@ func (n *ngt) InsertMultiple(vecs map[string][]float32) (err error) {
 	return n.insertMultiple(vecs, time.Now().UnixNano())
 }
 
+func (n *ngt) InsertMultipleWithTime(vecs map[string][]float32, t int64) (err error) {
+	if t <= 0 {
+		t = time.Now().UnixNano()
+	}
+	return n.insertMultiple(vecs, t)
+}
+
 func (n *ngt) insertMultiple(vecs map[string][]float32, now int64) (err error) {
 	for uuid, vec := range vecs {
 		ierr := n.insert(uuid, vec, now, true)
@@ -466,19 +486,40 @@ func (n *ngt) insertMultiple(vecs map[string][]float32, now int64) (err error) {
 }
 
 func (n *ngt) Update(uuid string, vec []float32) (err error) {
-	now := time.Now().UnixNano()
+	return n.update(uuid, vec, time.Now().UnixNano())
+}
+
+func (n *ngt) UpdateWithTime(uuid string, vec []float32, t int64) (err error) {
+	if t <= 0 {
+		t = time.Now().UnixNano()
+	}
+	return n.update(uuid, vec, t)
+}
+
+func (n *ngt) update(uuid string, vec []float32, t int64) (err error) {
 	if err = n.readyForUpdate(uuid, vec); err != nil {
 		return err
 	}
-	err = n.delete(uuid, now)
+	err = n.delete(uuid, t)
 	if err != nil {
 		return err
 	}
-	now++
-	return n.insert(uuid, vec, now, false)
+	t++
+	return n.insert(uuid, vec, t, false)
 }
 
 func (n *ngt) UpdateMultiple(vecs map[string][]float32) (err error) {
+	return n.updateMultiple(vecs, time.Now().UnixNano())
+}
+
+func (n *ngt) UpdateMultipleWithTime(vecs map[string][]float32, t int64) (err error) {
+	if t <= 0 {
+		t = time.Now().UnixNano()
+	}
+	return n.updateMultiple(vecs, t)
+}
+
+func (n *ngt) updateMultiple(vecs map[string][]float32, t int64) (err error) {
 	uuids := make([]string, 0, len(vecs))
 	for uuid, vec := range vecs {
 		if err = n.readyForUpdate(uuid, vec); err != nil {
@@ -487,17 +528,23 @@ func (n *ngt) UpdateMultiple(vecs map[string][]float32) (err error) {
 			uuids = append(uuids, uuid)
 		}
 	}
-	now := time.Now().UnixNano()
-	err = n.deleteMultiple(uuids, now)
+	err = n.deleteMultiple(uuids, t)
 	if err != nil {
 		return err
 	}
-	now++
-	return n.insertMultiple(vecs, now)
+	t++
+	return n.insertMultiple(vecs, t)
 }
 
 func (n *ngt) Delete(uuid string) (err error) {
 	return n.delete(uuid, time.Now().UnixNano())
+}
+
+func (n *ngt) DeleteWithTime(uuid string, t int64) (err error) {
+	if t <= 0 {
+		t = time.Now().UnixNano()
+	}
+	return n.delete(uuid, t)
 }
 
 func (n *ngt) delete(uuid string, t int64) (err error) {
@@ -514,6 +561,13 @@ func (n *ngt) delete(uuid string, t int64) (err error) {
 
 func (n *ngt) DeleteMultiple(uuids ...string) (err error) {
 	return n.deleteMultiple(uuids, time.Now().UnixNano())
+}
+
+func (n *ngt) DeleteMultipleWithTime(uuids []string, t int64) (err error) {
+	if t <= 0 {
+		t = time.Now().UnixNano()
+	}
+	return n.deleteMultiple(uuids, t)
 }
 
 func (n *ngt) deleteMultiple(uuids []string, now int64) (err error) {


### PR DESCRIPTION
Signed-off-by: kpango <kpango@vdaas.org>

<!--- Provide a general summary of your changes in the Title above -->

### Description:
Agent handler now uses timestamp configuration from API request users can control indexing order for each object.
In this PR, Multiple API is not supported for bypassing Timestamp. Because we have to make big internal API changes to support Multiple API.
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16.5
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
