### PR TITLE
Fix mount paths of Agent statefulset when using PVC template

### DIFF
--- a/charts/vald/templates/agent/statefulset.yaml
+++ b/charts/vald/templates/agent/statefulset.yaml
@@ -93,6 +93,14 @@ spec:
           volumeMounts:
             - name: {{ $agent.sidecar.name }}-config
               mountPath: /etc/server/
+            {{- if not $agent.ngt.enable_in_memory_mode }}
+            {{- if $agent.ngt.index_path }}
+            {{- if $agent.persistentVolume.enabled }}
+            - name: {{ $agent.name }}-pvc
+              mountPath: {{ dir $agent.ngt.index_path }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- if $agent.volumeMounts }}
             {{- toYaml $agent.volumeMounts | nindent 12 }}
             {{- end }}
@@ -129,7 +137,7 @@ spec:
             {{- if $agent.ngt.index_path }}
             {{- if $agent.persistentVolume.enabled }}
             - name: {{ $agent.name }}-pvc
-              mountPath: {{ $agent.ngt.index_path }}
+              mountPath: {{ dir $agent.ngt.index_path }}
             {{- end }}
             {{- end }}
             {{- end }}
@@ -163,7 +171,7 @@ spec:
             {{- if $agent.ngt.index_path }}
             {{- if $agent.persistentVolume.enabled }}
             - name: {{ $agent.name }}-pvc
-              mountPath: {{ $agent.ngt.index_path }}
+              mountPath: {{ dir $agent.ngt.index_path }}
             {{- end }}
             {{- end }}
             {{- end }}


### PR DESCRIPTION
Signed-off-by: Rintaro Okamura <rintaro.okamura@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
The `mountPath` parameters of Agent StatefulSet templates were invalid.
This PR fixes the problem by using Helm template's `dir` function.
(It was forgotten to add PVC volume mount for init containers. This fixes it too.)

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
nothing

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
nothing

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16.6
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
