### PR TITLE
change initial-index-directory removal logic

### DIFF
--- a/internal/core/algorithm/ngt/ngt.go
+++ b/internal/core/algorithm/ngt/ngt.go
@@ -26,6 +26,7 @@ import "C"
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"sync"
 	"unsafe"
@@ -242,8 +243,15 @@ func (n *ngt) loadOptions(opts ...Option) (err error) {
 func (n *ngt) create() (err error) {
 	if fileExists(n.idxPath) {
 		log.Warnf("index path exists, will remove the directory. path: %s", n.idxPath)
-		if err = os.RemoveAll(n.idxPath); err != nil {
+		files, err := filepath.Glob(filepath.Join(filepath.Dir(n.idxPath), "*"))
+		if err != nil {
 			return err
+		}
+		for _, file := range files {
+			err = os.RemoveAll(file)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	path := C.CString(n.idxPath)


### PR DESCRIPTION
Signed-off-by: kpango <kpango@vdaas.org>

<!--- Provide a general summary of your changes in the Title above -->

### Description:
Changed agent core ngt to exclude the target directory itself from the directory cleanup process at the time of initialization so that only its contents are removed.
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16.6
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
