### PR TITLE
Bugfix: e2e operator workflow

### DIFF
--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -169,7 +169,7 @@ jobs:
           for IMAGE_TAG in "${IMAGE_TAGS[@]}"
           do
             echo "IMAGE_TAG:${IMAGE_TAG}"
-            yq e ".spec.${IMAGE_TAG}" -i ./.github/valdrelease/valdrelease.yaml
+            yq e ".spec.\"${IMAGE_TAG}\"" -i ./.github/valdrelease/valdrelease.yaml
           done
       - name: deploy Vald
         id: deploy_vald


### PR DESCRIPTION


### Description:

### WHAT

As titled

### WHY

e2e operator workflow has failed due to an invalid character.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
