### PR TITLE
Fix deepsource: RVV-B0011 exported function returning value of unexported type 

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -26,15 +26,6 @@ import (
 	"github.com/vdaas/vald/internal/errors"
 )
 
-// Cache represent the cache interface to store cache.
-type Cache interface {
-	Start(context.Context)
-	Get(string) (interface{}, bool)
-	Set(string, interface{})
-	Delete(string)
-	GetAndDelete(string) (interface{}, bool)
-}
-
 type cache struct {
 	cacher         cacher.Type
 	expireDur      time.Duration
@@ -43,7 +34,7 @@ type cache struct {
 }
 
 // New returns the Cache instance or error.
-func New(opts ...Option) (cc Cache, err error) {
+func New(opts ...Option) (cc cacher.Cache, err error) {
 	c := new(cache)
 	for _, opt := range append(defaultOptions, opts...) {
 		opt(c)

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/vdaas/vald/internal/cache/cacher"
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/test/goleak"
 )
@@ -35,18 +36,18 @@ func TestNew(t *testing.T) {
 		opts []Option
 	}
 	type want struct {
-		wantCc Cache
+		wantCc cacher.Cache
 		err    error
 	}
 	type test struct {
 		name       string
 		args       args
 		want       want
-		checkFunc  func(want, Cache, error) error
+		checkFunc  func(want, cacher.Cache, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
-	defaultCheckFunc := func(w want, gotCc Cache, err error) error {
+	defaultCheckFunc := func(w want, gotCc cacher.Cache, err error) error {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 		}
@@ -61,7 +62,7 @@ func TestNew(t *testing.T) {
 			args: args{
 				opts: []Option{WithType("gache")},
 			},
-			checkFunc: func(w want, got Cache, err error) error {
+			checkFunc: func(w want, got cacher.Cache, err error) error {
 				if err != nil {
 					return err
 				}
@@ -86,7 +87,7 @@ func TestNew(t *testing.T) {
 			args: args{
 				opts: []Option{WithType("")},
 			},
-			checkFunc: func(w want, got Cache, err error) error {
+			checkFunc: func(w want, got cacher.Cache, err error) error {
 				if err != nil {
 					return err
 				}

--- a/internal/cache/cacher/cacher.go
+++ b/internal/cache/cacher/cacher.go
@@ -17,7 +17,20 @@
 // Package cacher provides implementation of cache type definition
 package cacher
 
-import "github.com/vdaas/vald/internal/strings"
+import (
+	"context"
+
+	"github.com/vdaas/vald/internal/strings"
+)
+
+// Cache represent the cache interface to store cache.
+type Cache interface {
+	Start(context.Context)
+	Get(string) (interface{}, bool)
+	Set(string, interface{})
+	Delete(string)
+	GetAndDelete(string) (interface{}, bool)
+}
 
 // Type represents the cacher type. Currently it support GACHE only.
 type Type uint8

--- a/internal/cache/gache/gache.go
+++ b/internal/cache/gache/gache.go
@@ -22,16 +22,8 @@ import (
 	"time"
 
 	"github.com/kpango/gache"
+	"github.com/vdaas/vald/internal/cache/cacher"
 )
-
-// Cache is an interface to handle a gache for cache.
-type Cache interface {
-	Start(context.Context)
-	Get(string) (interface{}, bool)
-	Set(string, interface{})
-	Delete(string)
-	GetAndDelete(string) (interface{}, bool)
-}
 
 type cache struct {
 	gache          gache.Gache
@@ -41,7 +33,7 @@ type cache struct {
 }
 
 // New loads a cache model and returns a new cache struct.
-func New(opts ...Option) (Cache) {
+func New(opts ...Option) (cacher.Cache) {
 	c := new(cache)
 	for _, opt := range append(defaultOptions(), opts...) {
 		opt(c)

--- a/internal/cache/gache/gache.go
+++ b/internal/cache/gache/gache.go
@@ -33,7 +33,7 @@ type cache struct {
 }
 
 // New loads a cache model and returns a new cache struct.
-func New(opts ...Option) (cacher.Cache) {
+func New(opts ...Option) cacher.Cache {
 	c := new(cache)
 	for _, opt := range append(defaultOptions(), opts...) {
 		opt(c)

--- a/internal/cache/gache/gache.go
+++ b/internal/cache/gache/gache.go
@@ -24,6 +24,15 @@ import (
 	"github.com/kpango/gache"
 )
 
+// Cache is an interface to handle a gache for cache.
+type Cache interface {
+	Start(context.Context)
+	Get(string) (interface{}, bool)
+	Set(string, interface{})
+	Delete(string)
+	GetAndDelete(string) (interface{}, bool)
+}
+
 type cache struct {
 	gache          gache.Gache
 	expireDur      time.Duration
@@ -32,8 +41,8 @@ type cache struct {
 }
 
 // New loads a cache model and returns a new cache struct.
-func New(opts ...Option) (c *cache) {
-	c = new(cache)
+func New(opts ...Option) (Cache) {
+	c := new(cache)
 	for _, opt := range append(defaultOptions(), opts...) {
 		opt(c)
 	}

--- a/internal/cache/gache/gache_test.go
+++ b/internal/cache/gache/gache_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/kpango/gache"
+	"github.com/vdaas/vald/internal/cache/cacher"
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/test/goleak"
 )
@@ -38,17 +39,17 @@ func TestNew(t *testing.T) {
 		opts []Option
 	}
 	type want struct {
-		wantC Cache
+		wantC cacher.Cache
 	}
 	type test struct {
 		name       string
 		args       args
 		want       want
-		checkFunc  func(want, Cache) error
+		checkFunc  func(want, cacher.Cache) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
-	defaultCheckFunc := func(w want, got Cache) error {
+	defaultCheckFunc := func(w want, got cacher.Cache) error {
 		wc := reflect.ValueOf(w.wantC.(*cache))
 		gc := reflect.ValueOf(got.(*cache))
 		flag := false

--- a/internal/config/compress.go
+++ b/internal/config/compress.go
@@ -19,11 +19,12 @@ package config
 
 import "github.com/vdaas/vald/internal/strings"
 
-type compressAlgorithm uint8
+// CompressAlgorithm is an enum for compress algorithm.
+type CompressAlgorithm uint8
 
 const (
 	// GOB represents gob algorithm.
-	GOB compressAlgorithm = 1 + iota
+	GOB CompressAlgorithm = 1 + iota
 	// GZIP represents gzip algorithm.
 	GZIP
 	// LZ4 represents lz4 algorithm.
@@ -33,7 +34,7 @@ const (
 )
 
 // String returns compress algorithm.
-func (ca compressAlgorithm) String() string {
+func (ca CompressAlgorithm) String() string {
 	switch ca {
 	case GOB:
 		return "gob"
@@ -47,8 +48,8 @@ func (ca compressAlgorithm) String() string {
 	return "unknown"
 }
 
-// CompressAlgorithm returns compressAlgorithm converted from string.
-func CompressAlgorithm(ca string) compressAlgorithm {
+// AToCompressAlgorithm returns CompressAlgorithm converted from string.
+func AToCompressAlgorithm(ca string) CompressAlgorithm {
 	switch strings.ToLower(ca) {
 	case "gob":
 		return GOB

--- a/internal/config/compress_test.go
+++ b/internal/config/compress_test.go
@@ -31,7 +31,7 @@ func Test_compressAlgorithm_String(t *testing.T) {
 	}
 	type test struct {
 		name       string
-		ca         compressAlgorithm
+		ca         CompressAlgorithm
 		want       want
 		checkFunc  func(want, string) error
 		beforeFunc func()
@@ -80,7 +80,7 @@ func Test_compressAlgorithm_String(t *testing.T) {
 		},
 		{
 			name: "return unknown when compressAlgorithm is 100",
-			ca:   compressAlgorithm(100),
+			ca:   CompressAlgorithm(100),
 			want: want{
 				want: "unknown",
 			},
@@ -110,22 +110,22 @@ func Test_compressAlgorithm_String(t *testing.T) {
 	}
 }
 
-func TestCompressAlgorithm(t *testing.T) {
+func TestAToCompressAlgorithm(t *testing.T) {
 	type args struct {
 		ca string
 	}
 	type want struct {
-		want compressAlgorithm
+		want CompressAlgorithm
 	}
 	type test struct {
 		name       string
 		args       args
 		want       want
-		checkFunc  func(want, compressAlgorithm) error
+		checkFunc  func(want, CompressAlgorithm) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
-	defaultCheckFunc := func(w want, got compressAlgorithm) error {
+	defaultCheckFunc := func(w want, got CompressAlgorithm) error {
 		if !reflect.DeepEqual(got, w.want) {
 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
 		}
@@ -227,7 +227,7 @@ func TestCompressAlgorithm(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := CompressAlgorithm(test.args.ca)
+			got := AToCompressAlgorithm(test.args.ca)
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/log/zap/zap.go
+++ b/internal/log/zap/zap.go
@@ -32,6 +32,27 @@ var (
 	zapcore_NewJSONEncoder    = zapcore.NewJSONEncoder
 )
 
+// Logger is an interface of zap logger.
+type Logger interface {
+	initialize(sinkPath, errSinkPath string) error
+	Close() error
+	Debug(...interface{})
+	Debugf(string, ...interface{})
+	Debugd(string, ...interface{})
+	Info(...interface{})
+	Infof(string, ...interface{})
+	Infod(string, ...interface{})
+	Warn(...interface{})
+	Warnf(string, ...interface{})
+	Warnd(string, ...interface{})
+	Error(...interface{})
+	Errorf(string, ...interface{})
+	Errord(string, ...interface{})
+	Fatal(...interface{})
+	Fatalf(string, ...interface{})
+	Fatald(string, ...interface{})
+}
+
 type logger struct {
 	format format.Format
 	level  level.Level
@@ -43,7 +64,7 @@ type logger struct {
 }
 
 // New returns a new logger instance.
-func New(opts ...Option) (*logger, error) {
+func New(opts ...Option) (Logger, error) {
 	l := new(logger)
 	for _, opt := range append(defaultOpts, opts...) {
 		opt(l)

--- a/internal/log/zap/zap.go
+++ b/internal/log/zap/zap.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/log/format"
 	"github.com/vdaas/vald/internal/log/level"
+	log "github.com/vdaas/vald/internal/log/logger"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -32,27 +33,6 @@ var (
 	zapcore_NewJSONEncoder    = zapcore.NewJSONEncoder
 )
 
-// Logger is an interface of zap logger.
-type Logger interface {
-	initialize(sinkPath, errSinkPath string) error
-	Close() error
-	Debug(...interface{})
-	Debugf(string, ...interface{})
-	Debugd(string, ...interface{})
-	Info(...interface{})
-	Infof(string, ...interface{})
-	Infod(string, ...interface{})
-	Warn(...interface{})
-	Warnf(string, ...interface{})
-	Warnd(string, ...interface{})
-	Error(...interface{})
-	Errorf(string, ...interface{})
-	Errord(string, ...interface{})
-	Fatal(...interface{})
-	Fatalf(string, ...interface{})
-	Fatald(string, ...interface{})
-}
-
 type logger struct {
 	format format.Format
 	level  level.Level
@@ -64,7 +44,7 @@ type logger struct {
 }
 
 // New returns a new logger instance.
-func New(opts ...Option) (Logger, error) {
+func New(opts ...Option) (log.Logger, error) {
 	l := new(logger)
 	for _, opt := range append(defaultOpts, opts...) {
 		opt(l)

--- a/internal/log/zap/zap_test.go
+++ b/internal/log/zap/zap_test.go
@@ -37,11 +37,11 @@ func TestNew(t *testing.T) {
 		name       string
 		args       args
 		want       want
-		checkFunc  func(want, *logger, error) error
+		checkFunc  func(want, Logger, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
-	defaultCheckFunc := func(w want, got *logger, err error) error {
+	defaultCheckFunc := func(w want, got Logger, err error) error {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 		}
@@ -58,7 +58,7 @@ func TestNew(t *testing.T) {
 				name: "return new logger instance correctly",
 				args: args{
 					opts: []Option{
-						func(l *logger) {
+						func(*logger) {
 							called = true
 						},
 					},
@@ -67,7 +67,7 @@ func TestNew(t *testing.T) {
 					want: &logger{},
 					err:  nil,
 				},
-				checkFunc: func(w want, got *logger, err error) error {
+				checkFunc: func(w want, got Logger, err error) error {
 					if !called {
 						return errors.New("Option function is not applied")
 					}

--- a/internal/log/zap/zap_test.go
+++ b/internal/log/zap/zap_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/log/format"
 	"github.com/vdaas/vald/internal/log/level"
+	log "github.com/vdaas/vald/internal/log/logger"
 	"github.com/vdaas/vald/internal/test/goleak"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -37,11 +38,11 @@ func TestNew(t *testing.T) {
 		name       string
 		args       args
 		want       want
-		checkFunc  func(want, Logger, error) error
+		checkFunc  func(want, log.Logger, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
-	defaultCheckFunc := func(w want, got Logger, err error) error {
+	defaultCheckFunc := func(w want, got log.Logger, err error) error {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 		}
@@ -67,7 +68,7 @@ func TestNew(t *testing.T) {
 					want: &logger{},
 					err:  nil,
 				},
-				checkFunc: func(w want, got Logger, err error) error {
+				checkFunc: func(w want, got log.Logger, err error) error {
 					if !called {
 						return errors.New("Option function is not applied")
 					}

--- a/internal/net/dialer.go
+++ b/internal/net/dialer.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/vdaas/vald/internal/cache"
+	"github.com/vdaas/vald/internal/cache/cacher"
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/log"
 	"github.com/vdaas/vald/internal/net/control"
@@ -43,7 +44,7 @@ type Dialer interface {
 }
 
 type dialer struct {
-	dnsCache              cache.Cache
+	dnsCache              cacher.Cache
 	enableDNSCache        bool
 	dnsCachedOnce         sync.Once
 	tlsConfig             *tls.Config

--- a/internal/net/dialer_test.go
+++ b/internal/net/dialer_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/vdaas/vald/internal/cache"
+	"github.com/vdaas/vald/internal/cache/cacher"
 	"github.com/vdaas/vald/internal/cache/gache"
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/io"
@@ -268,7 +269,7 @@ func TestNewDialer(t *testing.T) {
 		if diff := cmp.Diff(*want, *got,
 			cmpopts.IgnoreFields(*want, "dialer", "der", "addrs", "dnsCachedOnce", "dnsCache", "ctrl", "tmu"),
 			cmp.AllowUnexported(*want),
-			cmp.Comparer(func(x, y cache.Cache) bool {
+			cmp.Comparer(func(x, y cacher.Cache) bool {
 				if x == nil && y == nil {
 					return true
 				}
@@ -528,7 +529,7 @@ func Test_dialer_lookup(t *testing.T) {
 				addr: "addr",
 			},
 			opts: []DialerOption{
-				WithDNSCache(func() cache.Cache {
+				WithDNSCache(func() cacher.Cache {
 					g := gache.New()
 					g.Set("addr", &dialerCache{
 						ips: []string{"999.999.999.999"},
@@ -1806,7 +1807,7 @@ func Test_dialer_lookupIPAddrs(t *testing.T) {
 		host string
 	}
 	type fields struct {
-		dnsCache              cache.Cache
+		dnsCache              cacher.Cache
 		enableDNSCache        bool
 		dnsCachedOnce         sync.Once
 		tlsConfig             *tls.Config

--- a/internal/net/option.go
+++ b/internal/net/option.go
@@ -21,7 +21,7 @@ import (
 	"crypto/tls"
 	"time"
 
-	"github.com/vdaas/vald/internal/cache"
+	"github.com/vdaas/vald/internal/cache/cacher"
 	"github.com/vdaas/vald/internal/net/control"
 	"github.com/vdaas/vald/internal/timeutil"
 )
@@ -38,7 +38,7 @@ var defaultDialerOptions = []DialerOption{
 }
 
 // WithDNSCache returns the functional option to set the cache.
-func WithDNSCache(c cache.Cache) DialerOption {
+func WithDNSCache(c cacher.Cache) DialerOption {
 	return func(d *dialer) {
 		d.dnsCache = c
 		if d.dnsCache != nil {

--- a/internal/net/option_test.go
+++ b/internal/net/option_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vdaas/vald/internal/cache"
+	"github.com/vdaas/vald/internal/cache/cacher"
 	"github.com/vdaas/vald/internal/cache/gache"
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/net/control"
@@ -33,7 +33,7 @@ func TestWithDNSCache(t *testing.T) {
 	t.Parallel()
 	type T = dialer
 	type args struct {
-		c cache.Cache
+		c cacher.Cache
 	}
 	type want struct {
 		obj *T

--- a/internal/params/params.go
+++ b/internal/params/params.go
@@ -37,6 +37,11 @@ type data struct {
 	showVersion    bool
 }
 
+// Parser is an interface to parse commnad-line argument.
+type Parser interface {
+	Parse() (Data, bool, error)
+}
+
 type parser struct {
 	filePath struct {
 		keys        []string
@@ -51,7 +56,7 @@ type parser struct {
 }
 
 // New returns parser object.
-func New(opts ...Option) *parser {
+func New(opts ...Option) Parser {
 	p := new(parser)
 	for _, opt := range append(defaultOptions, opts...) {
 		opt(p)

--- a/internal/params/params_test.go
+++ b/internal/params/params_test.go
@@ -38,11 +38,11 @@ func TestNew(t *testing.T) {
 		name       string
 		args       args
 		want       want
-		checkFunc  func(want, *parser) error
+		checkFunc  func(want, Parser) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 	}
-	defaultCheckFunc := func(w want, got *parser) error {
+	defaultCheckFunc := func(w want, got Parser) error {
 		if !reflect.DeepEqual(got, w.want) {
 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
 		}

--- a/pkg/agent/sidecar/service/storage/storage.go
+++ b/pkg/agent/sidecar/service/storage/storage.go
@@ -83,7 +83,7 @@ func (b *bs) initCompressor() (err error) {
 		return nil
 	}
 
-	switch config.CompressAlgorithm(b.compressAlgorithm) {
+	switch config.AToCompressAlgorithm(b.compressAlgorithm) {
 	case config.GOB:
 		b.compressor, err = compress.NewGob()
 	case config.GZIP:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
I have fixed the `RVV-B0011`.

Fixing the issue, required changing the test code at the `internal/cache` package.

I have changed the `checkFunc` to ensure comparing `struct` which satisfies the `Cache` interface instead of using `go-cmp`.
The code is like:
```go
checkFunc := func(want, got Cache) error {
        cw := reflect.ValueOf(want.(*cache))
        cg := reflect.ValueOf(got.(*cache))
        for i := 0 ; i < reflect.Indirect(cg).NumFiled(); i++ {
                // compare
        }
        return nil
}
```

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
