### PR TITLE
bugfix success handling in the half-open and add flow control

### DIFF
--- a/internal/circuitbreaker/breaker.go
+++ b/internal/circuitbreaker/breaker.go
@@ -106,9 +106,11 @@ func (b *breaker) isReady() (st State, err error) {
 	case StateHalfOpen:
 
 		// For flow control in the "Half-Open" state. It is limited to 50%.
-		// If this modulo is used, 1/2 of the requests will be error.
-		total := b.count.Load().(*count).Total()
-		if total != 0 && total%2 == 0 {
+		// If this modulo is used, 1/2 of the requests will be error. And if an error occurs, mark as failures.
+		cnt := b.count.Load().(*count)
+		total := cnt.Total()
+		if total%2 == 0 {
+			cnt.onFail()
 			return st, errors.ErrCircuitBreakerHalfOpenFlowLimitation
 		}
 	}

--- a/internal/circuitbreaker/breaker.go
+++ b/internal/circuitbreaker/breaker.go
@@ -119,7 +119,7 @@ func (b *breaker) success() {
 	cnt := b.count.Load().(*count)
 	cnt.onSuccess()
 
-	// halfOpenErrShouldTrip.ShouldTrip is true when the sum of the number of successes and failures is greater than the b.minSamples and when the error rate is greater than the b.halfOpenErrRate.
+	// halfOpenErrShouldTrip.ShouldTrip returns true when the sum of the number of successes and failures is greater than the b.minSamples and when the error rate is greater than the b.halfOpenErrRate.
 	// In other words, if the error rate is less than the b.halfOpenErrRate, it can be judged that the success rate is high, so this function change to the "Close" state from "Half-Open".
 	if st := b.currentState(); st == StateHalfOpen && cnt.Total() >= b.minSamples && !b.halfOpenErrShouldTrip.ShouldTrip(cnt) {
 		log.Infof("the operation succeeded, circuit breaker state for '%s' changed,\tfrom: %s, to: %s", b.key, st.String(), StateClosed.String())

--- a/internal/circuitbreaker/breaker.go
+++ b/internal/circuitbreaker/breaker.go
@@ -108,8 +108,7 @@ func (b *breaker) isReady() (st State, err error) {
 		// For flow control in the "Half-Open" state. It is limited to 50%.
 		// If this modulo is used, 1/2 of the requests will be error. And if an error occurs, mark as failures.
 		cnt := b.count.Load().(*count)
-		total := cnt.Total()
-		if total%2 == 0 {
+		if cnt.Total()%2 == 0 {
 			cnt.onFail()
 			return st, errors.ErrCircuitBreakerHalfOpenFlowLimitation
 		}
@@ -123,7 +122,9 @@ func (b *breaker) success() {
 
 	// halfOpenErrShouldTrip.ShouldTrip returns true when the sum of the number of successes and failures is greater than the b.minSamples and when the error rate is greater than the b.halfOpenErrRate.
 	// In other words, if the error rate is less than the b.halfOpenErrRate, it can be judged that the success rate is high, so this function change to the "Close" state from "Half-Open".
-	if st := b.currentState(); st == StateHalfOpen && cnt.Total() >= b.minSamples && !b.halfOpenErrShouldTrip.ShouldTrip(cnt) {
+	if st := b.currentState(); st == StateHalfOpen &&
+		cnt.Total() >= b.minSamples &&
+		!b.halfOpenErrShouldTrip.ShouldTrip(cnt) {
 		log.Infof("the operation succeeded, circuit breaker state for '%s' changed,\tfrom: %s, to: %s", b.key, st.String(), StateClosed.String())
 		b.reset()
 	}

--- a/internal/circuitbreaker/breaker_test.go
+++ b/internal/circuitbreaker/breaker_test.go
@@ -456,7 +456,7 @@ func Test_breaker_success(t *testing.T) {
 			var atCount atomic.Value
 			atCount.Store(&count{
 				successes: 10,
-				failures:  1,
+				failures:  10,
 			})
 			halfOpenErrRate := float32(0.5)
 			minSamples := int64(10)
@@ -483,8 +483,8 @@ func Test_breaker_success(t *testing.T) {
 		func() test {
 			var atCount atomic.Value
 			atCount.Store(&count{
-				successes: 1,
-				failures:  10,
+				successes: 10,
+				failures:  11,
 			})
 			halfOpenErrRate := float32(0.5)
 			minSamples := int64(10)

--- a/internal/circuitbreaker/breaker_test.go
+++ b/internal/circuitbreaker/breaker_test.go
@@ -38,8 +38,8 @@ func Test_newBreaker(t *testing.T) {
 		args       args
 		want       want
 		checkFunc  func(want, *breaker, error) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, got *breaker, err error) error {
 		if !errors.Is(err, w.err) {
@@ -61,6 +61,12 @@ func Test_newBreaker(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -75,6 +81,12 @@ func Test_newBreaker(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -86,10 +98,10 @@ func Test_newBreaker(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -134,8 +146,8 @@ func Test_breaker_do(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, interface{}, State, error) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, gotVal interface{}, gotSt State, err error) error {
 		if !errors.Is(err, w.err) {
@@ -174,6 +186,12 @@ func Test_breaker_do(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -202,6 +220,12 @@ func Test_breaker_do(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -213,10 +237,10 @@ func Test_breaker_do(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -261,17 +285,25 @@ func Test_breaker_isReady(t *testing.T) {
 		closedRefreshExp      int64
 	}
 	type want struct {
+		wantSt State
 		wantOk bool
+		err    error
 	}
 	type test struct {
 		name       string
 		fields     fields
 		want       want
-		checkFunc  func(want, bool) error
-		beforeFunc func()
-		afterFunc  func()
+		checkFunc  func(want, State, bool, error) error
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
-	defaultCheckFunc := func(w want, gotOk bool) error {
+	defaultCheckFunc := func(w want, gotSt State, gotOk bool, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		if !reflect.DeepEqual(gotSt, w.wantSt) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", gotSt, w.wantSt)
+		}
 		if !reflect.DeepEqual(gotOk, w.wantOk) {
 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", gotOk, w.wantOk)
 		}
@@ -298,6 +330,12 @@ func Test_breaker_isReady(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -322,6 +360,12 @@ func Test_breaker_isReady(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -333,10 +377,10 @@ func Test_breaker_isReady(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -357,8 +401,8 @@ func Test_breaker_isReady(t *testing.T) {
 				closedRefreshExp:      test.fields.closedRefreshExp,
 			}
 
-			gotOk := b.isReady()
-			if err := checkFunc(test.want, gotOk); err != nil {
+			gotSt, gotOk, err := b.isReady()
+			if err := checkFunc(test.want, gotSt, gotOk, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
 		})
@@ -386,8 +430,8 @@ func Test_breaker_success(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -413,6 +457,12 @@ func Test_breaker_success(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -437,6 +487,12 @@ func Test_breaker_success(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -448,10 +504,10 @@ func Test_breaker_success(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -501,8 +557,8 @@ func Test_breaker_fail(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -528,6 +584,12 @@ func Test_breaker_fail(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -552,6 +614,12 @@ func Test_breaker_fail(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -563,10 +631,10 @@ func Test_breaker_fail(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -618,8 +686,8 @@ func Test_breaker_currentState(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, State) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, got State) error {
 		if !reflect.DeepEqual(got, w.want) {
@@ -648,6 +716,12 @@ func Test_breaker_currentState(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -672,6 +746,12 @@ func Test_breaker_currentState(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -683,10 +763,10 @@ func Test_breaker_currentState(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -736,8 +816,8 @@ func Test_breaker_reset(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -763,6 +843,12 @@ func Test_breaker_reset(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -787,6 +873,12 @@ func Test_breaker_reset(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -798,10 +890,10 @@ func Test_breaker_reset(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -851,8 +943,8 @@ func Test_breaker_trip(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -878,6 +970,12 @@ func Test_breaker_trip(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -902,6 +1000,12 @@ func Test_breaker_trip(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -913,10 +1017,10 @@ func Test_breaker_trip(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -968,8 +1072,8 @@ func Test_breaker_isTripped(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, bool) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, gotOk bool) error {
 		if !reflect.DeepEqual(gotOk, w.wantOk) {
@@ -998,6 +1102,12 @@ func Test_breaker_isTripped(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -1022,6 +1132,12 @@ func Test_breaker_isTripped(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1033,10 +1149,10 @@ func Test_breaker_isTripped(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {

--- a/internal/circuitbreaker/breaker_test.go
+++ b/internal/circuitbreaker/breaker_test.go
@@ -286,26 +286,22 @@ func Test_breaker_isReady(t *testing.T) {
 	}
 	type want struct {
 		wantSt State
-		wantOk bool
 		err    error
 	}
 	type test struct {
 		name       string
 		fields     fields
 		want       want
-		checkFunc  func(want, State, bool, error) error
+		checkFunc  func(want, State, error) error
 		beforeFunc func(*testing.T)
 		afterFunc  func(*testing.T)
 	}
-	defaultCheckFunc := func(w want, gotSt State, gotOk bool, err error) error {
+	defaultCheckFunc := func(w want, gotSt State, err error) error {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 		}
 		if !reflect.DeepEqual(gotSt, w.wantSt) {
 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", gotSt, w.wantSt)
-		}
-		if !reflect.DeepEqual(gotOk, w.wantOk) {
-			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", gotOk, w.wantOk)
 		}
 		return nil
 	}
@@ -401,8 +397,8 @@ func Test_breaker_isReady(t *testing.T) {
 				closedRefreshExp:      test.fields.closedRefreshExp,
 			}
 
-			gotSt, gotOk, err := b.isReady()
-			if err := checkFunc(test.want, gotSt, gotOk, err); err != nil {
+			gotSt, err := b.isReady()
+			if err := checkFunc(test.want, gotSt, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
 		})

--- a/internal/circuitbreaker/counter.go
+++ b/internal/circuitbreaker/counter.go
@@ -16,6 +16,7 @@ package circuitbreaker
 import "sync/atomic"
 
 type Counter interface {
+	Total() int64
 	Successes() int64
 	Fails() int64
 }
@@ -31,6 +32,10 @@ func (c *count) Successes() (n int64) {
 
 func (c *count) Fails() (n int64) {
 	return atomic.LoadInt64(&c.failures)
+}
+
+func (c *count) Total() (n int64) {
+	return c.Successes() + c.Fails()
 }
 
 func (c *count) onSuccess() {

--- a/internal/errors/circuitbreaker.go
+++ b/internal/errors/circuitbreaker.go
@@ -18,8 +18,8 @@ import (
 )
 
 var (
-	// ErrCircuitBreakerTooManyRequests is returned when the CB state is half open and the requests count is over the cb maxRequests.
-	ErrCircuitBreakerTooManyRequests = errors.New("too many requests")
+	// ErrCircuitBreakerHalfOpenFlowLimitation is returned in case of flow limitation in half-open state.
+	ErrCircuitBreakerHalfOpenFlowLimitation = errors.New("circuitbreaker breaker half-open flow limitation")
 	// ErrCircuitBreakerOpenState is returned when the CB state is open.
 	ErrCircuitBreakerOpenState = errors.New("circuit breaker is open")
 )


### PR DESCRIPTION

### Description:

### WHAT

As titled

### WHY

The rate is not being used properly because the state is being changed immediately on success at half-open. Also, there is no function to limit the flow rate at half-open, so this should be added.

### Related Issue:

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### How Has This Been Tested?:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Environment:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.1
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Types of changes:

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix [type/bug]
- [ ] New feature [type/feature]
- [x] Add tests [type/test]
- [ ] Security related changes [type/security]
- [ ] Add documents [type/documentation]
- [ ] Refactoring [type/refactoring]
- [ ] Update dependencies [type/dependency]
- [ ] Update benchmarks and performances [type/bench]
- [ ] Update CI [type/ci]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document.
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?
- [ ] I have added tests and benchmarks to cover my changes.
- [ ] I have ensured all new and existing tests passed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly.
