### PR TITLE
Fix deepsource: RVV-A0003 exit inside non-main function

### DIFF
--- a/hack/license/gen/main.go
+++ b/hack/license/gen/main.go
@@ -69,12 +69,14 @@ const (
 func main() {
 	log.Init()
 	if len(os.Args) < minimumArgumentLength {
+		// skipcq: RVV-A0003
 		log.Fatal(errors.New("invalid argument"))
 	}
 	for _, path := range dirwalk(os.Args[1]) {
 		fmt.Println(path)
 		err := readAndRewrite(path)
 		if err != nil {
+			// skipcq: RVV-A0003
 			log.Fatal(err)
 		}
 	}
@@ -165,6 +167,7 @@ func readAndRewrite(path string) error {
 	if err != nil {
 		err = f.Close()
 		if err != nil {
+			// skipcq: RVV-A0003
 			log.Fatal(err)
 		}
 		return errors.Errorf("filepath %s, could not open", path)
@@ -182,6 +185,7 @@ func readAndRewrite(path string) error {
 	if fi.Name() == "LICENSE" {
 		err = license.Execute(buf, d)
 		if err != nil {
+			// skipcq: RVV-A0003
 			log.Fatal(err)
 		}
 	} else {
@@ -200,14 +204,17 @@ func readAndRewrite(path string) error {
 				bf = true
 				_, err = buf.WriteString(line)
 				if err != nil {
+					// skipcq: RVV-A0003
 					log.Fatal(err)
 				}
 				_, err = buf.WriteString("\n")
 				if err != nil {
+					// skipcq: RVV-A0003
 					log.Fatal(err)
 				}
 				_, err = buf.WriteString("\n")
 				if err != nil {
+					// skipcq: RVV-A0003
 					log.Fatal(err)
 				}
 				continue
@@ -215,10 +222,12 @@ func readAndRewrite(path string) error {
 			if (filepath.Ext(path) == ".yaml" || filepath.Ext(path) == ".yml") && strings.HasPrefix(line, "---") {
 				_, err = buf.WriteString(line)
 				if err != nil {
+					// skipcq: RVV-A0003
 					log.Fatal(err)
 				}
 				_, err = buf.WriteString("\n")
 				if err != nil {
+					// skipcq: RVV-A0003
 					log.Fatal(err)
 				}
 				continue
@@ -229,6 +238,7 @@ func readAndRewrite(path string) error {
 				once.Do(func() {
 					err = apache.Execute(buf, d)
 					if err != nil {
+						// skipcq: RVV-A0003
 						log.Fatal(err)
 					}
 				})
@@ -237,10 +247,12 @@ func readAndRewrite(path string) error {
 			if !lf {
 				_, err = buf.WriteString(line)
 				if err != nil {
+					// skipcq: RVV-A0003
 					log.Fatal(err)
 				}
 				_, err = buf.WriteString("\n")
 				if err != nil {
+					// skipcq: RVV-A0003
 					log.Fatal(err)
 				}
 			}
@@ -259,16 +271,19 @@ func readAndRewrite(path string) error {
 	if err != nil {
 		err = f.Close()
 		if err != nil {
+			// skipcq: RVV-A0003
 			log.Fatal(err)
 		}
 		return errors.Errorf("filepath %s, could not open", path)
 	}
 	_, err = f.WriteString(strings.ReplaceAll(buf.String(), d.Escape+"\n\n\n", d.Escape+"\n\n"))
 	if err != nil {
+		// skipcq: RVV-A0003
 		log.Fatal(err)
 	}
 	err = f.Close()
 	if err != nil {
+		// skipcq: RVV-A0003
 		log.Fatal(err)
 	}
 	return nil

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -123,6 +123,7 @@ func Init(name string) {
 		i, err := New(WithServerName(name))
 		if err != nil {
 			log.Init()
+			// skipcq: RVV-A0003
 			log.Fatal(errors.ErrFailedToInitInfo(err))
 		}
 		infoProvider = i

--- a/internal/net/grpc/logger/logger.go
+++ b/internal/net/grpc/logger/logger.go
@@ -90,16 +90,19 @@ func (l *logger) Errorf(format string, args ...interface{}) {
 
 // Fatal prints the fatal log to the logger and exit the program.
 func (l *logger) Fatal(args ...interface{}) {
+	// skipcq: RVV-A0003
 	log.Fatal(append([]interface{}{tag}, args...)...)
 }
 
 // Fatalln prints the fatal log to the logger and exit the program.
 func (l *logger) Fatalln(args ...interface{}) {
+	// skipcq: RVV-A0003
 	log.Fatal(append([]interface{}{tag}, args...)...)
 }
 
 // Fatalf prints the fatal log to the logger and exit the program.
 func (l *logger) Fatalf(format string, args ...interface{}) {
+	// skipcq: RVV-A0003
 	log.Fatalf(tag+"\t"+format, args...)
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
I have fixed the `RVV-A0003` reported by deepsource.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
