### PR TITLE
create investigation test of max dim for NGT

### DIFF
--- a/internal/core/algorithm/ngt/ngt.go
+++ b/internal/core/algorithm/ngt/ngt.go
@@ -157,7 +157,7 @@ const (
 	// dimension constraints
 	// -------------------------------------------------------------.
 	VectorDimensionSizeLimit = 1<<32 - 1
-	minimumDimensionSize        = algorithm.MinimumVectorDimensionSize
+	minimumDimensionSize     = algorithm.MinimumVectorDimensionSize
 	// -------------------------------------------------------------.
 )
 

--- a/internal/core/algorithm/ngt/ngt.go
+++ b/internal/core/algorithm/ngt/ngt.go
@@ -156,7 +156,7 @@ const (
 	// -------------------------------------------------------------
 	// dimension constraints
 	// -------------------------------------------------------------.
-	NgtVectorDimensionSizeLimit = 1<<32 - 1
+	VectorDimensionSizeLimit = 1<<32 - 1
 	minimumDimensionSize        = algorithm.MinimumVectorDimensionSize
 	// -------------------------------------------------------------.
 )
@@ -685,8 +685,8 @@ func (n *ngt) GetVector(id uint) ([]float32, error) {
 		if results == nil {
 			return nil, n.newGoError(ebuf)
 		}
-		ret = (*[NgtVectorDimensionSizeLimit]float32)(unsafe.Pointer(results))[:dimension:dimension]
-		// for _, elem := range (*[NgtVectorDimensionSizeLimit]C.float)(unsafe.Pointer(results))[:dimension:dimension]{
+		ret = (*[VectorDimensionSizeLimit]float32)(unsafe.Pointer(results))[:dimension:dimension]
+		// for _, elem := range (*[VectorDimensionSizeLimit]C.float)(unsafe.Pointer(results))[:dimension:dimension]{
 		// 	ret = append(ret, float32(elem))
 		// }
 	case Uint8:
@@ -697,7 +697,7 @@ func (n *ngt) GetVector(id uint) ([]float32, error) {
 			return nil, n.newGoError(ebuf)
 		}
 		ret = make([]float32, 0, dimension)
-		for _, elem := range (*[NgtVectorDimensionSizeLimit]C.uint8_t)(unsafe.Pointer(results))[:dimension:dimension] {
+		for _, elem := range (*[VectorDimensionSizeLimit]C.uint8_t)(unsafe.Pointer(results))[:dimension:dimension] {
 			ret = append(ret, float32(elem))
 		}
 	default:

--- a/internal/core/algorithm/ngt/ngt.go
+++ b/internal/core/algorithm/ngt/ngt.go
@@ -156,7 +156,7 @@ const (
 	// -------------------------------------------------------------
 	// dimension constraints
 	// -------------------------------------------------------------.
-	ngtVectorDimensionSizeLimit = 1<<32 - 1
+	NgtVectorDimensionSizeLimit = 1<<32 - 1
 	minimumDimensionSize        = algorithm.MinimumVectorDimensionSize
 	// -------------------------------------------------------------.
 )
@@ -685,8 +685,8 @@ func (n *ngt) GetVector(id uint) ([]float32, error) {
 		if results == nil {
 			return nil, n.newGoError(ebuf)
 		}
-		ret = (*[ngtVectorDimensionSizeLimit]float32)(unsafe.Pointer(results))[:dimension:dimension]
-		// for _, elem := range (*[ngtVectorDimensionSizeLimit]C.float)(unsafe.Pointer(results))[:dimension:dimension]{
+		ret = (*[NgtVectorDimensionSizeLimit]float32)(unsafe.Pointer(results))[:dimension:dimension]
+		// for _, elem := range (*[NgtVectorDimensionSizeLimit]C.float)(unsafe.Pointer(results))[:dimension:dimension]{
 		// 	ret = append(ret, float32(elem))
 		// }
 	case Uint8:
@@ -697,7 +697,7 @@ func (n *ngt) GetVector(id uint) ([]float32, error) {
 			return nil, n.newGoError(ebuf)
 		}
 		ret = make([]float32, 0, dimension)
-		for _, elem := range (*[ngtVectorDimensionSizeLimit]C.uint8_t)(unsafe.Pointer(results))[:dimension:dimension] {
+		for _, elem := range (*[NgtVectorDimensionSizeLimit]C.uint8_t)(unsafe.Pointer(results))[:dimension:dimension] {
 			ret = append(ret, float32(elem))
 		}
 	default:

--- a/internal/core/algorithm/ngt/ngt.go
+++ b/internal/core/algorithm/ngt/ngt.go
@@ -156,7 +156,7 @@ const (
 	// -------------------------------------------------------------
 	// dimension constraints
 	// -------------------------------------------------------------.
-	ngtVectorDimensionSizeLimit = 1 << 16
+	ngtVectorDimensionSizeLimit = 1<<32 - 1
 	minimumDimensionSize        = algorithm.MinimumVectorDimensionSize
 	// -------------------------------------------------------------.
 )

--- a/internal/core/algorithm/ngt/ngt_test.go
+++ b/internal/core/algorithm/ngt/ngt_test.go
@@ -183,7 +183,7 @@ func TestNew(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.NewErrCriticalOption("dimension", 1, errors.ErrInvalidDimensionSize(1, NgtVectorDimensionSizeLimit)),
+				err: errors.NewErrCriticalOption("dimension", 1, errors.ErrInvalidDimensionSize(1, VectorDimensionSizeLimit)),
 			},
 		},
 	}
@@ -761,7 +761,7 @@ func Test_gen(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.NewErrCriticalOption("dimension", 1, errors.ErrInvalidDimensionSize(1, NgtVectorDimensionSizeLimit)),
+				err: errors.NewErrCriticalOption("dimension", 1, errors.ErrInvalidDimensionSize(1, VectorDimensionSizeLimit)),
 			},
 		},
 	}

