### PR TITLE
Fix to get only backoff metrics of discover RPC

### DIFF
--- a/internal/client/v1/client/discoverer/discover.go
+++ b/internal/client/v1/client/discoverer/discover.go
@@ -329,7 +329,10 @@ func (c *client) discoverAddrs(ctx context.Context, nodes *payload.Info_Nodes, e
 }
 
 func (c *client) disconnectOldAddrs(ctx context.Context, oldAddrs, connectedAddrs []string, ech chan<- error) (err error) {
-	var cur *sync.Map
+	if !c.autoconn {
+		return nil
+	}
+	var cur sync.Map
 	for _, addr := range connectedAddrs {
 		cur.Store(addr, struct{}{})
 	}
@@ -346,7 +349,7 @@ func (c *client) disconnectOldAddrs(ctx context.Context, oldAddrs, connectedAddr
 			}))
 		}
 	}
-	if c.autoconn && c.client != nil {
+	if c.client != nil {
 		if err = c.client.RangeConcurrent(ctx, len(connectedAddrs)/3, func(ctx context.Context,
 			addr string,
 			conn *grpc.ClientConn,

--- a/internal/client/v1/client/discoverer/discover.go
+++ b/internal/client/v1/client/discoverer/discover.go
@@ -304,10 +304,8 @@ func (c *client) discoverAddrs(ctx context.Context, nodes *payload.Info_Nodes, e
 			case <-ctx.Done():
 				return nil, ctx.Err()
 			default:
-				if node != nil && node.GetPods() != nil {
-					pods := node.GetPods().GetPods()
-					if i < len(pods) {
-						addr := net.JoinHostPort(pods[i].GetIp(), uint16(c.port))
+				if node != nil && node.GetPods() != nil && len(node.GetPods().GetPods()) > i {
+					addr := net.JoinHostPort(node.GetPods().GetPods()[i].GetIp(), uint16(c.port))
 						if err = c.connect(ctx, addr); err != nil {
 							err = errors.ErrAddrCouldNotDiscover(err, addr)
 							select {

--- a/internal/client/v1/client/discoverer/discover.go
+++ b/internal/client/v1/client/discoverer/discover.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/vdaas/vald/apis/grpc/v1/discoverer"
 	"github.com/vdaas/vald/apis/grpc/v1/payload"
+	"github.com/vdaas/vald/internal/backoff"
 	"github.com/vdaas/vald/internal/errgroup"
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/log"
@@ -48,6 +49,7 @@ type client struct {
 	client       grpc.Client
 	dns          string
 	opts         []grpc.Option
+	bo           backoff.Backoff
 	port         int
 	addrs        atomic.Value
 	dscClient    grpc.Client
@@ -218,16 +220,60 @@ func (c *client) dnsDiscovery(ctx context.Context, ech chan<- error) (addrs []st
 }
 
 func (c *client) discover(ctx context.Context, ech chan<- error) (err error) {
-	if c.dscClient == nil || (c.autoconn && c.client == nil) {
-		return errors.ErrGRPCClientNotFound
-	}
 	connected := make([]string, 0, len(c.GetAddrs(ctx)))
-	var cur sync.Map
-	if _, err = c.dscClient.RoundRobin(grpc.WithGRPCMethod(ctx, "discoverer.v1.Discoverer/Nodes"), func(ictx context.Context,
+	cur := new(sync.Map)
+	_, err = c.bo.Do(ctx, func(ctx context.Context) (interface{}, bool, error) {
+		nodes, err := c.discoverNodes(ctx)
+		if err != nil {
+			return nil, true, err
+		}
+		connected, err = c.discoverAddrs(ctx, nodes, ech)
+		if err != nil {
+			return nil, true, err
+		}
+		if len(connected) == 0 {
+			log.Warn("connected addr is zero")
+			cur = new(sync.Map)
+			return nil, true, errors.ErrAddrCouldNotDiscover(err, c.dns)
+		}
+		if c.onDiscover != nil {
+			err = c.onDiscover(ctx, c, connected)
+			if err != nil {
+				cur = new(sync.Map)
+				return nil, true, err
+			}
+		}
+		if c.autoconn {
+			for _, addr := range connected {
+				cur.Store(addr, struct{}{})
+			}
+		}
+		return nil, false, nil
+	})
+	if err != nil {
+		log.Warn("failed to discover addrs from discoverer API, trying to discover from dns...\t" + err.Error())
+		connected, err = c.dnsDiscovery(ctx, ech)
+		if err != nil {
+			return err
+		}
+		if c.autoconn {
+			cur = new(sync.Map)
+			for _, addr := range connected {
+				cur.Store(addr, struct{}{})
+			}
+		}
+	}
+	oldAddrs := c.GetAddrs(ctx)
+	c.addrs.Store(connected)
+	return c.disconnectOldAddrs(ctx, oldAddrs, cur, len(connected)/3, ech)
+}
+
+func (c *client) discoverNodes(ctx context.Context) (nodes *payload.Info_Nodes, err error) {
+	_, err = c.dscClient.RoundRobin(grpc.WithGRPCMethod(ctx, "discoverer.v1.Discoverer/Nodes"), func(ctx context.Context,
 		conn *grpc.ClientConn, copts ...grpc.CallOption,
 	) (interface{}, error) {
-		nodes, err := discoverer.NewDiscovererClient(conn).
-			Nodes(ictx, &payload.Discoverer_Request{
+		nodes, err = discoverer.NewDiscovererClient(conn).
+			Nodes(ctx, &payload.Discoverer_Request{
 				Namespace: c.namespace,
 				Name:      c.name,
 				Node:      c.nodeName,
@@ -235,83 +281,58 @@ func (c *client) discover(ctx context.Context, ech chan<- error) (err error) {
 		if err != nil {
 			return nil, err
 		}
-		maxPodLen := 0
-		podLength := 0
-		for _, node := range nodes.GetNodes() {
-			l := len(node.GetPods().GetPods())
-			podLength += l
-			if l > maxPodLen {
-				maxPodLen = l
-			}
+		return nodes, nil
+	})
+	return nodes, err
+}
+
+func (c *client) discoverAddrs(ctx context.Context, nodes *payload.Info_Nodes, ech chan<- error) (addrs []string, err error) {
+	maxPodLen := 0
+	podLength := 0
+	for _, node := range nodes.GetNodes() {
+		l := len(node.GetPods().GetPods())
+		podLength += l
+		if l > maxPodLen {
+			maxPodLen = l
 		}
-		addrs := make([]string, 0, podLength)
-		for i := 0; i < maxPodLen; i++ {
-			for _, node := range nodes.GetNodes() {
-				select {
-				case <-ictx.Done():
-					return nil, ictx.Err()
-				default:
-					if node != nil && node.GetPods() != nil {
-						pods := node.GetPods().GetPods()
-						if i < len(pods) {
-							addr := net.JoinHostPort(pods[i].GetIp(), uint16(c.port))
-							if err = c.connect(ctx, addr); err != nil {
-								err = errors.ErrAddrCouldNotDiscover(err, addr)
-								select {
-								case <-ictx.Done():
-									return nil, ictx.Err()
-								case ech <- err:
-								}
-								err = nil
-							} else {
-								if c.autoconn {
-									cur.Store(addr, struct{}{})
-								}
-								addrs = append(addrs, addr)
+	}
+	addrs = make([]string, 0, podLength)
+	for i := 0; i < maxPodLen; i++ {
+		for _, node := range nodes.GetNodes() {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+				if node != nil && node.GetPods() != nil {
+					pods := node.GetPods().GetPods()
+					if i < len(pods) {
+						addr := net.JoinHostPort(pods[i].GetIp(), uint16(c.port))
+						if err = c.connect(ctx, addr); err != nil {
+							err = errors.ErrAddrCouldNotDiscover(err, addr)
+							select {
+							case <-ctx.Done():
+								return nil, ctx.Err()
+							case ech <- err:
 							}
-							break
+							err = nil
+						} else {
+							addrs = append(addrs, addr)
 						}
+						break
 					}
 				}
 			}
 		}
-		connected = addrs
-		if len(connected) == 0 {
-			log.Warn("connected addr is zero")
-			cur = sync.Map{}
-			return nil, errors.ErrAddrCouldNotDiscover(err, c.dns)
-		}
-		if c.onDiscover != nil {
-			err = c.onDiscover(ctx, c, connected)
-			if err != nil {
-				cur = sync.Map{}
-				return nil, err
-			}
-		}
-		return nil, nil
-	}); err != nil {
-		log.Warn("failed to discover addrs from discoverer API, trying to discover from dns...\t" + err.Error())
-		connected, err = c.dnsDiscovery(ctx, ech)
-		if err != nil {
-			return err
-		}
-		if c.autoconn {
-			cur = sync.Map{}
-			for _, addr := range connected {
-				cur.Store(addr, struct{}{})
-			}
-		}
 	}
+	return addrs, nil
+}
 
-	oldAddrs := c.GetAddrs(ctx)
-
-	c.addrs.Store(connected)
-
+func (c *client) disconnectOldAddrs(ctx context.Context, oldAddrs []string, cur *sync.Map, concurrency int, ech chan<- error) (err error) {
 	for _, old := range oldAddrs {
 		_, ok := cur.Load(old)
 		if !ok {
 			c.eg.Go(safety.RecoverFunc(func() error {
-				err = c.disconnect(ctx, old)
+				err := c.disconnect(ctx, old)
 				if err != nil {
 					ech <- err
 				}
@@ -319,9 +340,8 @@ func (c *client) discover(ctx context.Context, ech chan<- error) (err error) {
 			}))
 		}
 	}
-
 	if c.autoconn && c.client != nil {
-		if err = c.client.RangeConcurrent(ctx, len(connected)/3, func(ctx context.Context,
+		if err = c.client.RangeConcurrent(ctx, concurrency, func(ctx context.Context,
 			addr string,
 			conn *grpc.ClientConn,
 			copts ...grpc.CallOption,

--- a/internal/client/v1/client/discoverer/discover.go
+++ b/internal/client/v1/client/discoverer/discover.go
@@ -218,13 +218,12 @@ func (c *client) dnsDiscovery(ctx context.Context, ech chan<- error) (addrs []st
 }
 
 func (c *client) discover(ctx context.Context, ech chan<- error) (err error) {
-	ctx = grpc.WithGRPCMethod(ctx, "discoverer.v1.Discoverer/Nodes")
 	if c.dscClient == nil || (c.autoconn && c.client == nil) {
 		return errors.ErrGRPCClientNotFound
 	}
 	connected := make([]string, 0, len(c.GetAddrs(ctx)))
 	var cur sync.Map
-	if _, err = c.dscClient.RoundRobin(ctx, func(ictx context.Context,
+	if _, err = c.dscClient.RoundRobin(grpc.WithGRPCMethod(ctx, "discoverer.v1.Discoverer/Nodes"), func(ictx context.Context,
 		conn *grpc.ClientConn, copts ...grpc.CallOption,
 	) (interface{}, error) {
 		nodes, err := discoverer.NewDiscovererClient(conn).

--- a/internal/client/v1/client/discoverer/discover.go
+++ b/internal/client/v1/client/discoverer/discover.go
@@ -306,19 +306,18 @@ func (c *client) discoverAddrs(ctx context.Context, nodes *payload.Info_Nodes, e
 			default:
 				if node != nil && node.GetPods() != nil && len(node.GetPods().GetPods()) > i {
 					addr := net.JoinHostPort(node.GetPods().GetPods()[i].GetIp(), uint16(c.port))
-						if err = c.connect(ctx, addr); err != nil {
-							err = errors.ErrAddrCouldNotDiscover(err, addr)
-							select {
-							case <-ctx.Done():
-								return nil, ctx.Err()
-							case ech <- err:
-							}
-							err = nil
-						} else {
-							addrs = append(addrs, addr)
+					if err = c.connect(ctx, addr); err != nil {
+						err = errors.ErrAddrCouldNotDiscover(err, addr)
+						select {
+						case <-ctx.Done():
+							return nil, ctx.Err()
+						case ech <- err:
 						}
-						break
+						err = nil
+					} else {
+						addrs = append(addrs, addr)
 					}
+					break
 				}
 			}
 		}
@@ -339,7 +338,7 @@ func (c *client) disconnectOldAddrs(ctx context.Context, oldAddrs, connectedAddr
 		_, ok := cur.Load(old)
 		if !ok {
 			c.eg.Go(safety.RecoverFunc(func() error {
-				err := c.disconnect(ctx, old)
+				err = c.disconnect(ctx, old)
 				if err != nil {
 					ech <- err
 				}

--- a/internal/client/v1/client/discoverer/option.go
+++ b/internal/client/v1/client/discoverer/option.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/vdaas/vald/internal/backoff"
 	"github.com/vdaas/vald/internal/errgroup"
 	"github.com/vdaas/vald/internal/net/grpc"
 	"github.com/vdaas/vald/internal/timeutil"
@@ -138,6 +139,15 @@ func WithErrGroup(eg errgroup.Group) Option {
 	return func(c *client) error {
 		if eg != nil {
 			c.eg = eg
+		}
+		return nil
+	}
+}
+
+func WithBackoff(bo backoff.Backoff) Option {
+	return func(c *client) error {
+		if bo != nil {
+			c.bo = bo
 		}
 		return nil
 	}

--- a/internal/client/v1/client/discoverer/option.go
+++ b/internal/client/v1/client/discoverer/option.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/vdaas/vald/internal/backoff"
 	"github.com/vdaas/vald/internal/errgroup"
 	"github.com/vdaas/vald/internal/net/grpc"
 	"github.com/vdaas/vald/internal/timeutil"
@@ -139,15 +138,6 @@ func WithErrGroup(eg errgroup.Group) Option {
 	return func(c *client) error {
 		if eg != nil {
 			c.eg = eg
-		}
-		return nil
-	}
-}
-
-func WithBackoff(bo backoff.Backoff) Option {
-	return func(c *client) error {
-		if bo != nil {
-			c.bo = bo
 		}
 		return nil
 	}

--- a/internal/net/grpc/client.go
+++ b/internal/net/grpc/client.go
@@ -467,6 +467,9 @@ func (g *gRPCClient) RoundRobin(ctx context.Context, f func(ctx context.Context,
 		}
 	}()
 	if g.bo != nil && g.atomicAddrs.Len() > 1 {
+		if method := FromGRPCMethod(sctx); len(method) != 0 {
+			sctx = backoff.WithBackoffName(ctx, method)
+		}
 		return g.bo.Do(sctx, func(ictx context.Context) (r interface{}, ret bool, err error) {
 			addr, ok := g.atomicAddrs.Next()
 			if !ok {

--- a/internal/net/grpc/client.go
+++ b/internal/net/grpc/client.go
@@ -85,6 +85,7 @@ type Client interface {
 		copts ...CallOption) (interface{}, error)) (interface{}, error)
 	GetDialOption() []DialOption
 	GetCallOption() []CallOption
+	GetBackoff() backoff.Backoff
 	ConnectedAddrs() []string
 	Close(ctx context.Context) error
 }
@@ -608,6 +609,10 @@ func (g *gRPCClient) GetDialOption() []DialOption {
 
 func (g *gRPCClient) GetCallOption() []CallOption {
 	return g.copts
+}
+
+func (g *gRPCClient) GetBackoff() backoff.Backoff {
+	return g.bo
 }
 
 func (g *gRPCClient) Connect(ctx context.Context, addr string, dopts ...DialOption) (conn pool.Conn, err error) {


### PR DESCRIPTION
### Description:

#### WHAT

I fixed code to get only backoff metrics of discover RPC.

#### WHY

There was a lot of backoff metrics in discover RPC before.
The current implementation included a backoff metrics that is not directly related to the RPC call.

https://github.com/vdaas/vald/blob/master/internal/client/v1/client/discoverer/discover.go#L221


### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.18.3
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.6

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
