### PR TITLE
remove global errgroup from kvsdb goroutine limitation

### DIFF
--- a/pkg/agent/core/ngt/service/kvs/kvs.go
+++ b/pkg/agent/core/ngt/service/kvs/kvs.go
@@ -66,16 +66,17 @@ func New(opts ...Option) BidiMap {
 	}
 	for i := range b.ou {
 		b.ou[i] = new(ou)
-	}
-	for i := range b.uo {
 		b.uo[i] = new(uo)
 	}
+
 	if b.eg == nil {
 		b.eg, _ = errgroup.New(context.Background())
 	}
-	if b.concurrency > 1 {
+
+	if b.concurrency > 0 {
 		b.eg.Limitation(b.concurrency)
 	}
+
 	return b
 }
 

--- a/pkg/agent/core/ngt/service/kvs/option.go
+++ b/pkg/agent/core/ngt/service/kvs/option.go
@@ -37,7 +37,7 @@ func WithErrGroup(eg errgroup.Group) Option {
 // WithConcurrency returns the option to set the concurrency.
 func WithConcurrency(c int) Option {
 	return func(b *bidi) {
-		if c > 1 {
+		if c > 0 {
 			b.concurrency = c
 		}
 	}

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -137,19 +137,7 @@ func New(cfg *config.NGT, opts ...Option) (nn NGT, err error) {
 
 	n.dim = cfg.Dimension
 
-	n.kvs = kvs.New(func() []kvs.Option {
-		if cfg.KVSDB.Concurrency < 1 {
-			return []kvs.Option{
-				// n.eg is global errgroup we can use it only concurrency < 1 (which means unlimited)
-				// if we use global errgroup under the limited concurrency it will affect other daemon process
-				kvs.WithErrGroup(n.eg),
-			}
-		}
-		return []kvs.Option{
-			// when concurrency >= 1 which means limited concurrency for retrieving kvsdb, we shouldn't use global errgroup kvsdb will automatically generates it's own errgroup
-			kvs.WithConcurrency(cfg.KVSDB.Concurrency),
-		}
-	}()...)
+	n.kvs = kvs.New(kvs.WithConcurrency(cfg.KVSDB.Concurrency))
 
 	err = n.initNGT(
 		core.WithInMemoryMode(n.inMem),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
This bug was found and reported by @rinx.
In PR #1384, it was reported that the Agent NGT Service does not start (blocking) only when KVSDB.Concurrency is set to 0.
It is not recommended to use your own errgroup in kvsdb from cancellation point of view.
However, since the number of goroutines to be invoked remains the same, we believe that using our own errgroup is not a problem from a performance point of view.
Therefore, in this PR, KVSDB will keep its own errgroup and use it for concurrent map search.

If the concurrency is less than or equal to 0, goroutines will be created without any limitation, and if the concurrency is greater than or equal to 1, the search will be performed using the number of goroutines.

<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.16.6
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