--- a/internal/core/algorithm/ngt/ngt_test.go
+++ b/internal/core/algorithm/ngt/ngt_test.go
@@ -183,7 +183,7 @@ func TestNew(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.NewErrCriticalOption("dimension", 1, errors.ErrInvalidDimensionSize(1, ngtVectorDimensionSizeLimit)),
+				err: errors.NewErrCriticalOption("dimension", 1, errors.ErrInvalidDimensionSize(1, NgtVectorDimensionSizeLimit)),
 			},
 		},
 	}
@@ -761,7 +761,7 @@ func Test_gen(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.NewErrCriticalOption("dimension", 1, errors.ErrInvalidDimensionSize(1, ngtVectorDimensionSizeLimit)),
+				err: errors.NewErrCriticalOption("dimension", 1, errors.ErrInvalidDimensionSize(1, NgtVectorDimensionSizeLimit)),
 			},
 		},
 	}

--- a/internal/core/algorithm/ngt/option.go
+++ b/internal/core/algorithm/ngt/option.go
@@ -86,8 +86,8 @@ func WithBulkInsertChunkSize(size int) Option {
 // WithDimension represents the option to set the dimension for NGT.
 func WithDimension(size int) Option {
 	return func(n *ngt) error {
-		if size > ngtVectorDimensionSizeLimit || size < minimumDimensionSize {
-			err := errors.ErrInvalidDimensionSize(size, ngtVectorDimensionSizeLimit)
+		if size > NgtVectorDimensionSizeLimit || size < minimumDimensionSize {
+			err := errors.ErrInvalidDimensionSize(size, NgtVectorDimensionSizeLimit)
 			return errors.NewErrCriticalOption("dimension", size, err)
 		}
 

--- a/internal/core/algorithm/ngt/option.go
+++ b/internal/core/algorithm/ngt/option.go
@@ -86,8 +86,8 @@ func WithBulkInsertChunkSize(size int) Option {
 // WithDimension represents the option to set the dimension for NGT.
 func WithDimension(size int) Option {
 	return func(n *ngt) error {
-		if size > NgtVectorDimensionSizeLimit || size < minimumDimensionSize {
-			err := errors.ErrInvalidDimensionSize(size, NgtVectorDimensionSizeLimit)
+		if size > VectorDimensionSizeLimit || size < minimumDimensionSize {
+			err := errors.ErrInvalidDimensionSize(size, VectorDimensionSizeLimit)
 			return errors.NewErrCriticalOption("dimension", size, err)
 		}
 

--- a/internal/core/algorithm/ngt/option_test.go
+++ b/internal/core/algorithm/ngt/option_test.go
@@ -336,7 +336,7 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: 0: dimension size 0 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(NgtVectorDimensionSizeLimit)),
+				err: errors.New("invalid critical option, name: dimension, val: 0: dimension size 0 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(VectorDimensionSizeLimit)),
 			},
 		},
 		{
@@ -349,9 +349,9 @@ func TestWithDimension(t *testing.T) {
 			},
 		},
 		{
-			name: "set success when the size is NgtVectorDimensionSizeLimit",
+			name: "set success when the size is VectorDimensionSizeLimit",
 			args: args{
-				size: NgtVectorDimensionSizeLimit,
+				size: VectorDimensionSizeLimit,
 			},
 			want: want{
 				obj: &T{},
@@ -364,7 +364,7 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: 1: dimension size 1 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(NgtVectorDimensionSizeLimit)),
+				err: errors.New("invalid critical option, name: dimension, val: 1: dimension size 1 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(VectorDimensionSizeLimit)),
 			},
 		},
 		{
@@ -374,17 +374,17 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: -100: dimension size -100 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(NgtVectorDimensionSizeLimit)),
+				err: errors.New("invalid critical option, name: dimension, val: -100: dimension size -100 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(VectorDimensionSizeLimit)),
 			},
 		},
 		{
-			name: "return error when the size is larger than NgtVectorDimensionSizeLimit",
+			name: "return error when the size is larger than VectorDimensionSizeLimit",
 			args: args{
-				size: NgtVectorDimensionSizeLimit + 1,
+				size: VectorDimensionSizeLimit + 1,
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: 4294967296: dimension size 4294967296 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(NgtVectorDimensionSizeLimit)),
+				err: errors.New("invalid critical option, name: dimension, val: 4294967296: dimension size 4294967296 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(VectorDimensionSizeLimit)),
 			},
 		},
 		{
@@ -411,7 +411,7 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: -2147483648: dimension size -2147483648 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(NgtVectorDimensionSizeLimit)),
+				err: errors.New("invalid critical option, name: dimension, val: -2147483648: dimension size -2147483648 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(VectorDimensionSizeLimit)),
 			},
 		},
 	}

--- a/internal/core/algorithm/ngt/option_test.go
+++ b/internal/core/algorithm/ngt/option_test.go
@@ -336,7 +336,9 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: 0: dimension size 0 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(VectorDimensionSizeLimit)),
+				err: errors.New(
+					"invalid critical option, name: dimension, val: 0: dimension size 0 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(VectorDimensionSizeLimit),
+				),
 			},
 		},
 		{
@@ -364,7 +366,9 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: 1: dimension size 1 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(VectorDimensionSizeLimit)),
+				err: errors.New(
+					"invalid critical option, name: dimension, val: 1: dimension size 1 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(VectorDimensionSizeLimit),
+				),
 			},
 		},
 		{
@@ -374,7 +378,9 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: -100: dimension size -100 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(VectorDimensionSizeLimit)),
+				err: errors.New(
+					"invalid critical option, name: dimension, val: -100: dimension size -100 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(VectorDimensionSizeLimit),
+				),
 			},
 		},
 		{
@@ -384,7 +390,11 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: 4294967296: dimension size 4294967296 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(VectorDimensionSizeLimit)),
+				err: errors.New(
+					"invalid critical option, name: dimension, val: 4294967296: dimension size 4294967296 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(
+						VectorDimensionSizeLimit,
+					),
+				),
 			},
 		},
 		{
@@ -411,7 +421,11 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: -2147483648: dimension size -2147483648 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(VectorDimensionSizeLimit)),
+				err: errors.New(
+					"invalid critical option, name: dimension, val: -2147483648: dimension size -2147483648 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(
+						VectorDimensionSizeLimit,
+					),
+				),
 			},
 		},
 	}

