### PR TITLE
Fix unsing undefined varibale at maxDimensionTest

### DIFF
--- a/tests/performance/max_vector_dim_test.go
+++ b/tests/performance/max_vector_dim_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/vdaas/vald/apis/grpc/v1/payload"
 	"github.com/vdaas/vald/internal/config"
+	"github.com/vdaas/vald/internal/core/algorithm"
 	"github.com/vdaas/vald/internal/core/algorithm/ngt"
 	"github.com/vdaas/vald/internal/errgroup"
 	"github.com/vdaas/vald/internal/errors"
@@ -130,8 +131,8 @@ func TestMaxDimInsert(t *testing.T) {
 				if bit == maxBit {
 					dim--
 				}
-				if dim > ngt.VectorDimensionSizeLimit {
-					t.Fatal(errors.ErrInvalidDimensionSize(dim, ngt.VectorDimensionSizeLimit))
+				if dim > algorithm.MaximumVectorDimensionSize {
+					t.Fatal(errors.ErrInvalidDimensionSize(dim, algorithm.MaximumVectorDimensionSize))
 				}
 				t.Logf("Start test: dimension = %d (bit = %d)", dim, bit)
 				ngt, err := init_ngt_service(dim)
@@ -233,8 +234,8 @@ func TestMaxDimInsertGRPC(t *testing.T) {
 				if bit == maxBit {
 					dim--
 				}
-				if dim > ngt.VectorDimensionSizeLimit {
-					t.Fatal(errors.ErrInvalidDimensionSize(dim, ngt.VectorDimensionSizeLimit))
+				if dim > algorithm.MaximumVectorDimensionSize {
+					t.Fatal(errors.ErrInvalidDimensionSize(dim, algorithm.MaximumVectorDimensionSize))
 				}
 				t.Logf("Start test: dimension = %d (bit = %d)", dim, bit)
 				ngt, err := init_ngt_service(dim)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
I have fixed the using a defined variable instead of an undefined variable in `MaxDimensionTest`.
It means I use `the algorithm.MaximumVectorDimensionSize` instead of `ngt.VecotrDimensionSizeLimit`.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
