### PR TITLE
Fix deepsource: GSC-G103 Function call made to an unsafe package

### DIFF
--- a/hack/benchmark/assets/x1b/loader.go
+++ b/hack/benchmark/assets/x1b/loader.go
@@ -93,6 +93,7 @@ func open(fname string, elementSize int) (f *file, err error) {
 		return nil, err
 	}
 
+	// skipcq: GSC-G103
 	dim := int(*(*int32)(unsafe.Pointer(&mem[0])))
 	block := headerSize + dim*elementSize
 	return &file{
@@ -128,6 +129,7 @@ func (bv *bvecs) LoadUint8(i int) ([]uint8, error) {
 	if err != nil {
 		return nil, err
 	}
+	// skipcq: GSC-G103
 	return ((*[1 << 26]uint8)(unsafe.Pointer(&buf[0])))[:bv.dim:bv.dim], nil
 }
 
@@ -140,6 +142,7 @@ func (fv *fvecs) LoadFloat32(i int) ([]float32, error) {
 	if err != nil {
 		return nil, err
 	}
+	// skipcq: GSC-G103
 	return ((*[1 << 26]float32)(unsafe.Pointer(&buf[0])))[:fv.dim:fv.dim], nil
 }
 
@@ -152,6 +155,7 @@ func (iv *ivecs) LoadInt32(i int) ([]int32, error) {
 	if err != nil {
 		return nil, err
 	}
+	// skipcq: GSC-G103
 	return ((*[1 << 26]int32)(unsafe.Pointer(&buf[0])))[:iv.dim:iv.dim], nil
 }
 

--- a/internal/conv/conv.go
+++ b/internal/conv/conv.go
@@ -25,7 +25,9 @@ import (
 
 // Btoa converts from byte slice to string.
 func Btoa(b []byte) (s string) {
+	// skipcq: GSC-G103
 	slh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	// skipcq: GSC-G103
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	sh.Data = slh.Data
 	sh.Len = slh.Len
@@ -34,7 +36,9 @@ func Btoa(b []byte) (s string) {
 
 // Atobs converts from string to byte slice.
 func Atob(s string) (b []byte) {
+	// skipcq: GSC-G103
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	// skipcq: GSC-G103
 	slh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	slh.Data = sh.Data
 	slh.Len = sh.Len
@@ -45,9 +49,13 @@ func Atob(s string) (b []byte) {
 // F32stos converts from float32 slice to type string.
 func F32stos(fs []float32) (s string) {
 	lf := 4 * len(fs)
+	// skipcq: GSC-G103
 	buf := (*(*[1]byte)(unsafe.Pointer(&(fs[0]))))[:]
+	// skipcq: GSC-G103
 	addr := unsafe.Pointer(&buf)
+	// skipcq: GSC-G103
 	(*(*int)(unsafe.Pointer(uintptr(addr) + uintptr(8)))) = lf
+	// skipcq: GSC-G103
 	(*(*int)(unsafe.Pointer(uintptr(addr) + uintptr(16)))) = lf
 	return Btoa(buf)
 }

--- a/internal/net/grpc/grpcconns.go
+++ b/internal/net/grpc/grpcconns.go
@@ -37,6 +37,7 @@ type readOnlyGrpcConns struct {
 	amended bool
 }
 
+// skipcq: GSC-G103
 var expungedGrpcConns = unsafe.Pointer(new(pool.Conn))
 
 type entryGrpcConns struct {
@@ -44,6 +45,7 @@ type entryGrpcConns struct {
 }
 
 func newEntryGrpcConns(i pool.Conn) *entryGrpcConns {
+	// skipcq: GSC-G103
 	return &entryGrpcConns{p: unsafe.Pointer(&i)}
 }
 
@@ -105,6 +107,7 @@ func (e *entryGrpcConns) tryStore(i *pool.Conn) bool {
 		if p == expungedGrpcConns {
 			return false
 		}
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, p, unsafe.Pointer(i)) {
 			return true
 		}
@@ -116,6 +119,7 @@ func (e *entryGrpcConns) unexpungeLocked() (wasExpunged bool) {
 }
 
 func (e *entryGrpcConns) storeLocked(i *pool.Conn) {
+	// skipcq: GSC-G103
 	atomic.StorePointer(&e.p, unsafe.Pointer(i))
 }
 

--- a/internal/strings/strings_benchmark_test.go
+++ b/internal/strings/strings_benchmark_test.go
@@ -57,6 +57,7 @@ func randStr(n int) string {
 		cache >>= rs6LetterIdxBits
 		remain--
 	}
+	// skipcq: GSC-G103
 	return *(*string)(unsafe.Pointer(&b))
 }
 

--- a/pkg/agent/core/ngt/service/kvs/ou.go
+++ b/pkg/agent/core/ngt/service/kvs/ou.go
@@ -31,6 +31,7 @@ type readOnlyOu struct {
 	amended bool
 }
 
+// skipcq: GSC-G103
 var expungedOu = unsafe.Pointer(new(string))
 
 type entryOu struct {
@@ -38,6 +39,7 @@ type entryOu struct {
 }
 
 func newEntryOu(i string) *entryOu {
+	// skipcq: GSC-G103
 	return &entryOu{p: unsafe.Pointer(&i)}
 }
 
@@ -98,6 +100,7 @@ func (e *entryOu) tryStore(i *string) bool {
 		if p == expungedOu {
 			return false
 		}
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, p, unsafe.Pointer(i)) {
 			return true
 		}
@@ -109,6 +112,7 @@ func (e *entryOu) unexpungeLocked() (wasExpunged bool) {
 }
 
 func (e *entryOu) storeLocked(i *string) {
+	// skipcq: GSC-G103
 	atomic.StorePointer(&e.p, unsafe.Pointer(i))
 }
 
@@ -152,6 +156,7 @@ func (e *entryOu) tryLoadOrStore(i string) (actual string, loaded, ok bool) {
 	}
 	ic := i
 	for {
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, nil, unsafe.Pointer(&ic)) {
 			return i, false, true
 		}

--- a/pkg/agent/core/ngt/service/kvs/uo.go
+++ b/pkg/agent/core/ngt/service/kvs/uo.go
@@ -31,6 +31,7 @@ type readOnlyUo struct {
 	amended bool
 }
 
+// skipcq: GSC-G103
 var expungedUo = unsafe.Pointer(new(uint32))
 
 type entryUo struct {
@@ -38,6 +39,7 @@ type entryUo struct {
 }
 
 func newEntryUo(i uint32) *entryUo {
+	// skipcq: GSC-G103
 	return &entryUo{p: unsafe.Pointer(&i)}
 }
 
@@ -98,6 +100,7 @@ func (e *entryUo) tryStore(i *uint32) bool {
 		if p == expungedUo {
 			return false
 		}
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, p, unsafe.Pointer(i)) {
 			return true
 		}
@@ -109,6 +112,7 @@ func (e *entryUo) unexpungeLocked() (wasExpunged bool) {
 }
 
 func (e *entryUo) storeLocked(i *uint32) {
+	// skipcq: GSC-G103
 	atomic.StorePointer(&e.p, unsafe.Pointer(i))
 }
 
@@ -152,6 +156,7 @@ func (e *entryUo) tryLoadOrStore(i uint32) (actual uint32, loaded, ok bool) {
 	}
 	ic := i
 	for {
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, nil, unsafe.Pointer(&ic)) {
 			return i, false, true
 		}

--- a/pkg/agent/core/ngt/service/vqueue/undeleted_index_map.go
+++ b/pkg/agent/core/ngt/service/vqueue/undeleted_index_map.go
@@ -31,6 +31,7 @@ type readOnlyUdim struct {
 	amended bool
 }
 
+// skipcq: GSC-G103
 var expungedUdim = unsafe.Pointer(new(int64))
 
 type entryUdim struct {
@@ -38,6 +39,7 @@ type entryUdim struct {
 }
 
 func newEntryUdim(i int64) *entryUdim {
+	// skipcq: GSC-G103
 	return &entryUdim{p: unsafe.Pointer(&i)}
 }
 
@@ -99,6 +101,7 @@ func (e *entryUdim) tryStore(i *int64) bool {
 		if p == expungedUdim {
 			return false
 		}
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, p, unsafe.Pointer(i)) {
 			return true
 		}
@@ -110,6 +113,7 @@ func (e *entryUdim) unexpungeLocked() (wasExpunged bool) {
 }
 
 func (e *entryUdim) storeLocked(i *int64) {
+	// skipcq: GSC-G103
 	atomic.StorePointer(&e.p, unsafe.Pointer(i))
 }
 
@@ -157,6 +161,7 @@ func (e *entryUdim) tryLoadOrStore(i int64) (actual int64, loaded, ok bool) {
 
 	ic := i
 	for {
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, nil, unsafe.Pointer(&ic)) {
 			return i, false, true
 		}

--- a/pkg/agent/core/ngt/service/vqueue/uninserted_index_map.go
+++ b/pkg/agent/core/ngt/service/vqueue/uninserted_index_map.go
@@ -34,6 +34,7 @@ type readOnlyUiim struct {
 	amended bool
 }
 
+// skipcq: GSC-G103
 var expungedUiim = unsafe.Pointer(new(index))
 
 type entryUiim struct {
@@ -41,6 +42,7 @@ type entryUiim struct {
 }
 
 func newEntryUiim(i index) *entryUiim {
+	// skipcq: GSC-G103
 	return &entryUiim{p: unsafe.Pointer(&i)}
 }
 
@@ -105,6 +107,7 @@ func (e *entryUiim) tryStore(i *index) bool {
 		if p == expungedUiim {
 			return false
 		}
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, p, unsafe.Pointer(i)) {
 			return true
 		}
@@ -116,6 +119,7 @@ func (e *entryUiim) unexpungeLocked() (wasExpunged bool) {
 }
 
 func (e *entryUiim) storeLocked(i *index) {
+	// skipcq: GSC-G103
 	atomic.StorePointer(&e.p, unsafe.Pointer(i))
 }
 
@@ -163,6 +167,7 @@ func (e *entryUiim) tryLoadOrStore(i index) (actual index, loaded, ok bool) {
 
 	ic := i
 	for {
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, nil, unsafe.Pointer(&ic)) {
 			return i, false, true
 		}

--- a/pkg/discoverer/k8s/service/nodemap.go
+++ b/pkg/discoverer/k8s/service/nodemap.go
@@ -82,6 +82,7 @@ type readOnlyNodeMap struct {
 
 // expunged is an arbitrary pointer that marks entries which have been deleted
 // from the dirty map.
+// skipcq: GSC-G103
 var expungedNodeMap = unsafe.Pointer(new(*node.Node))
 
 // An entry is a slot in the map corresponding to a particular key.
@@ -108,6 +109,7 @@ type entryNodeMap struct {
 }
 
 func newEntryNodeMap(i *node.Node) *entryNodeMap {
+	// skipcq: GSC-G103
 	return &entryNodeMap{p: unsafe.Pointer(&i)}
 }
 
@@ -187,6 +189,7 @@ func (e *entryNodeMap) tryStore(i **node.Node) bool {
 		if p == expungedNodeMap {
 			return false
 		}
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, p, unsafe.Pointer(i)) {
 			return true
 		}
@@ -205,6 +208,7 @@ func (e *entryNodeMap) unexpungeLocked() (wasExpunged bool) {
 //
 // The entry must be known not to be expunged.
 func (e *entryNodeMap) storeLocked(i **node.Node) {
+	// skipcq: GSC-G103
 	atomic.StorePointer(&e.p, unsafe.Pointer(i))
 }
 
@@ -265,6 +269,7 @@ func (e *entryNodeMap) tryLoadOrStore(i *node.Node) (actual *node.Node, loaded, 
 	// shouldn't bother heap-allocating.
 	ic := i
 	for {
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, nil, unsafe.Pointer(&ic)) {
 			return i, false, true
 		}

--- a/pkg/discoverer/k8s/service/nodemetricsmap.go
+++ b/pkg/discoverer/k8s/service/nodemetricsmap.go
@@ -82,6 +82,7 @@ type readOnlyNodeMetricsMap struct {
 
 // expunged is an arbitrary pointer that marks entries which have been deleted
 // from the dirty map.
+// skipcq: GSC-G103
 var expungedNodeMetricsMap = unsafe.Pointer(new(mnode.Node))
 
 // An entry is a slot in the map corresponding to a particular key.
@@ -108,6 +109,7 @@ type entryNodeMetricsMap struct {
 }
 
 func newEntryNodeMetricsMap(i mnode.Node) *entryNodeMetricsMap {
+	// skipcq: GSC-G103
 	return &entryNodeMetricsMap{p: unsafe.Pointer(&i)}
 }
 
@@ -187,6 +189,7 @@ func (e *entryNodeMetricsMap) tryStore(i *mnode.Node) bool {
 		if p == expungedNodeMetricsMap {
 			return false
 		}
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, p, unsafe.Pointer(i)) {
 			return true
 		}
@@ -205,6 +208,7 @@ func (e *entryNodeMetricsMap) unexpungeLocked() (wasExpunged bool) {
 //
 // The entry must be known not to be expunged.
 func (e *entryNodeMetricsMap) storeLocked(i *mnode.Node) {
+	// skipcq: GSC-G103
 	atomic.StorePointer(&e.p, unsafe.Pointer(i))
 }
 
@@ -265,6 +269,7 @@ func (e *entryNodeMetricsMap) tryLoadOrStore(i mnode.Node) (actual mnode.Node, l
 	// shouldn't bother heap-allocating.
 	ic := i
 	for {
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, nil, unsafe.Pointer(&ic)) {
 			return i, false, true
 		}

--- a/pkg/discoverer/k8s/service/podmetricsmap.go
+++ b/pkg/discoverer/k8s/service/podmetricsmap.go
@@ -82,6 +82,7 @@ type readOnlyPodMetricsMap struct {
 
 // expunged is an arbitrary pointer that marks entries which have been deleted
 // from the dirty map.
+// skipcq: GSC-G103
 var expungedPodMetricsMap = unsafe.Pointer(new(mpod.Pod))
 
 // An entry is a slot in the map corresponding to a particular key.
@@ -108,6 +109,7 @@ type entryPodMetricsMap struct {
 }
 
 func newEntryPodMetricsMap(i mpod.Pod) *entryPodMetricsMap {
+	// skipcq: GSC-G103
 	return &entryPodMetricsMap{p: unsafe.Pointer(&i)}
 }
 
@@ -187,6 +189,7 @@ func (e *entryPodMetricsMap) tryStore(i *mpod.Pod) bool {
 		if p == expungedPodMetricsMap {
 			return false
 		}
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, p, unsafe.Pointer(i)) {
 			return true
 		}
@@ -205,6 +208,7 @@ func (e *entryPodMetricsMap) unexpungeLocked() (wasExpunged bool) {
 //
 // The entry must be known not to be expunged.
 func (e *entryPodMetricsMap) storeLocked(i *mpod.Pod) {
+	// skipcq: GSC-G103
 	atomic.StorePointer(&e.p, unsafe.Pointer(i))
 }
 
@@ -265,6 +269,7 @@ func (e *entryPodMetricsMap) tryLoadOrStore(i mpod.Pod) (actual mpod.Pod, loaded
 	// shouldn't bother heap-allocating.
 	ic := i
 	for {
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, nil, unsafe.Pointer(&ic)) {
 			return i, false, true
 		}

--- a/pkg/discoverer/k8s/service/podsmap.go
+++ b/pkg/discoverer/k8s/service/podsmap.go
@@ -82,6 +82,7 @@ type readOnlyPodsMap struct {
 
 // expunged is an arbitrary pointer that marks entries which have been deleted
 // from the dirty map.
+// skipcq: GSC-G103
 var expungedPodsMap = unsafe.Pointer(new([]pod.Pod))
 
 // An entry is a slot in the map corresponding to a particular key.
@@ -108,6 +109,7 @@ type entryPodsMap struct {
 }
 
 func newEntryPodsMap(i []pod.Pod) *entryPodsMap {
+	// skipcq: GSC-G103
 	return &entryPodsMap{p: unsafe.Pointer(&i)}
 }
 
@@ -187,6 +189,7 @@ func (e *entryPodsMap) tryStore(i *[]pod.Pod) bool {
 		if p == expungedPodsMap {
 			return false
 		}
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, p, unsafe.Pointer(i)) {
 			return true
 		}
@@ -205,6 +208,7 @@ func (e *entryPodsMap) unexpungeLocked() (wasExpunged bool) {
 //
 // The entry must be known not to be expunged.
 func (e *entryPodsMap) storeLocked(i *[]pod.Pod) {
+	// skipcq: GSC-G103
 	atomic.StorePointer(&e.p, unsafe.Pointer(i))
 }
 
@@ -265,6 +269,7 @@ func (e *entryPodsMap) tryLoadOrStore(i []pod.Pod) (actual []pod.Pod, loaded, ok
 	// shouldn't bother heap-allocating.
 	ic := i
 	for {
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, nil, unsafe.Pointer(&ic)) {
 			return i, false, true
 		}

--- a/pkg/manager/index/service/indexinfos.go
+++ b/pkg/manager/index/service/indexinfos.go
@@ -36,6 +36,7 @@ type readOnlyIndexInfos struct {
 	amended bool
 }
 
+// skipcq: GSC-G103
 var expungedIndexInfos = unsafe.Pointer(new(*payload.Info_Index_Count))
 
 type entryIndexInfos struct {
@@ -43,6 +44,7 @@ type entryIndexInfos struct {
 }
 
 func newEntryIndexInfos(i *payload.Info_Index_Count) *entryIndexInfos {
+	// skipcq: GSC-G103
 	return &entryIndexInfos{p: unsafe.Pointer(&i)}
 }
 
@@ -104,6 +106,7 @@ func (e *entryIndexInfos) tryStore(i **payload.Info_Index_Count) bool {
 		if p == expungedIndexInfos {
 			return false
 		}
+		// skipcq: GSC-G103
 		if atomic.CompareAndSwapPointer(&e.p, p, unsafe.Pointer(i)) {
 			return true
 		}
@@ -115,6 +118,7 @@ func (e *entryIndexInfos) unexpungeLocked() (wasExpunged bool) {
 }
 
 func (e *entryIndexInfos) storeLocked(i **payload.Info_Index_Count) {
+	// skipcq: GSC-G103
 	atomic.StorePointer(&e.p, unsafe.Pointer(i))
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
Ignore this rule.

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
