### PR TITLE
Fix watcher test for fsnotify v1.5 update

### DIFF
--- a/internal/file/watch/watch_test.go
+++ b/internal/file/watch/watch_test.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/fsnotify/fsnotify"
@@ -193,7 +192,7 @@ func Test_watch_init(t *testing.T) {
 				},
 			},
 			want: want{
-				err: syscall.Errno(0x2),
+				err: errors.New("error resolving \"vald.go\": lstat vald.go: no such file or directory"),
 			},
 		},
 		{
@@ -204,7 +203,7 @@ func Test_watch_init(t *testing.T) {
 				},
 			},
 			want: want{
-				err: syscall.Errno(0x2),
+				err: errors.New("error resolving \"test\": lstat test: no such file or directory"),
 			},
 		},
 		{
@@ -216,7 +215,7 @@ func Test_watch_init(t *testing.T) {
 				},
 			},
 			want: want{
-				err: syscall.Errno(0x2),
+				err: errors.New("error resolving \"vald.go\": lstat vald.go: no such file or directory"),
 			},
 		},
 		{
@@ -914,7 +913,7 @@ func Test_watch_Add(t *testing.T) {
 				dirs: make(map[string]struct{}),
 			},
 			want: want{
-				err: syscall.Errno(0x2),
+				err: errors.New("error resolving \"vald.go\": lstat vald.go: no such file or directory"),
 				want: &watch{
 					dirs: map[string]struct{}{
 						"watch.go": {},


### PR DESCRIPTION
Signed-off-by: kevindiu <kevindiujp@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
This PR fixes the failed test because of fsnotify v1.5 update.
This PR merge into non-master branch.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.17
- Docker Version: 19.03.8
- Kubernetes Version: 1.18.2
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [x] I have added tests and benchmarks to cover my changes.
- [x] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
