### PR TITLE
fix deepsource: Audit required: Insecure gRPC server

### DIFF
--- a/internal/net/grpc/pool/pool_bench_test.go
+++ b/internal/net/grpc/pool/pool_bench_test.go
@@ -64,6 +64,7 @@ func ListenAndServe(b *testing.B, addr string) func() {
 		b.Error(err)
 	}
 
+	// skipcq: GO-S0902
 	s := grpc.NewServer()
 	discoverer.RegisterDiscovererServer(s, new(server))
 

--- a/internal/net/grpc/server.go
+++ b/internal/net/grpc/server.go
@@ -45,6 +45,7 @@ var ErrServerStopped = grpc.ErrServerStopped
 
 // NewServer returns the gRPC server.
 func NewServer(opts ...ServerOption) *Server {
+	// skipcq: GO-S0902
 	return grpc.NewServer(opts...)
 }
 

--- a/internal/net/grpc/server_test.go
+++ b/internal/net/grpc/server_test.go
@@ -70,6 +70,7 @@ func TestNewServer(t *testing.T) {
 				opts: nil,
 			},
 			want: want{
+				// skipcq: GO-S0902
 				want: grpc.NewServer(),
 			},
 		},
@@ -79,6 +80,7 @@ func TestNewServer(t *testing.T) {
 				opts: []ServerOption{MaxSendMsgSize(100)},
 			},
 			want: want{
+				// skipcq: GO-S0902
 				want: grpc.NewServer(),
 			},
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
Ignore this rule.

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
