### PR TITLE
remove owner and description info from resource info rich error for each grpc handler

### DIFF
--- a/pkg/agent/core/ngt/handler/grpc/handler.go
+++ b/pkg/agent/core/ngt/handler/grpc/handler.go
@@ -122,8 +122,6 @@ func (s *server) Exists(ctx context.Context, uid *payload.Object_ID) (res *paylo
 			&errdetails.ResourceInfo{
 				ResourceType: ngtResourceType + "/ngt.Exists",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			},
 			uid.GetId(), info.Get())
 		if span != nil {
@@ -162,8 +160,6 @@ func (s *server) Search(ctx context.Context, req *payload.Search_Request) (res *
 			&errdetails.ResourceInfo{
 				ResourceType: ngtResourceType + "/ngt.Search",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			})
 		log.Warn(err)
 		if span != nil {
@@ -188,8 +184,6 @@ func (s *server) Search(ctx context.Context, req *payload.Search_Request) (res *
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.Search",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			stat = trace.StatusCodeResourceExhausted(err.Error())
 		} else {
@@ -201,8 +195,6 @@ func (s *server) Search(ctx context.Context, req *payload.Search_Request) (res *
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.Search",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				}, info.Get())
 			log.Error(err)
 			stat = trace.StatusCodeInternal(err.Error())
@@ -240,8 +232,6 @@ func (s *server) SearchByID(ctx context.Context, req *payload.Search_IDRequest) 
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.SearchByID",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			stat = trace.StatusCodeResourceExhausted(err.Error())
 		} else {
@@ -253,8 +243,6 @@ func (s *server) SearchByID(ctx context.Context, req *payload.Search_IDRequest) 
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.SearchByID",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				}, info.Get())
 			log.Error(err)
 			stat = trace.StatusCodeInternal(err.Error())
@@ -436,8 +424,6 @@ func (s *server) MultiSearch(ctx context.Context, reqs *payload.Search_MultiRequ
 			&errdetails.ResourceInfo{
 				ResourceType: ngtResourceType + "/ngt.MultiSearch",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  errs.Error(),
 			})
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -508,8 +494,6 @@ func (s *server) MultiSearchByID(ctx context.Context, reqs *payload.Search_Multi
 			&errdetails.ResourceInfo{
 				ResourceType: ngtResourceType + "/ngt.MultiSearchByID",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  errs.Error(),
 			})
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -546,8 +530,6 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (res *
 			&errdetails.ResourceInfo{
 				ResourceType: ngtResourceType + "/ngt.Insert",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			})
 		log.Warn(err)
 		if span != nil {
@@ -569,8 +551,6 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (res *
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.Insert",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			code = trace.StatusCodeAlreadyExists(err.Error())
@@ -591,8 +571,6 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (res *
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.Insert",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			code = trace.StatusCodeInvalidArgument(err.Error())
@@ -610,8 +588,6 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (res *
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.Insert",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				}, info.Get())
 			code = trace.FromGRPCStatus(st.Code(), msg)
 		}
@@ -699,8 +675,6 @@ func (s *server) MultiInsert(ctx context.Context, reqs *payload.Insert_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.MultiInsert",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			if span != nil {
@@ -731,8 +705,6 @@ func (s *server) MultiInsert(ctx context.Context, reqs *payload.Insert_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.MultiInsert",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			code = trace.StatusCodeAlreadyExists(err.Error())
@@ -753,8 +725,6 @@ func (s *server) MultiInsert(ctx context.Context, reqs *payload.Insert_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.MultiInsert",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			code = trace.StatusCodeInvalidArgument(err.Error())
@@ -767,8 +737,6 @@ func (s *server) MultiInsert(ctx context.Context, reqs *payload.Insert_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.MultiInsert",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				}, info.Get())
 			log.Error(err)
 			code = trace.StatusCodeInternal(err.Error())
@@ -808,8 +776,6 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (res *
 			&errdetails.ResourceInfo{
 				ResourceType: ngtResourceType + "/ngt.Update",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			})
 		log.Warn(err)
 		if span != nil {
@@ -829,8 +795,6 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (res *
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.Update",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			code = trace.StatusCodeNotFound(err.Error())
@@ -851,8 +815,6 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (res *
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.Update",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			code = trace.StatusCodeInvalidArgument(err.Error())
@@ -865,8 +827,6 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (res *
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.Update",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			code = trace.StatusCodeAlreadyExists(err.Error())
@@ -879,8 +839,6 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (res *
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.Update",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				}, info.Get())
 			log.Error(err)
 			code = trace.StatusCodeInternal(err.Error())
@@ -970,8 +928,6 @@ func (s *server) MultiUpdate(ctx context.Context, reqs *payload.Update_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.MultiUpdate",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			if span != nil {
@@ -1003,8 +959,6 @@ func (s *server) MultiUpdate(ctx context.Context, reqs *payload.Update_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.MultiUpdate",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			code = trace.StatusCodeNotFound(err.Error())
@@ -1033,8 +987,6 @@ func (s *server) MultiUpdate(ctx context.Context, reqs *payload.Update_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.MultiUpdate",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			code = trace.StatusCodeInvalidArgument(err.Error())
@@ -1055,8 +1007,6 @@ func (s *server) MultiUpdate(ctx context.Context, reqs *payload.Update_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.MultiUpdate",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			code = trace.StatusCodeAlreadyExists(err.Error())
@@ -1069,8 +1019,6 @@ func (s *server) MultiUpdate(ctx context.Context, reqs *payload.Update_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.Update",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				}, info.Get())
 			log.Error(err)
 			code = trace.StatusCodeInternal(err.Error())
@@ -1110,8 +1058,6 @@ func (s *server) Upsert(ctx context.Context, req *payload.Upsert_Request) (loc *
 			&errdetails.ResourceInfo{
 				ResourceType: ngtResourceType + "/ngt.Upsert",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			})
 		log.Warn(err)
 		if span != nil {
@@ -1142,8 +1088,6 @@ func (s *server) Upsert(ctx context.Context, req *payload.Upsert_Request) (loc *
 			&errdetails.ResourceInfo{
 				ResourceType: ngtResourceType + rtName,
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			})
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1234,8 +1178,6 @@ func (s *server) MultiUpsert(ctx context.Context, reqs *payload.Upsert_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.MultiUpsert",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			if span != nil {
@@ -1288,8 +1230,6 @@ func (s *server) MultiUpsert(ctx context.Context, reqs *payload.Upsert_MultiRequ
 			&errdetails.ResourceInfo{
 				ResourceType: ngtResourceType + "/ngt.MultiUpsert",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			})
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1324,8 +1264,6 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (res *
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.Remove",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			code = trace.StatusCodeNotFound(err.Error())
@@ -1346,8 +1284,6 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (res *
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.Remove",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			code = trace.StatusCodeInvalidArgument(err.Error())
@@ -1360,8 +1296,6 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (res *
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.Remove",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				}, info.Get())
 			log.Error(err)
 			code = trace.StatusCodeInternal(err.Error())
@@ -1452,8 +1386,6 @@ func (s *server) MultiRemove(ctx context.Context, reqs *payload.Remove_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.MultiRemove",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			code = trace.StatusCodeNotFound(err.Error())
@@ -1474,8 +1406,6 @@ func (s *server) MultiRemove(ctx context.Context, reqs *payload.Remove_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.MultiRemove",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			log.Warn(err)
 			code = trace.StatusCodeInvalidArgument(err.Error())
@@ -1488,8 +1418,6 @@ func (s *server) MultiRemove(ctx context.Context, reqs *payload.Remove_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.MultiRemove",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				}, info.Get())
 			log.Error(err)
 			code = trace.StatusCodeInternal(err.Error())
@@ -1521,8 +1449,6 @@ func (s *server) GetObject(ctx context.Context, id *payload.Object_VectorRequest
 			&errdetails.ResourceInfo{
 				ResourceType: ngtResourceType + "/ngt.GetObject",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		if span != nil {
 			span.SetStatus(trace.StatusCodeNotFound(err.Error()))
@@ -1602,8 +1528,6 @@ func (s *server) CreateIndex(ctx context.Context, c *payload.Control_CreateIndex
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.CreateIndex",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				},
 				&errdetails.PreconditionFailure{
 					Violations: []*errdetails.PreconditionFailureViolation{
@@ -1625,8 +1549,6 @@ func (s *server) CreateIndex(ctx context.Context, c *payload.Control_CreateIndex
 			&errdetails.ResourceInfo{
 				ResourceType: ngtResourceType + "/ngt.CreateIndex",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		log.Error(err)
 		if span != nil {
@@ -1651,8 +1573,6 @@ func (s *server) SaveIndex(ctx context.Context, _ *payload.Empty) (res *payload.
 			&errdetails.ResourceInfo{
 				ResourceType: ngtResourceType + "/ngt.SaveIndex",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		log.Error(err)
 		if span != nil {
@@ -1681,8 +1601,6 @@ func (s *server) CreateAndSaveIndex(ctx context.Context, c *payload.Control_Crea
 				&errdetails.ResourceInfo{
 					ResourceType: ngtResourceType + "/ngt.CreateAndSaveIndex",
 					ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				},
 				&errdetails.PreconditionFailure{
 					Violations: []*errdetails.PreconditionFailureViolation{
@@ -1704,8 +1622,6 @@ func (s *server) CreateAndSaveIndex(ctx context.Context, c *payload.Control_Crea
 			&errdetails.ResourceInfo{
 				ResourceType: ngtResourceType + "/ngt.CreateAndSaveIndex",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		log.Error(err)
 		if span != nil {

--- a/pkg/discoverer/k8s/handler/grpc/handler.go
+++ b/pkg/discoverer/k8s/handler/grpc/handler.go
@@ -91,8 +91,6 @@ func (s *server) Pods(ctx context.Context, req *payload.Discoverer_Request) (*pa
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/discoverer.v1.Pods",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			},
 			info.Get())
 		if span != nil {
@@ -110,8 +108,6 @@ func (s *server) Pods(ctx context.Context, req *payload.Discoverer_Request) (*pa
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/discoverer.v1.Pods",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			},
 			info.Get())
 		if span != nil {
@@ -130,8 +126,6 @@ func (s *server) Pods(ctx context.Context, req *payload.Discoverer_Request) (*pa
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/discoverer.v1.Pods",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			},
 			info.Get())
 		if span != nil {
@@ -150,8 +144,6 @@ func (s *server) Pods(ctx context.Context, req *payload.Discoverer_Request) (*pa
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/discoverer.v1.Pods",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			},
 			info.Get())
 		if span != nil {
@@ -184,8 +176,6 @@ func (s *server) Nodes(ctx context.Context, req *payload.Discoverer_Request) (*p
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/discoverer.v1.Nodes",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			},
 			info.Get())
 		if span != nil {
@@ -203,8 +193,6 @@ func (s *server) Nodes(ctx context.Context, req *payload.Discoverer_Request) (*p
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/discoverer.v1.Nodes",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			},
 			info.Get())
 		if span != nil {
@@ -223,8 +211,6 @@ func (s *server) Nodes(ctx context.Context, req *payload.Discoverer_Request) (*p
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/discoverer.v1.Nodes",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			},
 			info.Get())
 		if span != nil {
@@ -243,8 +229,6 @@ func (s *server) Nodes(ctx context.Context, req *payload.Discoverer_Request) (*p
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/discoverer.v1.Nodes",
 				ResourceName: fmt.Sprintf("%s(%s)", s.name, s.ip),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			},
 			info.Get())
 		if span != nil {

--- a/pkg/gateway/lb/handler/grpc/handler.go
+++ b/pkg/gateway/lb/handler/grpc/handler.go
@@ -123,8 +123,6 @@ func (s *server) Exists(ctx context.Context, meta *payload.Object_ID) (id *paylo
 					&errdetails.ResourceInfo{
 						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Exists",
 						ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-						Owner:        errdetails.ValdResourceOwner,
-						Description:  err.Error(),
 					})
 				if sspan != nil {
 					sspan.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -162,8 +160,6 @@ func (s *server) Exists(ctx context.Context, meta *payload.Object_ID) (id *paylo
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Exists",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			})
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -217,8 +213,6 @@ func (s *server) Search(ctx context.Context, req *payload.Search_Request) (res *
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Search",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -272,8 +266,6 @@ func (s *server) SearchByID(ctx context.Context, req *payload.Search_IDRequest) 
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.GetObject",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		var serr error
 		res, serr = s.search(ctx, req.GetConfig(),
@@ -293,8 +285,6 @@ func (s *server) SearchByID(ctx context.Context, req *payload.Search_IDRequest) 
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.SearchByID",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			})
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -315,8 +305,6 @@ func (s *server) SearchByID(ctx context.Context, req *payload.Search_IDRequest) 
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Search",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		var serr error
 		res, serr = s.search(ctx, req.GetConfig(),
@@ -334,8 +322,6 @@ func (s *server) SearchByID(ctx context.Context, req *payload.Search_IDRequest) 
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.SearchByID",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			})
 		err = errors.Wrap(err, serr.Error())
 		if span != nil {
@@ -405,8 +391,6 @@ func (s *server) search(ctx context.Context, cfg *payload.Search_Config,
 					&errdetails.ResourceInfo{
 						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Search",
 						ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-						Owner:        errdetails.ValdResourceOwner,
-						Description:  err.Error(),
 					})
 				if sspan != nil {
 					sspan.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -418,8 +402,6 @@ func (s *server) search(ctx context.Context, cfg *payload.Search_Config,
 					&errdetails.ResourceInfo{
 						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Search",
 						ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-						Owner:        errdetails.ValdResourceOwner,
-						Description:  err.Error(),
 					})
 				if sspan != nil {
 					sspan.SetStatus(trace.StatusCodeNotFound(err.Error()))
@@ -509,8 +491,6 @@ func (s *server) search(ctx context.Context, cfg *payload.Search_Config,
 					&errdetails.ResourceInfo{
 						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.search",
 						ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-						Owner:        errdetails.ValdResourceOwner,
-						Description:  err.Error(),
 					}, info.Get())
 				if span != nil {
 					span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -530,8 +510,6 @@ func (s *server) search(ctx context.Context, cfg *payload.Search_Config,
 					&errdetails.ResourceInfo{
 						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.search",
 						ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-						Owner:        errdetails.ValdResourceOwner,
-						Description:  err.Error(),
 					}, info.Get())
 				if span != nil {
 					span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -720,8 +698,6 @@ func (s *server) MultiSearch(ctx context.Context, reqs *payload.Search_MultiRequ
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.MultiSearch",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  errs.Error(),
 			})
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -792,8 +768,6 @@ func (s *server) MultiSearchByID(ctx context.Context, reqs *payload.Search_Multi
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.MultiSearchByID",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  errs.Error(),
 			})
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -850,8 +824,6 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (ce *p
 				&errdetails.ResourceInfo{
 					ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Exists",
 					ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				}, info.Get())
 			if span != nil {
 				span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -920,8 +892,6 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (ce *p
 				&errdetails.ResourceInfo{
 					ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Insert",
 					ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			if span != nil {
 				span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -961,8 +931,6 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (ce *p
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Insert.DoMulti",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  errs.Error(),
 			}, info.Get())
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1070,8 +1038,6 @@ func (s *server) MultiInsert(ctx context.Context, reqs *payload.Insert_MultiRequ
 					&errdetails.ResourceInfo{
 						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Exists",
 						ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-						Owner:        errdetails.ValdResourceOwner,
-						Description:  err.Error(),
 					}, info.Get())
 				if span != nil {
 					span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1141,8 +1107,6 @@ func (s *server) MultiInsert(ctx context.Context, reqs *payload.Insert_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.MultiInsert",
 					ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			if span != nil {
 				span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1182,8 +1146,6 @@ func (s *server) MultiInsert(ctx context.Context, reqs *payload.Insert_MultiRequ
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.MultiInsert.DoMulti",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  errs.Error(),
 			}, info.Get())
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1243,8 +1205,6 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (res *
 				&errdetails.ResourceInfo{
 					ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Update.GetObject",
 					ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				}, info.Get())
 			if span != nil {
 				span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1264,8 +1224,6 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (res *
 				&errdetails.ResourceInfo{
 					ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.GetObject",
 					ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				}, info.Get())
 			if span != nil {
 				span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1305,8 +1263,6 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (res *
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Update.Remove",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1333,8 +1289,6 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (res *
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Update.Insert",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1445,8 +1399,6 @@ func (s *server) MultiUpdate(ctx context.Context, reqs *payload.Update_MultiRequ
 					&errdetails.ResourceInfo{
 						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.MultiUpdate.GetObject",
 						ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-						Owner:        errdetails.ValdResourceOwner,
-						Description:  err.Error(),
 					}, info.Get())
 				if span != nil {
 					span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1502,8 +1454,6 @@ func (s *server) MultiUpdate(ctx context.Context, reqs *payload.Update_MultiRequ
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.MultiUpdate.MultiRemove",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1524,8 +1474,6 @@ func (s *server) MultiUpdate(ctx context.Context, reqs *payload.Update_MultiRequ
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.MultiUpdate.MultiInsert",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1588,8 +1536,6 @@ func (s *server) Upsert(ctx context.Context, req *payload.Upsert_Request) (loc *
 				&errdetails.ResourceInfo{
 					ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.GetObject",
 					ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				}, info.Get())
 			if span != nil {
 				span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1636,8 +1582,6 @@ func (s *server) Upsert(ctx context.Context, req *payload.Upsert_Request) (loc *
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Upsert." + operation,
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1729,10 +1673,6 @@ func (s *server) MultiUpsert(ctx context.Context, reqs *payload.Upsert_MultiRequ
 			}
 			return nil, err
 		}
-		ids = append(ids, uuid)
-		_, err = s.Exists(ctx, &payload.Object_ID{
-			Id: uuid,
-		})
 		var shouldInsert bool
 		if !req.GetConfig().GetSkipStrictExistCheck() {
 			vec, err := s.GetObject(ctx, &payload.Object_VectorRequest{
@@ -1751,6 +1691,7 @@ func (s *server) MultiUpsert(ctx context.Context, reqs *payload.Upsert_MultiRequ
 			})
 			shouldInsert = err != nil || id == nil || len(id.GetId()) == 0
 		}
+		ids = append(ids, uuid)
 		if shouldInsert {
 			insertReqs = append(insertReqs, &payload.Insert_Request{
 				Vector: vec,
@@ -1846,7 +1787,7 @@ func (s *server) MultiUpsert(ctx context.Context, reqs *payload.Upsert_MultiRequ
 		}
 	}
 	if errs != nil {
-		st, msg, err := status.ParseError(err, codes.Internal,
+		st, msg, err := status.ParseError(errs, codes.Internal,
 			"failed to parse MultiUpsert gRPC error response",
 			&errdetails.RequestInfo{
 				RequestId:   strings.Join(ids, ","),
@@ -1855,8 +1796,6 @@ func (s *server) MultiUpsert(ctx context.Context, reqs *payload.Upsert_MultiRequ
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.MultiUpsert",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1892,8 +1831,6 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (locs 
 				&errdetails.ResourceInfo{
 					ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Exists",
 					ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				}, info.Get())
 			if span != nil {
 				span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1939,8 +1876,6 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (locs 
 				&errdetails.ResourceInfo{
 					ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Remove",
 					ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			if span != nil {
 				span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1967,8 +1902,6 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (locs 
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Remove",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -1985,8 +1918,6 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (locs 
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Remove",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			})
 		if span != nil {
 			span.SetStatus(trace.StatusCodeNotFound(err.Error()))
@@ -2070,8 +2001,6 @@ func (s *server) MultiRemove(ctx context.Context, reqs *payload.Remove_MultiRequ
 					&errdetails.ResourceInfo{
 						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.Exists",
 						ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-						Owner:        errdetails.ValdResourceOwner,
-						Description:  err.Error(),
 					}, info.Get())
 				if span != nil {
 					span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -2137,8 +2066,6 @@ func (s *server) MultiRemove(ctx context.Context, reqs *payload.Remove_MultiRequ
 				&errdetails.ResourceInfo{
 					ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.MultiRemove",
 					ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-					Owner:        errdetails.ValdResourceOwner,
-					Description:  err.Error(),
 				})
 			if span != nil {
 				span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -2165,8 +2092,6 @@ func (s *server) MultiRemove(ctx context.Context, reqs *payload.Remove_MultiRequ
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.MultiRemove",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -2183,8 +2108,6 @@ func (s *server) MultiRemove(ctx context.Context, reqs *payload.Remove_MultiRequ
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.MultiRemove",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			})
 		if span != nil {
 			span.SetStatus(trace.StatusCodeNotFound(err.Error()))
@@ -2248,8 +2171,6 @@ func (s *server) GetObject(ctx context.Context, req *payload.Object_VectorReques
 					&errdetails.ResourceInfo{
 						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.GetObject",
 						ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-						Owner:        errdetails.ValdResourceOwner,
-						Description:  err.Error(),
 					}, info.Get())
 				if span != nil {
 					span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))
@@ -2286,8 +2207,6 @@ func (s *server) GetObject(ctx context.Context, req *payload.Object_VectorReques
 			&errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1.GetObject",
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %v", apiName, s.name, s.ip, s.gateway.Addrs(ctx)),
-				Owner:        errdetails.ValdResourceOwner,
-				Description:  err.Error(),
 			}, info.Get())
 		if span != nil {
 			span.SetStatus(trace.FromGRPCStatus(st.Code(), msg))


### PR DESCRIPTION
Signed-off-by: kpango <kpango@vdaas.org>

<!--- Provide a general summary of your changes in the Title above -->

### Description

This PR includes 2 chanees.

1. In Vald, when the gRPC Handler returns an error, we add a ResourceInfo so that the user can detect which resource had the error.
However, due to feedback that the Owner and Description in the ResourceInfo are redundant and do not make much sense, this PR removes the Owner and Description.

2. Removed unnecessary exists checking in MultiUpsert operation.
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16.5
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [x] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
