### PR TITLE
fix deepsource: Duplicate cases found in switch statement

### DIFF
--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -280,7 +280,7 @@ func writeFile(ctx context.Context, target string, r io.Reader, flg int, perm fs
 		err = errors.ErrFileAlreadyExists(target)
 	case err != nil && !errors.Is(err, fs.ErrNotExist), err != nil && errors.Is(err, fs.ErrExist):
 		err = errors.Wrap(errors.ErrFileAlreadyExists(target), err.Error())
-	case err != nil && !errors.Is(err, fs.ErrNotExist):
+	case err != nil:
 		log.Warn(err)
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
SSIA

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
