### PR TITLE
Different id returned when GetObject RPC and Exists RPC

### DIFF
--- a/pkg/agent/core/ngt/handler/grpc/object.go
+++ b/pkg/agent/core/ngt/handler/grpc/object.go
@@ -18,7 +18,6 @@ package grpc
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/vdaas/vald/apis/grpc/v1/payload"
 	"github.com/vdaas/vald/apis/grpc/v1/vald"
@@ -66,8 +65,7 @@ func (s *server) Exists(ctx context.Context, uid *payload.Object_ID) (res *paylo
 		log.Warn(err)
 		return nil, err
 	}
-	oid, ok := s.ngt.Exists(uuid)
-	if !ok {
+	if _, ok := s.ngt.Exists(uuid); !ok {
 		err = errors.ErrObjectIDNotFound(uid.GetId())
 		err = status.WrapWithNotFound(fmt.Sprintf("Exists API meta %s's uuid not found", uid.GetId()), err,
 			&errdetails.RequestInfo{
@@ -84,9 +82,7 @@ func (s *server) Exists(ctx context.Context, uid *payload.Object_ID) (res *paylo
 		}
 		return nil, err
 	}
-	return &payload.Object_ID{
-		Id: strconv.Itoa(int(oid)),
-	}, nil
+	return uid, nil
 }
 
 func (s *server) GetObject(ctx context.Context, id *payload.Object_VectorRequest) (res *payload.Object_Vector, err error) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

#### WHAT

I fixed GetObject RPC and Exists RPC to return the same type of ID. (uuid)

#### WHY

The different ID type are returned when the user called GetObject RPC and Exists RPC.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.18.3
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.6

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [ ] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