--- a/internal/core/algorithm/ngt/option_test.go
+++ b/internal/core/algorithm/ngt/option_test.go
@@ -352,7 +352,7 @@ func TestWithDimension(t *testing.T) {
 		{
 			name: "set success when the size is maxDim",
 			args: args{
-				size: 1<<32 - 1,
+				size: maxDim,
 			},
 			want: want{
 				obj: &T{},
@@ -381,7 +381,7 @@ func TestWithDimension(t *testing.T) {
 		{
 			name: "return error when the size is larger than maxDim",
 			args: args{
-				size: 1 << 32,
+				size: maxDim + 1,
 			},
 			want: want{
 				obj: &T{},

--- a/internal/core/algorithm/ngt/option_test.go
+++ b/internal/core/algorithm/ngt/option_test.go
@@ -310,7 +310,6 @@ func TestWithDimension(t *testing.T) {
 		}
 		return nil
 	}
-	const maxDim = 1<<32 - 1
 
 	tests := []test{
 		{
@@ -337,7 +336,7 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: 0: dimension size 0 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(maxDim)),
+				err: errors.New("invalid critical option, name: dimension, val: 0: dimension size 0 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(NgtVectorDimensionSizeLimit)),
 			},
 		},
 		{
@@ -350,9 +349,9 @@ func TestWithDimension(t *testing.T) {
 			},
 		},
 		{
-			name: "set success when the size is maxDim",
+			name: "set success when the size is NgtVectorDimensionSizeLimit",
 			args: args{
-				size: maxDim,
+				size: NgtVectorDimensionSizeLimit,
 			},
 			want: want{
 				obj: &T{},
@@ -365,7 +364,7 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: 1: dimension size 1 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(maxDim)),
+				err: errors.New("invalid critical option, name: dimension, val: 1: dimension size 1 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(NgtVectorDimensionSizeLimit)),
 			},
 		},
 		{
@@ -375,17 +374,17 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: -100: dimension size -100 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(maxDim)),
+				err: errors.New("invalid critical option, name: dimension, val: -100: dimension size -100 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(NgtVectorDimensionSizeLimit)),
 			},
 		},
 		{
-			name: "return error when the size is larger than maxDim",
+			name: "return error when the size is larger than NgtVectorDimensionSizeLimit",
 			args: args{
-				size: maxDim + 1,
+				size: NgtVectorDimensionSizeLimit + 1,
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: 4294967296: dimension size 4294967296 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(maxDim)),
+				err: errors.New("invalid critical option, name: dimension, val: 4294967296: dimension size 4294967296 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(NgtVectorDimensionSizeLimit)),
 			},
 		},
 		{
@@ -412,7 +411,7 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: -2147483648: dimension size -2147483648 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(maxDim)),
+				err: errors.New("invalid critical option, name: dimension, val: -2147483648: dimension size -2147483648 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(NgtVectorDimensionSizeLimit)),
 			},
 		},
 	}

--- a/internal/core/algorithm/ngt/option_test.go
+++ b/internal/core/algorithm/ngt/option_test.go
@@ -20,6 +20,7 @@ package ngt
 import (
 	"math"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/vdaas/vald/internal/errors"
@@ -309,6 +310,7 @@ func TestWithDimension(t *testing.T) {
 		}
 		return nil
 	}
+	const maxDim = 1<<32 - 1
 
 	tests := []test{
 		{
@@ -329,13 +331,13 @@ func TestWithDimension(t *testing.T) {
 			},
 		},
 		{
-			name: "set success when the size is 0",
+			name: "return error when the size is 0",
 			args: args{
 				size: 0,
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: 0: dimension size 0 is invalid, the supporting dimension size must be between 2 ~ 65536"),
+				err: errors.New("invalid critical option, name: dimension, val: 0: dimension size 0 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(maxDim)),
 			},
 		},
 		{
@@ -348,9 +350,9 @@ func TestWithDimension(t *testing.T) {
 			},
 		},
 		{
-			name: "set success when the size is 65536",
+			name: "set success when the size is maxDim",
 			args: args{
-				size: 65536,
+				size: 1<<32 - 1,
 			},
 			want: want{
 				obj: &T{},
@@ -363,7 +365,7 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: 1: dimension size 1 is invalid, the supporting dimension size must be between 2 ~ 65536"),
+				err: errors.New("invalid critical option, name: dimension, val: 1: dimension size 1 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(maxDim)),
 			},
 		},
 		{
@@ -373,27 +375,34 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: -100: dimension size -100 is invalid, the supporting dimension size must be between 2 ~ 65536"),
+				err: errors.New("invalid critical option, name: dimension, val: -100: dimension size -100 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(maxDim)),
 			},
 		},
 		{
-			name: "return error when the size is 65537",
+			name: "return error when the size is larger than maxDim",
 			args: args{
-				size: 65537,
+				size: 1 << 32,
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: 65537: dimension size 65537 is invalid, the supporting dimension size must be between 2 ~ 65536"),
+				err: errors.New("invalid critical option, name: dimension, val: 4294967296: dimension size 4294967296 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(maxDim)),
 			},
 		},
 		{
-			name: "return error when the size is MaxInt32",
+			name: "set success when the size is MaxInt32",
 			args: args{
 				size: math.MaxInt32,
 			},
 			want: want{
-				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: 2147483647: dimension size 2147483647 is invalid, the supporting dimension size must be between 2 ~ 65536"),
+				obj: func() *T {
+					t := &T{
+						dimension: math.MaxInt32,
+					}
+					if err := t.setup(); err != nil {
+						return nil
+					}
+					return t
+				}(),
 			},
 		},
 		{
@@ -403,7 +412,7 @@ func TestWithDimension(t *testing.T) {
 			},
 			want: want{
 				obj: &T{},
-				err: errors.New("invalid critical option, name: dimension, val: -2147483648: dimension size -2147483648 is invalid, the supporting dimension size must be between 2 ~ 65536"),
+				err: errors.New("invalid critical option, name: dimension, val: -2147483648: dimension size -2147483648 is invalid, the supporting dimension size must be between 2 ~ " + strconv.Itoa(maxDim)),
 			},
 		},
 	}

--- a/internal/net/control/control_darwin.go
+++ b/internal/net/control/control_darwin.go
@@ -1,4 +1,3 @@
-//go:build darwin && !linux && !windows && !wasm && !js
 // +build darwin,!linux,!windows,!wasm,!js
 
 //

--- a/internal/net/control/control_other.go
+++ b/internal/net/control/control_other.go
@@ -1,4 +1,3 @@
-//go:build wasm && js && !windows && !linux && !darwin
 // +build wasm,js,!windows,!linux,!darwin
 
 //

--- a/internal/net/control/control_unix.go
+++ b/internal/net/control/control_unix.go
@@ -1,4 +1,3 @@
-//go:build linux && !windows && !wasm && !js && !darwin
 // +build linux,!windows,!wasm,!js,!darwin
 
 //

--- a/internal/net/control/control_windows.go
+++ b/internal/net/control/control_windows.go
@@ -1,4 +1,3 @@
-//go:build windows
 // +build windows
 
 //

--- a/internal/runner/runner_race_test.go
+++ b/internal/runner/runner_race_test.go
@@ -1,4 +1,3 @@
-//go:build !race
 // +build !race
 
 //

--- a/internal/singleflight/singleflight_test.go
+++ b/internal/singleflight/singleflight_test.go
@@ -1,4 +1,3 @@
-//go:build !race
 // +build !race
 
 //

--- a/internal/timeutil/location/set_test.go
+++ b/internal/timeutil/location/set_test.go
@@ -1,4 +1,3 @@
-//go:build !race
 // +build !race
 
 //

--- a/tests/e2e/crud/crud_test.go
+++ b/tests/e2e/crud/crud_test.go
@@ -1,4 +1,3 @@
-//go:build e2e
 // +build e2e
 
 //

--- a/tests/e2e/hdf5/hdf5.go
+++ b/tests/e2e/hdf5/hdf5.go
@@ -1,4 +1,3 @@
-//go:build e2e
 // +build e2e
 
 //

--- a/tests/e2e/kubernetes/client/client.go
+++ b/tests/e2e/kubernetes/client/client.go
@@ -1,4 +1,3 @@
-//go:build e2e
 // +build e2e
 
 //

--- a/tests/e2e/kubernetes/portforward/portforward.go
+++ b/tests/e2e/kubernetes/portforward/portforward.go
@@ -1,4 +1,3 @@
-//go:build e2e
 // +build e2e
 
 //

--- a/tests/e2e/multiapis/multiapis_test.go
+++ b/tests/e2e/multiapis/multiapis_test.go
@@ -1,4 +1,3 @@
-//go:build e2e
 // +build e2e
 
 //

--- a/tests/e2e/operation/doc.go
+++ b/tests/e2e/operation/doc.go
@@ -1,4 +1,3 @@
-//go:build e2e
 // +build e2e
 
 //

--- a/tests/e2e/operation/multi.go
+++ b/tests/e2e/operation/multi.go
@@ -1,4 +1,3 @@
-//go:build e2e
 // +build e2e
 
 //

--- a/tests/e2e/operation/operation.go
+++ b/tests/e2e/operation/operation.go
@@ -1,4 +1,3 @@
-//go:build e2e
 // +build e2e
 
 //

--- a/tests/e2e/operation/stream.go
+++ b/tests/e2e/operation/stream.go
@@ -1,4 +1,3 @@
-//go:build e2e
 // +build e2e
 
 //

--- a/tests/e2e/sidecar/sidecar_test.go
+++ b/tests/e2e/sidecar/sidecar_test.go
@@ -1,4 +1,3 @@
-//go:build e2e
 // +build e2e
 
 //

--- a/tests/performance/max_vector_dim_test.go
+++ b/tests/performance/max_vector_dim_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright (C) 2019-2022 vdaas.org vald team <vald@vdaas.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package performance
 
 import (

--- a/tests/performance/max_vector_dim_test.go
+++ b/tests/performance/max_vector_dim_test.go
@@ -1,0 +1,280 @@
+package performance
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vdaas/vald/apis/grpc/v1/payload"
+	"github.com/vdaas/vald/internal/config"
+	"github.com/vdaas/vald/internal/core/algorithm/ngt"
+	"github.com/vdaas/vald/internal/errgroup"
+	"github.com/vdaas/vald/internal/errors"
+	"github.com/vdaas/vald/internal/test/data/vector"
+	"github.com/vdaas/vald/pkg/agent/core/ngt/handler/grpc"
+	"github.com/vdaas/vald/pkg/agent/core/ngt/service"
+)
+
+const (
+	maxBit               = 32
+	ngtMaxDimensionLimit = 1<<32 - 1 // internal/core/algorithm/ngt/ngt.go#ngtVectorDimensionLimit
+	freeMemLimit         = 500       // Limit of free memory remaining(MB)
+)
+
+func init_ngt_service(dim int) (service.NGT, error) {
+	cfg := &config.NGT{
+		Dimension:              dim,
+		DistanceType:           ngt.L2.String(),
+		ObjectType:             ngt.Float.String(),
+		EnableInMemoryMode:     true,
+		AutoIndexDurationLimit: "96h",
+		AutoIndexCheckDuration: "96h",
+		AutoSaveIndexDuration:  "96h",
+		AutoIndexLength:        10000000000,
+		KVSDB: &config.KVSDB{
+			Concurrency: 1,
+		},
+		VQueue: &config.VQueue{
+			InsertBufferPoolSize: 100,
+			DeleteBufferPoolSize: 100,
+		},
+	}
+	ngt, err := service.New(cfg.Bind())
+	if err != nil {
+		return nil, err
+	}
+	return ngt, nil
+}
+
+func parse(raw string) (key string, value int) {
+	text := strings.ReplaceAll(raw[:len(raw)-2], " ", "")
+	keyValue := strings.Split(text, ":")
+	val := 0
+	if keyValue[1] != "" {
+		val, err := strconv.Atoi(keyValue[1])
+		if err != nil {
+			panic(err)
+		}
+		return keyValue[0], val
+	}
+	return keyValue[0], val
+}
+
+// Test for investigation of max dimension size for agent handler
+func TestMaxDimInsert(t *testing.T) {
+	t.Helper()
+	eg, ctx := errgroup.New(context.Background())
+	mu := sync.Mutex{}
+	// Get the above the limit of bit (2~32)
+	bits := make([]int, 0, maxBit-1)
+	ticker := time.NewTicker(5 * time.Second)
+	eg.Go(func() error {
+		for {
+			select {
+			case <-ctx.Done():
+				if ok := mu.TryLock(); !ok {
+					mu.Unlock()
+				}
+				return nil
+			case <-ticker.C:
+				f, err := os.Open("/proc/meminfo")
+				if err != nil {
+					panic(err)
+				}
+				bufio.NewScanner(f)
+				scanner := bufio.NewScanner(f)
+				var MemFree int
+				for scanner.Scan() {
+					key, value := parse(scanner.Text())
+					switch key {
+					case "MemFree":
+						MemFree = value
+					}
+				}
+				err = f.Close()
+				if err != nil {
+					panic(err)
+				}
+				if MemFree/1024 < freeMemLimit {
+					t.Logf("MemFree reaches the limit: current : %dMb, limit : %dMb", MemFree/1024, freeMemLimit)
+					return errors.New("Memory Limit")
+				}
+			}
+		}
+	})
+	eg.Go(func() error {
+		for bit := 2; bit <= maxBit; bit++ {
+			select {
+			case <-ctx.Done():
+				t.Log("canceld")
+				return nil
+			default:
+				dim := 1 << bit
+				if bit == maxBit {
+					dim--
+				}
+				t.Logf("Start test: dimension = %d (bit = %d)", dim, bit)
+				ngt, err := init_ngt_service(dim)
+				time.Sleep(100 * time.Millisecond)
+				if err != nil {
+					t.Errorf("[Fail] Create NGT service: %#v", err)
+					return err
+				}
+				vec := vector.GaussianDistributedFloat32VectorGenerator(1, dim)[0]
+				err = ngt.Insert(strconv.Itoa(dim), vec)
+				if err != nil {
+					t.Errorf("Insert error: %#v", err)
+					return err
+				}
+				t.Logf("Insert is finished: dimension = %d (bit = %d)", dim, bit)
+				err = ngt.CreateIndex(ctx, 10)
+				if err != nil {
+					t.Errorf("CreateIndex is failed: %#v", err)
+					return err
+				}
+				t.Logf("CreateIndex is finished: dimension = %d (bit = %d)", dim, bit)
+				err = ngt.Close(ctx)
+				if err != nil {
+					t.Errorf("NGT close error: %#v", err)
+					return err
+				}
+				mu.Lock()
+				bits = append(bits, bit)
+				mu.Unlock()
+				t.Logf("All processes are finished: dimension = %d (bit = %d)", dim, bit)
+			}
+			t.Log("Wait for memory release")
+			time.Sleep(30 * time.Second)
+		}
+		return nil
+	})
+	eg.Wait()
+	// Get the max bit, which the environment finish process, from bits
+	var max_bit int
+	for _, v := range bits {
+		if max_bit < v {
+			max_bit = v
+		}
+	}
+	t.Logf("Max bit is %d", max_bit)
+}
+
+// Test for investigation of max dimension size for agent handler with gRPC
+func TestMaxDimInsertGRPC(t *testing.T) {
+	// MaxUint64 cannot be used due to overflows
+	t.Helper()
+	eg, ctx := errgroup.New(context.Background())
+	mu := sync.Mutex{}
+	// Get the above the limit of bit (2~32)
+	bits := make([]int, 0, maxBit-1)
+	ticker := time.NewTicker(5 * time.Second)
+	eg.Go(func() error {
+		for {
+			select {
+			case <-ctx.Done():
+				if ok := mu.TryLock(); !ok {
+					mu.Unlock()
+				}
+				return nil
+			case <-ticker.C:
+				f, err := os.Open("/proc/meminfo")
+				if err != nil {
+					panic(err)
+				}
+				bufio.NewScanner(f)
+				scanner := bufio.NewScanner(f)
+				var MemFree int
+				for scanner.Scan() {
+					key, value := parse(scanner.Text())
+					switch key {
+					case "MemFree":
+						MemFree = value
+					}
+				}
+				err = f.Close()
+				if err != nil {
+					panic(err)
+				}
+				if MemFree/1024 < freeMemLimit {
+					t.Logf("MemFree reaches the limit: current : %dMb, limit : %dMb", MemFree/1024, freeMemLimit)
+					return errors.New("Memory Limit")
+				}
+			}
+		}
+	})
+	eg.Go(func() error {
+		for bit := 2; bit <= maxBit; bit++ {
+			select {
+			case <-ctx.Done():
+				t.Log("canceld")
+				return nil
+			default:
+				dim := 1 << bit
+				if bit == maxBit {
+					dim--
+				}
+				t.Logf("Start test: dimension = %d (bit = %d)", dim, bit)
+				ngt, err := init_ngt_service(dim)
+				time.Sleep(100 * time.Millisecond)
+				if err != nil {
+					t.Errorf("[Fail] Create NGT service: %#v", err)
+					return err
+				}
+				s, err := grpc.New(grpc.WithNGT(ngt))
+				if err != nil {
+					t.Errorf("[Error] Failed to create grpc service: %#v", s)
+					return err
+				}
+				vec := vector.GaussianDistributedFloat32VectorGenerator(1, dim)[0]
+				req := &payload.Insert_Request{
+					Vector: &payload.Object_Vector{
+						Id:     strconv.Itoa(dim),
+						Vector: vec,
+					},
+					Config: &payload.Insert_Config{
+						SkipStrictExistCheck: false,
+					},
+				}
+				_, err = s.Insert(ctx, req)
+				if err != nil {
+					t.Errorf("[Error] Failed to Insert Vector (Dim = %d): %#v", dim, err)
+					return err
+				}
+				t.Logf("Insert is finished: dimension = %d (bit = %d)", dim, bit)
+				_, err = s.CreateIndex(ctx, &payload.Control_CreateIndexRequest{
+					PoolSize: 10,
+				})
+				if err != nil {
+					t.Errorf("CreateIndex is failed: %#v", err)
+					return err
+				}
+				t.Logf("CreateIndex is finished: dimension = %d (bit = %d)", dim, bit)
+				err = ngt.Close(ctx)
+				if err != nil {
+					return err
+				}
+				mu.Lock()
+				bits = append(bits, bit)
+				mu.Unlock()
+				t.Logf("All processes are finished: dimension = %d (bit = %d)", dim, bit)
+			}
+			t.Log("Wait for memory release")
+			time.Sleep(30 * time.Second)
+		}
+		return nil
+	})
+	eg.Wait()
+	// Get the max bit, which the environment finish process, from bits
+	var max_bit int
+	for _, v := range bits {
+		if max_bit < v {
+			max_bit = v
+		}
+	}
+	t.Logf("Max bit is %d", max_bit)
+}

--- a/tests/performance/max_vector_dim_test.go
+++ b/tests/performance/max_vector_dim_test.go
@@ -21,9 +21,8 @@ import (
 )
 
 const (
-	maxBit               = 32
-	ngtMaxDimensionLimit = 1<<32 - 1 // internal/core/algorithm/ngt/ngt.go#ngtVectorDimensionLimit
-	freeMemLimit         = 500       // Limit of free memory remaining(MB)
+	maxBit       = 32
+	freeMemLimit = 500 // Limit of free memory remaining(MB)
 )
 
 func init_ngt_service(dim int) (service.NGT, error) {
@@ -117,6 +116,9 @@ func TestMaxDimInsert(t *testing.T) {
 				dim := 1 << bit
 				if bit == maxBit {
 					dim--
+				}
+				if dim > ngt.NgtVectorDimensionSizeLimit {
+					t.Fatal(errors.ErrInvalidDimensionSize(dim, ngt.NgtVectorDimensionSizeLimit))
 				}
 				t.Logf("Start test: dimension = %d (bit = %d)", dim, bit)
 				ngt, err := init_ngt_service(dim)
@@ -217,6 +219,9 @@ func TestMaxDimInsertGRPC(t *testing.T) {
 				dim := 1 << bit
 				if bit == maxBit {
 					dim--
+				}
+				if dim > ngt.NgtVectorDimensionSizeLimit {
+					t.Fatal(errors.ErrInvalidDimensionSize(dim, ngt.NgtVectorDimensionSizeLimit))
 				}
 				t.Logf("Start test: dimension = %d (bit = %d)", dim, bit)
 				ngt, err := init_ngt_service(dim)

--- a/tests/performance/max_vector_dim_test.go
+++ b/tests/performance/max_vector_dim_test.go
@@ -117,8 +117,8 @@ func TestMaxDimInsert(t *testing.T) {
 				if bit == maxBit {
 					dim--
 				}
-				if dim > ngt.NgtVectorDimensionSizeLimit {
-					t.Fatal(errors.ErrInvalidDimensionSize(dim, ngt.NgtVectorDimensionSizeLimit))
+				if dim > ngt.VectorDimensionSizeLimit {
+					t.Fatal(errors.ErrInvalidDimensionSize(dim, ngt.VectorDimensionSizeLimit))
 				}
 				t.Logf("Start test: dimension = %d (bit = %d)", dim, bit)
 				ngt, err := init_ngt_service(dim)
@@ -220,8 +220,8 @@ func TestMaxDimInsertGRPC(t *testing.T) {
 				if bit == maxBit {
 					dim--
 				}
-				if dim > ngt.NgtVectorDimensionSizeLimit {
-					t.Fatal(errors.ErrInvalidDimensionSize(dim, ngt.NgtVectorDimensionSizeLimit))
+				if dim > ngt.VectorDimensionSizeLimit {
+					t.Fatal(errors.ErrInvalidDimensionSize(dim, ngt.VectorDimensionSizeLimit))
 				}
 				t.Logf("Start test: dimension = %d (bit = %d)", dim, bit)
 				ngt, err := init_ngt_service(dim)


### PR DESCRIPTION
Signed-off-by: vankichi <kyukawa315@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
I implemented the test for investigating the max dimension limit of `vald-agent-ngt` in any environment.
NGT can handle up to the `1 << 32 -1` dimension, but the real max dimension may not be the same depending on the environment.
This test can get the real max dimension for any environment.
For the time being, I set the limit of remaining free memory as 500MB to avoid such OOM kill or memory leak.
When the remaining free memory becomes 500MB or less, the test will finish and we can get the max bit in the environment.
In my environment (32GB Mem and free memory at the beginning is about 24GB), both results (max bit) are`29` bit.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.18.1
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.3

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
