### PR TITLE
[bugfix] resolve errgroup limitation channel close panic

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -54,9 +54,8 @@ jobs:
           go-version: ${{ steps.golang_version.outputs.version }}
       - name: Run formatter and license.go
         run: |
-          make format/go
-          make format/yaml
-          make license
+          make deps/install
+          make format
           git checkout go.mod go.sum
       - name: Check and Push to master
         continue-on-error: true

--- a/Makefile
+++ b/Makefile
@@ -373,9 +373,9 @@ format: \
 .PHONY: format/go
 ## run golines, gofumpt, goimports for all go files
 format/go:
-	find ./ -type d -name .git -prune -o -type f -regex '.*[^\.pb]\.go' -print | xargs golines -w -m $(GOLINES_MAX_WIDTH)
-	find ./ -type d -name .git -prune -o -type f -regex '.*[^\.pb]\.go' -print | xargs gofumpt -w
-	find ./ -type d -name .git -prune -o -type f -regex '.*\.go' -print | xargs goimports -w
+	find ./ -type d -name .git -prune -o -type f -regex '.*[^\.pb]\.go' -print | xargs $(GOPATH)/bin/golines -w -m $(GOLINES_MAX_WIDTH)
+	find ./ -type d -name .git -prune -o -type f -regex '.*[^\.pb]\.go' -print | xargs $(GOPATH)/bin/gofumpt -w
+	find ./ -type d -name .git -prune -o -type f -regex '.*\.go' -print | xargs $(GOPATH)/bin/goimports -w
 
 .PHONY: format/yaml
 format/yaml:

--- a/hack/git/hooks/pre-commit
+++ b/hack/git/hooks/pre-commit
@@ -37,7 +37,7 @@ if git diff HEAD^ --name-only | grep ".go$" > /dev/null; then
 
     # go build
     echo "Run go build..."
-    go build ./...
+    go build -mod=readonly ./...
     echo "go build finished."
 
     if [ `git rev-parse --abbrev-ref HEAD` = "master" ]; then

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -363,10 +363,6 @@ func (n *ngt) Start(ctx context.Context) <-chan error {
 			err = nil
 			select {
 			case <-ctx.Done():
-				err = n.kvs.Close()
-				if err != nil {
-					ech <- err
-				}
 				err = n.CreateIndex(ctx, n.poolSize)
 				if err != nil && !errors.Is(err, errors.ErrUncommittedIndexNotFound) {
 					ech <- err
@@ -657,10 +653,9 @@ func (n *ngt) CreateIndex(ctx context.Context, poolSize uint32) (err error) {
 	log.Debug("create index insert phase finished")
 	log.Debug("create graph and tree phase started")
 	log.Debugf("pool size = %d", poolSize)
-	cierr := n.core.CreateIndex(poolSize)
-	if cierr != nil {
-		log.Error("an error occurred on creating graph and tree phase:", cierr)
-		err = errors.Wrap(err, cierr.Error())
+	err = n.core.CreateIndex(poolSize)
+	if err != nil {
+		log.Error("an error occurred on creating graph and tree phase:", err)
 	}
 	log.Debug("create graph and tree phase finished")
 
@@ -677,10 +672,9 @@ func (n *ngt) SaveIndex(ctx context.Context) (err error) {
 		}
 	}()
 	if len(n.path) != 0 && !n.inMem {
-		err = n.saveIndex(ctx)
+		return n.saveIndex(ctx)
 	}
-
-	return
+	return nil
 }
 
 func (n *ngt) saveIndex(ctx context.Context) (err error) {
@@ -786,7 +780,10 @@ func (n *ngt) CreateAndSaveIndex(ctx context.Context, poolSize uint32) (err erro
 	}()
 
 	err = n.CreateIndex(ctx, poolSize)
-	if err != nil {
+	if err != nil &&
+		!errors.Is(err, errors.ErrUncommittedIndexNotFound) &&
+		!errors.Is(err, context.Canceled) &&
+		!errors.Is(err, context.DeadlineExceeded) {
 		return err
 	}
 	return n.SaveIndex(ctx)
@@ -909,12 +906,26 @@ func (n *ngt) GetDimensionSize() int {
 func (n *ngt) Close(ctx context.Context) (err error) {
 	err = n.kvs.Close()
 	if len(n.path) != 0 {
-		cerr := n.CreateAndSaveIndex(ctx, n.poolSize)
-		if cerr != nil {
+		cerr := n.CreateIndex(ctx, n.poolSize)
+		if cerr != nil &&
+			!errors.Is(err, errors.ErrUncommittedIndexNotFound) &&
+			!errors.Is(err, context.Canceled) &&
+			!errors.Is(err, context.DeadlineExceeded) {
 			if err != nil {
 				err = errors.Wrap(cerr, err.Error())
 			} else {
 				err = cerr
+			}
+		}
+		serr := n.SaveIndex(ctx)
+		if serr != nil &&
+			!errors.Is(err, errors.ErrUncommittedIndexNotFound) &&
+			!errors.Is(err, context.Canceled) &&
+			!errors.Is(err, context.DeadlineExceeded) {
+			if err != nil {
+				err = errors.Wrap(serr, err.Error())
+			} else {
+				err = serr
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: kpango <kpango@vdaas.org>

<!--- Provide a general summary of your changes in the Title above -->

### Description:
The agent service closed kvsdb twice and performed duplicate close operations on the errgroup limitaiton channel, resulting in a runtime panic `close on closed channel` error.
This PR fixes these issues.
<!--- Describe your changes in detail -->

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.17
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.12.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
