### PR TITLE
Fix deepsource: CRT-A0014 switch single case can be rewritten if or if-else

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -46,6 +46,7 @@ func New(opts ...Option) (cc cacher.Cache, err error) {
 			gache.WithExpireCheckDuration(c.expireCheckDur),
 			gache.WithExpiredHook(c.expiredHook),
 		), nil
+	default:
+		return nil, errors.ErrInvalidCacherType
 	}
-	return nil, errors.ErrInvalidCacherType
 }

--- a/internal/cache/cacher/cacher.go
+++ b/internal/cache/cacher/cacher.go
@@ -45,8 +45,9 @@ func (m Type) String() string {
 	switch m {
 	case GACHE:
 		return "gache"
+	default:
+		return "unknown"
 	}
-	return "unknown"
 }
 
 // ToType returns the type based on the string.
@@ -54,6 +55,7 @@ func ToType(str string) Type {
 	switch strings.ToLower(str) {
 	case "gache":
 		return GACHE
+	default:
+		return Unknown
 	}
-	return Unknown
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
I have fixed `CRT-A0014`.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
