### PR TITLE
fix deepsource: Unsafe defer of os.Close

### DIFF
--- a/hack/benchmark/src/singleflight/singleflight_bench_test.go
+++ b/hack/benchmark/src/singleflight/singleflight_bench_test.go
@@ -266,7 +266,6 @@ func toCSV(name string, r []Result) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 	_, err = fmt.Fprintln(f, "goroutine,duration,hit_rate")
 	if err != nil {
 		return err
@@ -277,5 +276,5 @@ func toCSV(name string, r []Result) error {
 			return err
 		}
 	}
-	return nil
+	return f.Close()
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
SSIA

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
