### PR TITLE
[bugfix] agent.GetObject API returns old indexed vector problem instead of vqueue's new data

### DIFF
--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -585,21 +585,19 @@ func (n *ngt) deleteMultiple(uuids []string, now int64) (err error) {
 }
 
 func (n *ngt) GetObject(uuid string) (vec []float32, err error) {
-	oid, ok := n.kvs.Get(uuid)
+	vec, ok := n.vq.GetVector(uuid)
 	if !ok {
-		log.Debugf("GetObject\tuuid: %s's kvs data not found, trying to read from vqueue", uuid)
-		vec, ok := n.vq.GetVector(uuid)
+		log.Debugf("GetObject\tuuid: %s's data not found in vqueue, trying to read from indexed kvsdb data", uuid)
+		oid, ok := n.kvs.Get(uuid)
 		if !ok {
-			log.Debugf("GetObject\tuuid: %s's vqueue data not found", uuid)
+			log.Debugf("GetObject\tuuid: %s's data not found in kvsdb and vqueue", uuid)
 			return nil, errors.ErrObjectIDNotFound(uuid)
 		}
-		return vec, nil
-	}
-	log.Debugf("GetObject\tGetVector oid: %d", oid)
-	vec, err = n.core.GetVector(uint(oid))
-	if err != nil {
-		log.Debugf("GetObject\tuuid: %s oid: %d's vector not found", uuid, oid)
-		return nil, errors.ErrObjectNotFound(err, uuid)
+		vec, err = n.core.GetVector(uint(oid))
+		if err != nil {
+			log.Debugf("GetObject\tuuid: %s oid: %d's vector not found in ngt index", uuid, oid)
+			return nil, errors.ErrObjectNotFound(err, uuid)
+		}
 	}
 	return vec, nil
 }


### PR DESCRIPTION
Signed-off-by: kpango <kpango@vdaas.org>

<!--- Provide a general summary of your changes in the Title above -->

### Description:
Problem: agent.GetObject API returns old indiced vector data when there is vector data with the same uuid in both kvsdb and vqueue.
Solution: In the Vald, vqueue is designed to hold the newest data rather than kvsdb, so I changed the implementation to verify the existence of vector data on GetObject API priority from vqueue and refer to kvsdb only if it does not exist in vqueue.

<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16.5
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
