### PR TITLE
[bugfix] return NotFound error when delete fails in multiUpdate

### DIFF
--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -1230,8 +1230,8 @@ func (n *ngt) readyForUpdate(uuid string, vec []float32) (err error) {
 	if err != nil {
 		return err
 	}
+	// if vector length is not equal or if some difference exists let's try update
 	if len(vec) != len(ovec) || conv.F32stos(vec) != conv.F32stos(ovec) {
-	// if vector length is not equal or if difference exists let's try update
 		return nil
 	}
 	// if no difference exists (same vector already exists) return error for skip update

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -1231,6 +1231,7 @@ func (n *ngt) readyForUpdate(uuid string, vec []float32) (err error) {
 		return err
 	}
 	if len(vec) != len(ovec) || conv.F32stos(vec) != conv.F32stos(ovec) {
+	// if vector length is not equal or if difference exists let's try update
 		return nil
 	}
 	// if no difference exists (same vector already exists) return error for skip update

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -760,7 +760,7 @@ func (n *ngt) updateMultiple(vecs map[string][]float32, t int64) (err error) {
 			uuids = append(uuids, uuid)
 		}
 	}
-	err = n.deleteMultiple(uuids, t, false)
+	err = n.deleteMultiple(uuids, t, true) // `true` is to return NotFound error with non-existent ID
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -1226,10 +1226,11 @@ func (n *ngt) readyForUpdate(uuid string, vec []float32) (err error) {
 		return errors.ErrInvalidDimensionSize(len(vec), n.GetDimensionSize())
 	}
 	ovec, err := n.GetObject(uuid)
-	if err != nil ||
-		len(vec) != len(ovec) ||
-		conv.F32stos(vec) != conv.F32stos(ovec) {
-		// if error (GetObject cannot find vector) or vector length is not equal or if difference exists let's try update
+	// if error (GetObject cannot find vector) return error
+	if err != nil {
+		return err
+	}
+	if len(vec) != len(ovec) || conv.F32stos(vec) != conv.F32stos(ovec) {
 		return nil
 	}
 	// if no difference exists (same vector already exists) return error for skip update


### PR DESCRIPTION
Signed-off-by: vankichi <kyukawa315@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!--- Describe your changes in detail -->
The delete index function runs in the `multiUpdate`, but it does not return `NotFound` error when the index does not exist in `pkg/agent/core/ngt` layer.
It affects when vald agent standalone.
This PR changes the flag validation as true to return `NotFound` error.

In addition, I have fixed the `readyForUpdate` method.
When the error occurs in `GetObject()`, which `readyForUpdate` calls, `readyForUpdate` returns error.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.18.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.5

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
