### PR TITLE
fix e2e multi apis test code

### DIFF
--- a/tests/e2e/operation/multi.go
+++ b/tests/e2e/operation/multi.go
@@ -1,4 +1,3 @@
-//go:build e2e
 // +build e2e
 
 //

--- a/tests/e2e/operation/multi.go
+++ b/tests/e2e/operation/multi.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 //
@@ -164,9 +165,12 @@ func (c *client) MultiUpdate(t *testing.T, ctx context.Context, ds Dataset) erro
 		return err
 	}
 
-	if len(res.GetLocations()) != len(ds.Train) {
-		t.Error("number of responses does not match with sent requests")
-	}
+	// Note: The MultiUpdate API internally checks the identity of the vectors to be updated by the LB Gateway,
+	// so it is important to remember that the number of responses is not always the same as the number of requested data.
+	// The response includes an ID, so the client can check the order of the data based on the requested ID.
+	// if len(res.GetLocations()) != len(ds.Train) {
+	// 	t.Error("number of responses does not match with sent requests")
+	// }
 
 	return nil
 }
@@ -201,9 +205,12 @@ func (c *client) MultiUpsert(t *testing.T, ctx context.Context, ds Dataset) erro
 		return err
 	}
 
-	if len(res.GetLocations()) != len(ds.Train) {
-		t.Error("number of responses does not match with sent requests")
-	}
+	// Note: The MultiUpsert API internally checks the identity of the vectors to be updated by the LB Gateway,
+	// so it is important to remember that the number of responses is not always the same as the number of requested data.
+	// The response includes an ID, so the client can check the order of the data based on the requested ID.
+	// if len(res.GetLocations()) != len(ds.Train) {
+	// 	t.Error("number of responses does not match with sent requests")
+	// }
 
 	return nil
 }

--- a/tests/e2e/operation/multi.go
+++ b/tests/e2e/operation/multi.go
@@ -168,9 +168,9 @@ func (c *client) MultiUpdate(t *testing.T, ctx context.Context, ds Dataset) erro
 	// Note: The MultiUpdate API internally checks the identity of the vectors to be updated by the LB Gateway,
 	// so it is important to remember that the number of responses is not always the same as the number of requested data.
 	// The response includes an ID, so the client can check the order of the data based on the requested ID.
-	// if len(res.GetLocations()) != len(ds.Train) {
-	// 	t.Error("number of responses does not match with sent requests")
-	// }
+	if len(res.GetLocations()) == 0 {
+		t.Error("empty response detected")
+	}
 
 	return nil
 }
@@ -208,9 +208,9 @@ func (c *client) MultiUpsert(t *testing.T, ctx context.Context, ds Dataset) erro
 	// Note: The MultiUpsert API internally checks the identity of the vectors to be updated by the LB Gateway,
 	// so it is important to remember that the number of responses is not always the same as the number of requested data.
 	// The response includes an ID, so the client can check the order of the data based on the requested ID.
-	// if len(res.GetLocations()) != len(ds.Train) {
-	// 	t.Error("number of responses does not match with sent requests")
-	// }
+	if len(res.GetLocations()) == 0 {
+		t.Error("empty response detected")
+	}
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: kpango <kpango@vdaas.org>

<!--- Provide a general summary of your changes in the Title above -->

### Description:
The MultiUpdate&MultiUpsert API internally checks the identity of the vectors to be updated by the LB Gateway, so it is important to remember that the number of responses is not always the same as the number of requested data.
The response includes an ID, so the client can check the order of the data based on the requested ID.

In this PR removed the length comparison test with seed data from the e2e multi-upsert/update.
and replace it to check size is not zero.
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16.6
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
