### PR TITLE
Fix deepsource: VET-V0008 lock erroneously passed by value pkg/discoverer

### DIFF
--- a/pkg/discoverer/k8s/service/discover_test.go
+++ b/pkg/discoverer/k8s/service/discover_test.go
@@ -131,7 +131,7 @@ func Test_discoverer_Start(t *testing.T) {
 	}
 	type fields struct {
 		maxPods int
-		nodes    struct {
+		nodes   struct {
 			read   atomic.Value
 			dirty  map[string]*entryNodeMap
 			misses int
@@ -320,8 +320,8 @@ func Test_discoverer_GetPods(t *testing.T) {
 		req *payload.Discoverer_Request
 	}
 	type fields struct {
-		maxPods         int
-		nodes    struct {
+		maxPods int
+		nodes   struct {
 			read   atomic.Value
 			dirty  map[string]*entryNodeMap
 			misses int
@@ -464,7 +464,7 @@ func Test_discoverer_GetPods(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 			d := &discoverer{
-				maxPods:         test.fields.maxPods,
+				maxPods: test.fields.maxPods,
 				nodes: nodeMap{
 					read:   test.fields.nodes.read,
 					dirty:  test.fields.nodes.dirty,
@@ -510,8 +510,8 @@ func Test_discoverer_GetNodes(t *testing.T) {
 		req *payload.Discoverer_Request
 	}
 	type fields struct {
-		maxPods         int
-		nodes    struct {
+		maxPods int
+		nodes   struct {
 			read   atomic.Value
 			dirty  map[string]*entryNodeMap
 			misses int
@@ -654,7 +654,7 @@ func Test_discoverer_GetNodes(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 			d := &discoverer{
-				maxPods:         test.fields.maxPods,
+				maxPods: test.fields.maxPods,
 				nodes: nodeMap{
 					read:   test.fields.nodes.read,
 					dirty:  test.fields.nodes.dirty,
@@ -691,7 +691,6 @@ func Test_discoverer_GetNodes(t *testing.T) {
 			if err := checkFunc(test.want, gotNodes, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }

--- a/pkg/discoverer/k8s/service/discover_test.go
+++ b/pkg/discoverer/k8s/service/discover_test.go
@@ -121,7 +121,6 @@ func TestNew(t *testing.T) {
 			if err := checkFunc(test.want, gotDsc, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -280,7 +279,6 @@ func Test_discoverer_Start(t *testing.T) {
 			if err := checkFunc(test.want, got, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -439,7 +437,6 @@ func Test_discoverer_GetPods(t *testing.T) {
 			if err := checkFunc(test.want, gotPods, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }

--- a/pkg/discoverer/k8s/service/discover_test.go
+++ b/pkg/discoverer/k8s/service/discover_test.go
@@ -130,11 +130,27 @@ func Test_discoverer_Start(t *testing.T) {
 		ctx context.Context
 	}
 	type fields struct {
-		maxPods         int
-		nodes           func() nodeMap
-		nodeMetrics     func() nodeMetricsMap
-		pods            func() podsMap
-		podMetrics      func() podMetricsMap
+		maxPods int
+		nodes    struct {
+			read   atomic.Value
+			dirty  map[string]*entryNodeMap
+			misses int
+		}
+		nodeMetrics struct {
+			read   atomic.Value
+			dirty  map[string]*entryNodeMetricsMap
+			misses int
+		}
+		pods struct {
+			read   atomic.Value
+			dirty  map[string]*entryPodsMap
+			misses int
+		}
+		podMetrics struct {
+			read   atomic.Value
+			dirty  map[string]*entryPodMetricsMap
+			misses int
+		}
 		podsByNode      atomic.Value
 		podsByNamespace atomic.Value
 		podsByName      atomic.Value
@@ -178,10 +194,10 @@ func Test_discoverer_Start(t *testing.T) {
 		       },
 		       fields: fields {
 		           maxPods: 0,
-		           nodes: nodeMap{},
-		           nodeMetrics: nodeMetricsMap{},
-		           pods: podsMap{},
-		           podMetrics: podMetricsMap{},
+		           nodes: struct{},
+		           nodeMetrics: struct{},
+		           pods: struct{},
+		           podMetrics: struct{},
 		           podsByNode: nil,
 		           podsByNamespace: nil,
 		           podsByName: nil,
@@ -214,10 +230,10 @@ func Test_discoverer_Start(t *testing.T) {
 		           },
 		           fields: fields {
 		           maxPods: 0,
-		           nodes: nodeMap{},
-		           nodeMetrics: nodeMetricsMap{},
-		           pods: podsMap{},
-		           podMetrics: podMetricsMap{},
+		           nodes: struct{},
+		           nodeMetrics: struct{},
+		           pods: struct{},
+		           podMetrics: struct{},
 		           podsByNode: nil,
 		           podsByNamespace: nil,
 		           podsByName: nil,
@@ -258,11 +274,27 @@ func Test_discoverer_Start(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 			d := &discoverer{
-				maxPods:         test.fields.maxPods,
-				nodes:           test.fields.nodes(),
-				nodeMetrics:     test.fields.nodeMetrics(),
-				pods:            test.fields.pods(),
-				podMetrics:      test.fields.podMetrics(),
+				maxPods: test.fields.maxPods,
+				nodes: nodeMap{
+					read:   test.fields.nodes.read,
+					dirty:  test.fields.nodes.dirty,
+					misses: test.fields.nodes.misses,
+				},
+				nodeMetrics: nodeMetricsMap{
+					read:   test.fields.nodeMetrics.read,
+					dirty:  test.fields.nodeMetrics.dirty,
+					misses: test.fields.nodeMetrics.misses,
+				},
+				pods: podsMap{
+					read:   test.fields.pods.read,
+					dirty:  test.fields.pods.dirty,
+					misses: test.fields.pods.misses,
+				},
+				podMetrics: podMetricsMap{
+					read:   test.fields.podMetrics.read,
+					dirty:  test.fields.podMetrics.dirty,
+					misses: test.fields.podMetrics.misses,
+				},
 				podsByNode:      test.fields.podsByNode,
 				podsByNamespace: test.fields.podsByNamespace,
 				podsByName:      test.fields.podsByName,
@@ -289,10 +321,26 @@ func Test_discoverer_GetPods(t *testing.T) {
 	}
 	type fields struct {
 		maxPods         int
-		nodes           func() nodeMap
-		nodeMetrics     func() nodeMetricsMap
-		pods            func() podsMap
-		podMetrics      func() podMetricsMap
+		nodes    struct {
+			read   atomic.Value
+			dirty  map[string]*entryNodeMap
+			misses int
+		}
+		nodeMetrics struct {
+			read   atomic.Value
+			dirty  map[string]*entryNodeMetricsMap
+			misses int
+		}
+		pods struct {
+			read   atomic.Value
+			dirty  map[string]*entryPodsMap
+			misses int
+		}
+		podMetrics struct {
+			read   atomic.Value
+			dirty  map[string]*entryPodMetricsMap
+			misses int
+		}
 		podsByNode      atomic.Value
 		podsByNamespace atomic.Value
 		podsByName      atomic.Value
@@ -336,10 +384,10 @@ func Test_discoverer_GetPods(t *testing.T) {
 		       },
 		       fields: fields {
 		           maxPods: 0,
-		           nodes: nodeMap{},
-		           nodeMetrics: nodeMetricsMap{},
-		           pods: podsMap{},
-		           podMetrics: podMetricsMap{},
+		           nodes: struct{},
+		           nodeMetrics: struct{},
+		           pods: struct{},
+		           podMetrics: struct{},
 		           podsByNode: nil,
 		           podsByNamespace: nil,
 		           podsByName: nil,
@@ -372,10 +420,10 @@ func Test_discoverer_GetPods(t *testing.T) {
 		           },
 		           fields: fields {
 		           maxPods: 0,
-		           nodes: nodeMap{},
-		           nodeMetrics: nodeMetricsMap{},
-		           pods: podsMap{},
-		           podMetrics: podMetricsMap{},
+		           nodes: struct{},
+		           nodeMetrics: struct{},
+		           pods: struct{},
+		           podMetrics: struct{},
 		           podsByNode: nil,
 		           podsByNamespace: nil,
 		           podsByName: nil,
@@ -417,10 +465,26 @@ func Test_discoverer_GetPods(t *testing.T) {
 			}
 			d := &discoverer{
 				maxPods:         test.fields.maxPods,
-				nodes:           test.fields.nodes(),
-				nodeMetrics:     test.fields.nodeMetrics(),
-				pods:            test.fields.pods(),
-				podMetrics:      test.fields.podMetrics(),
+				nodes: nodeMap{
+					read:   test.fields.nodes.read,
+					dirty:  test.fields.nodes.dirty,
+					misses: test.fields.nodes.misses,
+				},
+				nodeMetrics: nodeMetricsMap{
+					read:   test.fields.nodeMetrics.read,
+					dirty:  test.fields.nodeMetrics.dirty,
+					misses: test.fields.nodeMetrics.misses,
+				},
+				pods: podsMap{
+					read:   test.fields.pods.read,
+					dirty:  test.fields.pods.dirty,
+					misses: test.fields.pods.misses,
+				},
+				podMetrics: podMetricsMap{
+					read:   test.fields.podMetrics.read,
+					dirty:  test.fields.podMetrics.dirty,
+					misses: test.fields.podMetrics.misses,
+				},
 				podsByNode:      test.fields.podsByNode,
 				podsByNamespace: test.fields.podsByNamespace,
 				podsByName:      test.fields.podsByName,
@@ -447,10 +511,26 @@ func Test_discoverer_GetNodes(t *testing.T) {
 	}
 	type fields struct {
 		maxPods         int
-		nodes           func() nodeMap
-		nodeMetrics     func() nodeMetricsMap
-		pods            func() podsMap
-		podMetrics      func() podMetricsMap
+		nodes    struct {
+			read   atomic.Value
+			dirty  map[string]*entryNodeMap
+			misses int
+		}
+		nodeMetrics struct {
+			read   atomic.Value
+			dirty  map[string]*entryNodeMetricsMap
+			misses int
+		}
+		pods struct {
+			read   atomic.Value
+			dirty  map[string]*entryPodsMap
+			misses int
+		}
+		podMetrics struct {
+			read   atomic.Value
+			dirty  map[string]*entryPodMetricsMap
+			misses int
+		}
 		podsByNode      atomic.Value
 		podsByNamespace atomic.Value
 		podsByName      atomic.Value
@@ -494,10 +574,10 @@ func Test_discoverer_GetNodes(t *testing.T) {
 		       },
 		       fields: fields {
 		           maxPods: 0,
-		           nodes: nodeMap{},
-		           nodeMetrics: nodeMetricsMap{},
-		           pods: podsMap{},
-		           podMetrics: podMetricsMap{},
+		           nodes: struct{},
+		           nodeMetrics: struct{},
+		           pods: struct{},
+		           podMetrics: struct{},
 		           podsByNode: nil,
 		           podsByNamespace: nil,
 		           podsByName: nil,
@@ -530,10 +610,10 @@ func Test_discoverer_GetNodes(t *testing.T) {
 		           },
 		           fields: fields {
 		           maxPods: 0,
-		           nodes: nodeMap{},
-		           nodeMetrics: nodeMetricsMap{},
-		           pods: podsMap{},
-		           podMetrics: podMetricsMap{},
+		           nodes: struct{},
+		           nodeMetrics: struct{},
+		           pods: struct{},
+		           podMetrics: struct{},
 		           podsByNode: nil,
 		           podsByNamespace: nil,
 		           podsByName: nil,
@@ -575,10 +655,26 @@ func Test_discoverer_GetNodes(t *testing.T) {
 			}
 			d := &discoverer{
 				maxPods:         test.fields.maxPods,
-				nodes:           test.fields.nodes(),
-				nodeMetrics:     test.fields.nodeMetrics(),
-				pods:            test.fields.pods(),
-				podMetrics:      test.fields.podMetrics(),
+				nodes: nodeMap{
+					read:   test.fields.nodes.read,
+					dirty:  test.fields.nodes.dirty,
+					misses: test.fields.nodes.misses,
+				},
+				nodeMetrics: nodeMetricsMap{
+					read:   test.fields.nodeMetrics.read,
+					dirty:  test.fields.nodeMetrics.dirty,
+					misses: test.fields.nodeMetrics.misses,
+				},
+				pods: podsMap{
+					read:   test.fields.pods.read,
+					dirty:  test.fields.pods.dirty,
+					misses: test.fields.pods.misses,
+				},
+				podMetrics: podMetricsMap{
+					read:   test.fields.podMetrics.read,
+					dirty:  test.fields.podMetrics.dirty,
+					misses: test.fields.podMetrics.misses,
+				},
 				podsByNode:      test.fields.podsByNode,
 				podsByNamespace: test.fields.podsByNamespace,
 				podsByName:      test.fields.podsByName,

--- a/pkg/discoverer/k8s/service/nodemap_test.go
+++ b/pkg/discoverer/k8s/service/nodemap_test.go
@@ -108,7 +108,6 @@ func Test_newEntryNodeMap(t *testing.T) {
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -219,7 +218,6 @@ func Test_nodeMap_Load(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -312,7 +310,6 @@ func Test_entryNodeMap_load(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -327,8 +324,7 @@ func Test_nodeMap_Store(t *testing.T) {
 		dirty  map[string]*entryNodeMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -516,7 +512,6 @@ func Test_entryNodeMap_tryStore(t *testing.T) {
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -605,7 +600,6 @@ func Test_entryNodeMap_unexpungeLocked(t *testing.T) {
 			if err := checkFunc(test.want, gotWasExpunged); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -617,8 +611,7 @@ func Test_entryNodeMap_storeLocked(t *testing.T) {
 	type fields struct {
 		p unsafe.Pointer
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -813,7 +806,6 @@ func Test_nodeMap_LoadOrStore(t *testing.T) {
 			if err := checkFunc(test.want, gotActual, gotLoaded); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -920,7 +912,6 @@ func Test_entryNodeMap_tryLoadOrStore(t *testing.T) {
 			if err := checkFunc(test.want, gotActual, gotLoaded, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -1031,7 +1022,6 @@ func Test_nodeMap_LoadAndDelete(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotLoaded); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -1045,8 +1035,7 @@ func Test_nodeMap_Delete(t *testing.T) {
 		dirty  map[string]*entryNodeMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -1226,7 +1215,6 @@ func Test_entryNodeMap_delete(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -1240,8 +1228,7 @@ func Test_nodeMap_Range(t *testing.T) {
 		dirty  map[string]*entryNodeMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -1339,8 +1326,7 @@ func Test_nodeMap_missLocked(t *testing.T) {
 		dirty  map[string]*entryNodeMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		fields     fields
@@ -1431,8 +1417,7 @@ func Test_nodeMap_dirtyLocked(t *testing.T) {
 		dirty  map[string]*entryNodeMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		fields     fields
@@ -1601,7 +1586,6 @@ func Test_entryNodeMap_tryExpungeLocked(t *testing.T) {
 			if err := checkFunc(test.want, gotIsExpunged); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }

--- a/pkg/discoverer/k8s/service/nodemap_test.go
+++ b/pkg/discoverer/k8s/service/nodemap_test.go
@@ -18,18 +18,16 @@ package service
 
 import (
 	"reflect"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"unsafe"
 
-	"github.com/vdaas/vald/internal/errors"
+	"github.com/pkg/errors"
 	"github.com/vdaas/vald/internal/k8s/node"
 	"github.com/vdaas/vald/internal/test/goleak"
 )
 
 func Test_newEntryNodeMap(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		i *node.Node
 	}
@@ -41,8 +39,8 @@ func Test_newEntryNodeMap(t *testing.T) {
 		args       args
 		want       want
 		checkFunc  func(want, *entryNodeMap) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, got *entryNodeMap) error {
 		if !reflect.DeepEqual(got, w.want) {
@@ -60,6 +58,12 @@ func Test_newEntryNodeMap(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -73,6 +77,12 @@ func Test_newEntryNodeMap(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -84,10 +94,10 @@ func Test_newEntryNodeMap(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -98,17 +108,16 @@ func Test_newEntryNodeMap(t *testing.T) {
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_nodeMap_Load(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		key string
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMap
 		misses int
@@ -123,8 +132,8 @@ func Test_nodeMap_Load(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, *node.Node, bool) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, gotValue *node.Node, gotOk bool) error {
 		if !reflect.DeepEqual(gotValue, w.wantValue) {
@@ -144,13 +153,18 @@ func Test_nodeMap_Load(t *testing.T) {
 		           key: "",
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -163,13 +177,18 @@ func Test_nodeMap_Load(t *testing.T) {
 		           key: "",
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -181,17 +200,16 @@ func Test_nodeMap_Load(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -201,12 +219,12 @@ func Test_nodeMap_Load(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_entryNodeMap_load(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		p unsafe.Pointer
 	}
@@ -219,8 +237,8 @@ func Test_entryNodeMap_load(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, *node.Node, bool) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, gotValue *node.Node, gotOk bool) error {
 		if !reflect.DeepEqual(gotValue, w.wantValue) {
@@ -241,6 +259,12 @@ func Test_entryNodeMap_load(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -254,6 +278,12 @@ func Test_entryNodeMap_load(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -265,10 +295,10 @@ func Test_entryNodeMap_load(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -282,31 +312,31 @@ func Test_entryNodeMap_load(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_nodeMap_Store(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		key   string
 		value *node.Node
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -321,13 +351,18 @@ func Test_nodeMap_Store(t *testing.T) {
 		           value: nil,
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -341,13 +376,18 @@ func Test_nodeMap_Store(t *testing.T) {
 		           value: nil,
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -359,17 +399,16 @@ func Test_nodeMap_Store(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -384,7 +423,6 @@ func Test_nodeMap_Store(t *testing.T) {
 }
 
 func Test_entryNodeMap_tryStore(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		i **node.Node
 	}
@@ -400,8 +438,8 @@ func Test_entryNodeMap_tryStore(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, bool) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, got bool) error {
 		if !reflect.DeepEqual(got, w.want) {
@@ -422,6 +460,12 @@ func Test_entryNodeMap_tryStore(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -438,6 +482,12 @@ func Test_entryNodeMap_tryStore(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -449,10 +499,10 @@ func Test_entryNodeMap_tryStore(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -466,12 +516,12 @@ func Test_entryNodeMap_tryStore(t *testing.T) {
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_entryNodeMap_unexpungeLocked(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		p unsafe.Pointer
 	}
@@ -483,8 +533,8 @@ func Test_entryNodeMap_unexpungeLocked(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, bool) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, gotWasExpunged bool) error {
 		if !reflect.DeepEqual(gotWasExpunged, w.wantWasExpunged) {
@@ -502,6 +552,12 @@ func Test_entryNodeMap_unexpungeLocked(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -515,6 +571,12 @@ func Test_entryNodeMap_unexpungeLocked(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -526,10 +588,10 @@ func Test_entryNodeMap_unexpungeLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -543,27 +605,28 @@ func Test_entryNodeMap_unexpungeLocked(t *testing.T) {
 			if err := checkFunc(test.want, gotWasExpunged); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_entryNodeMap_storeLocked(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		i **node.Node
 	}
 	type fields struct {
 		p unsafe.Pointer
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -581,6 +644,12 @@ func Test_entryNodeMap_storeLocked(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -597,6 +666,12 @@ func Test_entryNodeMap_storeLocked(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -608,10 +683,10 @@ func Test_entryNodeMap_storeLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -630,13 +705,11 @@ func Test_entryNodeMap_storeLocked(t *testing.T) {
 }
 
 func Test_nodeMap_LoadOrStore(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		key   string
 		value *node.Node
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMap
 		misses int
@@ -651,8 +724,8 @@ func Test_nodeMap_LoadOrStore(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, *node.Node, bool) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, gotActual *node.Node, gotLoaded bool) error {
 		if !reflect.DeepEqual(gotActual, w.wantActual) {
@@ -673,13 +746,18 @@ func Test_nodeMap_LoadOrStore(t *testing.T) {
 		           value: nil,
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -693,13 +771,18 @@ func Test_nodeMap_LoadOrStore(t *testing.T) {
 		           value: nil,
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -711,17 +794,16 @@ func Test_nodeMap_LoadOrStore(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -731,12 +813,12 @@ func Test_nodeMap_LoadOrStore(t *testing.T) {
 			if err := checkFunc(test.want, gotActual, gotLoaded); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_entryNodeMap_tryLoadOrStore(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		i *node.Node
 	}
@@ -754,8 +836,8 @@ func Test_entryNodeMap_tryLoadOrStore(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, *node.Node, bool, bool) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, gotActual *node.Node, gotLoaded bool, gotOk bool) error {
 		if !reflect.DeepEqual(gotActual, w.wantActual) {
@@ -782,6 +864,12 @@ func Test_entryNodeMap_tryLoadOrStore(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -798,6 +886,12 @@ func Test_entryNodeMap_tryLoadOrStore(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -809,10 +903,10 @@ func Test_entryNodeMap_tryLoadOrStore(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -826,17 +920,16 @@ func Test_entryNodeMap_tryLoadOrStore(t *testing.T) {
 			if err := checkFunc(test.want, gotActual, gotLoaded, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_nodeMap_LoadAndDelete(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		key string
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMap
 		misses int
@@ -851,8 +944,8 @@ func Test_nodeMap_LoadAndDelete(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, *node.Node, bool) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, gotValue *node.Node, gotLoaded bool) error {
 		if !reflect.DeepEqual(gotValue, w.wantValue) {
@@ -872,13 +965,18 @@ func Test_nodeMap_LoadAndDelete(t *testing.T) {
 		           key: "",
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -891,13 +989,18 @@ func Test_nodeMap_LoadAndDelete(t *testing.T) {
 		           key: "",
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -909,17 +1012,16 @@ func Test_nodeMap_LoadAndDelete(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -929,30 +1031,30 @@ func Test_nodeMap_LoadAndDelete(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotLoaded); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_nodeMap_Delete(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		key string
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -966,13 +1068,18 @@ func Test_nodeMap_Delete(t *testing.T) {
 		           key: "",
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -985,13 +1092,18 @@ func Test_nodeMap_Delete(t *testing.T) {
 		           key: "",
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1003,17 +1115,16 @@ func Test_nodeMap_Delete(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -1028,7 +1139,6 @@ func Test_nodeMap_Delete(t *testing.T) {
 }
 
 func Test_entryNodeMap_delete(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		p unsafe.Pointer
 	}
@@ -1041,8 +1151,8 @@ func Test_entryNodeMap_delete(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, *node.Node, bool) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, gotValue *node.Node, gotOk bool) error {
 		if !reflect.DeepEqual(gotValue, w.wantValue) {
@@ -1063,6 +1173,12 @@ func Test_entryNodeMap_delete(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -1076,6 +1192,12 @@ func Test_entryNodeMap_delete(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1087,10 +1209,10 @@ func Test_entryNodeMap_delete(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -1104,30 +1226,30 @@ func Test_entryNodeMap_delete(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_nodeMap_Range(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		f func(key string, value *node.Node) bool
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -1141,13 +1263,18 @@ func Test_nodeMap_Range(t *testing.T) {
 		           f: nil,
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -1160,13 +1287,18 @@ func Test_nodeMap_Range(t *testing.T) {
 		           f: nil,
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1178,17 +1310,16 @@ func Test_nodeMap_Range(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -1203,21 +1334,20 @@ func Test_nodeMap_Range(t *testing.T) {
 }
 
 func Test_nodeMap_missLocked(t *testing.T) {
-	t.Parallel()
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -1228,13 +1358,18 @@ func Test_nodeMap_missLocked(t *testing.T) {
 		   {
 		       name: "test_case_1",
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -1244,13 +1379,18 @@ func Test_nodeMap_missLocked(t *testing.T) {
 		       return test {
 		           name: "test_case_2",
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1262,17 +1402,16 @@ func Test_nodeMap_missLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -1287,21 +1426,20 @@ func Test_nodeMap_missLocked(t *testing.T) {
 }
 
 func Test_nodeMap_dirtyLocked(t *testing.T) {
-	t.Parallel()
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -1312,13 +1450,18 @@ func Test_nodeMap_dirtyLocked(t *testing.T) {
 		   {
 		       name: "test_case_1",
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -1328,13 +1471,18 @@ func Test_nodeMap_dirtyLocked(t *testing.T) {
 		       return test {
 		           name: "test_case_2",
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1346,17 +1494,16 @@ func Test_nodeMap_dirtyLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -1371,7 +1518,6 @@ func Test_nodeMap_dirtyLocked(t *testing.T) {
 }
 
 func Test_entryNodeMap_tryExpungeLocked(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		p unsafe.Pointer
 	}
@@ -1383,8 +1529,8 @@ func Test_entryNodeMap_tryExpungeLocked(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, bool) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, gotIsExpunged bool) error {
 		if !reflect.DeepEqual(gotIsExpunged, w.wantIsExpunged) {
@@ -1402,6 +1548,12 @@ func Test_entryNodeMap_tryExpungeLocked(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -1415,6 +1567,12 @@ func Test_entryNodeMap_tryExpungeLocked(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1426,10 +1584,10 @@ func Test_entryNodeMap_tryExpungeLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -1443,6 +1601,7 @@ func Test_entryNodeMap_tryExpungeLocked(t *testing.T) {
 			if err := checkFunc(test.want, gotIsExpunged); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }

--- a/pkg/discoverer/k8s/service/nodemap_test.go
+++ b/pkg/discoverer/k8s/service/nodemap_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/pkg/errors"
+	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/k8s/node"
 	"github.com/vdaas/vald/internal/test/goleak"
 )

--- a/pkg/discoverer/k8s/service/nodemetricsmap_test.go
+++ b/pkg/discoverer/k8s/service/nodemetricsmap_test.go
@@ -18,18 +18,16 @@ package service
 
 import (
 	"reflect"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"unsafe"
 
-	"github.com/vdaas/vald/internal/errors"
+	"github.com/pkg/errors"
 	mnode "github.com/vdaas/vald/internal/k8s/metrics/node"
 	"github.com/vdaas/vald/internal/test/goleak"
 )
 
 func Test_newEntryNodeMetricsMap(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		i mnode.Node
 	}
@@ -41,8 +39,8 @@ func Test_newEntryNodeMetricsMap(t *testing.T) {
 		args       args
 		want       want
 		checkFunc  func(want, *entryNodeMetricsMap) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, got *entryNodeMetricsMap) error {
 		if !reflect.DeepEqual(got, w.want) {
@@ -60,6 +58,12 @@ func Test_newEntryNodeMetricsMap(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -73,6 +77,12 @@ func Test_newEntryNodeMetricsMap(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -84,10 +94,10 @@ func Test_newEntryNodeMetricsMap(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -98,17 +108,16 @@ func Test_newEntryNodeMetricsMap(t *testing.T) {
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_nodeMetricsMap_Load(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		key string
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMetricsMap
 		misses int
@@ -123,8 +132,8 @@ func Test_nodeMetricsMap_Load(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, mnode.Node, bool) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, gotValue mnode.Node, gotOk bool) error {
 		if !reflect.DeepEqual(gotValue, w.wantValue) {
@@ -144,13 +153,18 @@ func Test_nodeMetricsMap_Load(t *testing.T) {
 		           key: "",
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -163,13 +177,18 @@ func Test_nodeMetricsMap_Load(t *testing.T) {
 		           key: "",
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -181,17 +200,16 @@ func Test_nodeMetricsMap_Load(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMetricsMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -201,12 +219,12 @@ func Test_nodeMetricsMap_Load(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_entryNodeMetricsMap_load(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		p unsafe.Pointer
 	}
@@ -219,8 +237,8 @@ func Test_entryNodeMetricsMap_load(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, mnode.Node, bool) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, gotValue mnode.Node, gotOk bool) error {
 		if !reflect.DeepEqual(gotValue, w.wantValue) {
@@ -241,6 +259,12 @@ func Test_entryNodeMetricsMap_load(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -254,6 +278,12 @@ func Test_entryNodeMetricsMap_load(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -265,10 +295,10 @@ func Test_entryNodeMetricsMap_load(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -282,31 +312,31 @@ func Test_entryNodeMetricsMap_load(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_nodeMetricsMap_Store(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		key   string
 		value mnode.Node
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMetricsMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -321,13 +351,18 @@ func Test_nodeMetricsMap_Store(t *testing.T) {
 		           value: nil,
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -341,13 +376,18 @@ func Test_nodeMetricsMap_Store(t *testing.T) {
 		           value: nil,
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -359,17 +399,16 @@ func Test_nodeMetricsMap_Store(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMetricsMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -384,7 +423,6 @@ func Test_nodeMetricsMap_Store(t *testing.T) {
 }
 
 func Test_entryNodeMetricsMap_tryStore(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		i *mnode.Node
 	}
@@ -400,8 +438,8 @@ func Test_entryNodeMetricsMap_tryStore(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, bool) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, got bool) error {
 		if !reflect.DeepEqual(got, w.want) {
@@ -422,6 +460,12 @@ func Test_entryNodeMetricsMap_tryStore(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -438,6 +482,12 @@ func Test_entryNodeMetricsMap_tryStore(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -449,10 +499,10 @@ func Test_entryNodeMetricsMap_tryStore(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -466,12 +516,12 @@ func Test_entryNodeMetricsMap_tryStore(t *testing.T) {
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_entryNodeMetricsMap_unexpungeLocked(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		p unsafe.Pointer
 	}
@@ -483,8 +533,8 @@ func Test_entryNodeMetricsMap_unexpungeLocked(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, bool) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, gotWasExpunged bool) error {
 		if !reflect.DeepEqual(gotWasExpunged, w.wantWasExpunged) {
@@ -502,6 +552,12 @@ func Test_entryNodeMetricsMap_unexpungeLocked(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -515,6 +571,12 @@ func Test_entryNodeMetricsMap_unexpungeLocked(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -526,10 +588,10 @@ func Test_entryNodeMetricsMap_unexpungeLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -543,27 +605,28 @@ func Test_entryNodeMetricsMap_unexpungeLocked(t *testing.T) {
 			if err := checkFunc(test.want, gotWasExpunged); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_entryNodeMetricsMap_storeLocked(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		i *mnode.Node
 	}
 	type fields struct {
 		p unsafe.Pointer
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -581,6 +644,12 @@ func Test_entryNodeMetricsMap_storeLocked(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -597,6 +666,12 @@ func Test_entryNodeMetricsMap_storeLocked(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -608,10 +683,10 @@ func Test_entryNodeMetricsMap_storeLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -630,13 +705,11 @@ func Test_entryNodeMetricsMap_storeLocked(t *testing.T) {
 }
 
 func Test_nodeMetricsMap_LoadOrStore(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		key   string
 		value mnode.Node
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMetricsMap
 		misses int
@@ -651,8 +724,8 @@ func Test_nodeMetricsMap_LoadOrStore(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, mnode.Node, bool) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, gotActual mnode.Node, gotLoaded bool) error {
 		if !reflect.DeepEqual(gotActual, w.wantActual) {
@@ -673,13 +746,18 @@ func Test_nodeMetricsMap_LoadOrStore(t *testing.T) {
 		           value: nil,
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -693,13 +771,18 @@ func Test_nodeMetricsMap_LoadOrStore(t *testing.T) {
 		           value: nil,
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -711,17 +794,16 @@ func Test_nodeMetricsMap_LoadOrStore(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMetricsMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -731,12 +813,12 @@ func Test_nodeMetricsMap_LoadOrStore(t *testing.T) {
 			if err := checkFunc(test.want, gotActual, gotLoaded); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_entryNodeMetricsMap_tryLoadOrStore(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		i mnode.Node
 	}
@@ -754,8 +836,8 @@ func Test_entryNodeMetricsMap_tryLoadOrStore(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, mnode.Node, bool, bool) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, gotActual mnode.Node, gotLoaded bool, gotOk bool) error {
 		if !reflect.DeepEqual(gotActual, w.wantActual) {
@@ -782,6 +864,12 @@ func Test_entryNodeMetricsMap_tryLoadOrStore(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -798,6 +886,12 @@ func Test_entryNodeMetricsMap_tryLoadOrStore(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -809,10 +903,10 @@ func Test_entryNodeMetricsMap_tryLoadOrStore(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -826,30 +920,30 @@ func Test_entryNodeMetricsMap_tryLoadOrStore(t *testing.T) {
 			if err := checkFunc(test.want, gotActual, gotLoaded, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_nodeMetricsMap_Delete(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		key string
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMetricsMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -863,13 +957,18 @@ func Test_nodeMetricsMap_Delete(t *testing.T) {
 		           key: "",
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -882,13 +981,18 @@ func Test_nodeMetricsMap_Delete(t *testing.T) {
 		           key: "",
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -900,17 +1004,16 @@ func Test_nodeMetricsMap_Delete(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMetricsMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -925,7 +1028,6 @@ func Test_nodeMetricsMap_Delete(t *testing.T) {
 }
 
 func Test_entryNodeMetricsMap_delete(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		p unsafe.Pointer
 	}
@@ -937,8 +1039,8 @@ func Test_entryNodeMetricsMap_delete(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, bool) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, gotHadValue bool) error {
 		if !reflect.DeepEqual(gotHadValue, w.wantHadValue) {
@@ -956,6 +1058,12 @@ func Test_entryNodeMetricsMap_delete(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -969,6 +1077,12 @@ func Test_entryNodeMetricsMap_delete(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -980,10 +1094,10 @@ func Test_entryNodeMetricsMap_delete(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -997,30 +1111,30 @@ func Test_entryNodeMetricsMap_delete(t *testing.T) {
 			if err := checkFunc(test.want, gotHadValue); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_nodeMetricsMap_Range(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		f func(key string, value mnode.Node) bool
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMetricsMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -1034,13 +1148,18 @@ func Test_nodeMetricsMap_Range(t *testing.T) {
 		           f: nil,
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -1053,13 +1172,18 @@ func Test_nodeMetricsMap_Range(t *testing.T) {
 		           f: nil,
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1071,17 +1195,16 @@ func Test_nodeMetricsMap_Range(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMetricsMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -1096,21 +1219,20 @@ func Test_nodeMetricsMap_Range(t *testing.T) {
 }
 
 func Test_nodeMetricsMap_missLocked(t *testing.T) {
-	t.Parallel()
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMetricsMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -1121,13 +1243,18 @@ func Test_nodeMetricsMap_missLocked(t *testing.T) {
 		   {
 		       name: "test_case_1",
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -1137,13 +1264,18 @@ func Test_nodeMetricsMap_missLocked(t *testing.T) {
 		       return test {
 		           name: "test_case_2",
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1155,17 +1287,16 @@ func Test_nodeMetricsMap_missLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMetricsMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -1180,21 +1311,20 @@ func Test_nodeMetricsMap_missLocked(t *testing.T) {
 }
 
 func Test_nodeMetricsMap_dirtyLocked(t *testing.T) {
-	t.Parallel()
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryNodeMetricsMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -1205,13 +1335,18 @@ func Test_nodeMetricsMap_dirtyLocked(t *testing.T) {
 		   {
 		       name: "test_case_1",
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -1221,13 +1356,18 @@ func Test_nodeMetricsMap_dirtyLocked(t *testing.T) {
 		       return test {
 		           name: "test_case_2",
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1239,17 +1379,16 @@ func Test_nodeMetricsMap_dirtyLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &nodeMetricsMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -1264,7 +1403,6 @@ func Test_nodeMetricsMap_dirtyLocked(t *testing.T) {
 }
 
 func Test_entryNodeMetricsMap_tryExpungeLocked(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		p unsafe.Pointer
 	}
@@ -1276,8 +1414,8 @@ func Test_entryNodeMetricsMap_tryExpungeLocked(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, bool) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, gotIsExpunged bool) error {
 		if !reflect.DeepEqual(gotIsExpunged, w.wantIsExpunged) {
@@ -1295,6 +1433,12 @@ func Test_entryNodeMetricsMap_tryExpungeLocked(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -1308,6 +1452,12 @@ func Test_entryNodeMetricsMap_tryExpungeLocked(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1319,10 +1469,10 @@ func Test_entryNodeMetricsMap_tryExpungeLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -1336,6 +1486,7 @@ func Test_entryNodeMetricsMap_tryExpungeLocked(t *testing.T) {
 			if err := checkFunc(test.want, gotIsExpunged); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }

--- a/pkg/discoverer/k8s/service/nodemetricsmap_test.go
+++ b/pkg/discoverer/k8s/service/nodemetricsmap_test.go
@@ -108,7 +108,6 @@ func Test_newEntryNodeMetricsMap(t *testing.T) {
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -219,7 +218,6 @@ func Test_nodeMetricsMap_Load(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -312,7 +310,6 @@ func Test_entryNodeMetricsMap_load(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -327,8 +324,7 @@ func Test_nodeMetricsMap_Store(t *testing.T) {
 		dirty  map[string]*entryNodeMetricsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -516,7 +512,6 @@ func Test_entryNodeMetricsMap_tryStore(t *testing.T) {
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -605,7 +600,6 @@ func Test_entryNodeMetricsMap_unexpungeLocked(t *testing.T) {
 			if err := checkFunc(test.want, gotWasExpunged); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -617,8 +611,7 @@ func Test_entryNodeMetricsMap_storeLocked(t *testing.T) {
 	type fields struct {
 		p unsafe.Pointer
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -813,7 +806,6 @@ func Test_nodeMetricsMap_LoadOrStore(t *testing.T) {
 			if err := checkFunc(test.want, gotActual, gotLoaded); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -920,7 +912,6 @@ func Test_entryNodeMetricsMap_tryLoadOrStore(t *testing.T) {
 			if err := checkFunc(test.want, gotActual, gotLoaded, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -934,8 +925,7 @@ func Test_nodeMetricsMap_Delete(t *testing.T) {
 		dirty  map[string]*entryNodeMetricsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -1111,7 +1101,6 @@ func Test_entryNodeMetricsMap_delete(t *testing.T) {
 			if err := checkFunc(test.want, gotHadValue); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -1125,8 +1114,7 @@ func Test_nodeMetricsMap_Range(t *testing.T) {
 		dirty  map[string]*entryNodeMetricsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -1224,8 +1212,7 @@ func Test_nodeMetricsMap_missLocked(t *testing.T) {
 		dirty  map[string]*entryNodeMetricsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		fields     fields
@@ -1316,8 +1303,7 @@ func Test_nodeMetricsMap_dirtyLocked(t *testing.T) {
 		dirty  map[string]*entryNodeMetricsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		fields     fields
@@ -1486,7 +1472,6 @@ func Test_entryNodeMetricsMap_tryExpungeLocked(t *testing.T) {
 			if err := checkFunc(test.want, gotIsExpunged); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }

--- a/pkg/discoverer/k8s/service/nodemetricsmap_test.go
+++ b/pkg/discoverer/k8s/service/nodemetricsmap_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/pkg/errors"
+	"github.com/vdaas/vald/internal/errors"
 	mnode "github.com/vdaas/vald/internal/k8s/metrics/node"
 	"github.com/vdaas/vald/internal/test/goleak"
 )

--- a/pkg/discoverer/k8s/service/podmetricsmap_test.go
+++ b/pkg/discoverer/k8s/service/podmetricsmap_test.go
@@ -18,18 +18,16 @@ package service
 
 import (
 	"reflect"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"unsafe"
 
-	"github.com/vdaas/vald/internal/errors"
+	"github.com/pkg/errors"
 	mpod "github.com/vdaas/vald/internal/k8s/metrics/pod"
 	"github.com/vdaas/vald/internal/test/goleak"
 )
 
 func Test_newEntryPodMetricsMap(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		i mpod.Pod
 	}
@@ -41,8 +39,8 @@ func Test_newEntryPodMetricsMap(t *testing.T) {
 		args       args
 		want       want
 		checkFunc  func(want, *entryPodMetricsMap) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, got *entryPodMetricsMap) error {
 		if !reflect.DeepEqual(got, w.want) {
@@ -60,6 +58,12 @@ func Test_newEntryPodMetricsMap(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -73,6 +77,12 @@ func Test_newEntryPodMetricsMap(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -84,10 +94,10 @@ func Test_newEntryPodMetricsMap(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -98,17 +108,16 @@ func Test_newEntryPodMetricsMap(t *testing.T) {
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_podMetricsMap_Load(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		key string
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryPodMetricsMap
 		misses int
@@ -123,8 +132,8 @@ func Test_podMetricsMap_Load(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, mpod.Pod, bool) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, gotValue mpod.Pod, gotOk bool) error {
 		if !reflect.DeepEqual(gotValue, w.wantValue) {
@@ -144,13 +153,18 @@ func Test_podMetricsMap_Load(t *testing.T) {
 		           key: "",
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -163,13 +177,18 @@ func Test_podMetricsMap_Load(t *testing.T) {
 		           key: "",
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -181,17 +200,16 @@ func Test_podMetricsMap_Load(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &podMetricsMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -201,12 +219,12 @@ func Test_podMetricsMap_Load(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_entryPodMetricsMap_load(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		p unsafe.Pointer
 	}
@@ -219,8 +237,8 @@ func Test_entryPodMetricsMap_load(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, mpod.Pod, bool) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, gotValue mpod.Pod, gotOk bool) error {
 		if !reflect.DeepEqual(gotValue, w.wantValue) {
@@ -241,6 +259,12 @@ func Test_entryPodMetricsMap_load(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -254,6 +278,12 @@ func Test_entryPodMetricsMap_load(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -265,10 +295,10 @@ func Test_entryPodMetricsMap_load(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -282,31 +312,31 @@ func Test_entryPodMetricsMap_load(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_podMetricsMap_Store(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		key   string
 		value mpod.Pod
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryPodMetricsMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -321,13 +351,18 @@ func Test_podMetricsMap_Store(t *testing.T) {
 		           value: nil,
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -341,13 +376,18 @@ func Test_podMetricsMap_Store(t *testing.T) {
 		           value: nil,
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -359,17 +399,16 @@ func Test_podMetricsMap_Store(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &podMetricsMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -384,7 +423,6 @@ func Test_podMetricsMap_Store(t *testing.T) {
 }
 
 func Test_entryPodMetricsMap_tryStore(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		i *mpod.Pod
 	}
@@ -400,8 +438,8 @@ func Test_entryPodMetricsMap_tryStore(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, bool) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, got bool) error {
 		if !reflect.DeepEqual(got, w.want) {
@@ -422,6 +460,12 @@ func Test_entryPodMetricsMap_tryStore(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -438,6 +482,12 @@ func Test_entryPodMetricsMap_tryStore(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -449,10 +499,10 @@ func Test_entryPodMetricsMap_tryStore(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -466,12 +516,12 @@ func Test_entryPodMetricsMap_tryStore(t *testing.T) {
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_entryPodMetricsMap_unexpungeLocked(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		p unsafe.Pointer
 	}
@@ -483,8 +533,8 @@ func Test_entryPodMetricsMap_unexpungeLocked(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, bool) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, gotWasExpunged bool) error {
 		if !reflect.DeepEqual(gotWasExpunged, w.wantWasExpunged) {
@@ -502,6 +552,12 @@ func Test_entryPodMetricsMap_unexpungeLocked(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -515,6 +571,12 @@ func Test_entryPodMetricsMap_unexpungeLocked(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -526,10 +588,10 @@ func Test_entryPodMetricsMap_unexpungeLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -543,27 +605,28 @@ func Test_entryPodMetricsMap_unexpungeLocked(t *testing.T) {
 			if err := checkFunc(test.want, gotWasExpunged); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_entryPodMetricsMap_storeLocked(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		i *mpod.Pod
 	}
 	type fields struct {
 		p unsafe.Pointer
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -581,6 +644,12 @@ func Test_entryPodMetricsMap_storeLocked(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -597,6 +666,12 @@ func Test_entryPodMetricsMap_storeLocked(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -608,10 +683,10 @@ func Test_entryPodMetricsMap_storeLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -630,13 +705,11 @@ func Test_entryPodMetricsMap_storeLocked(t *testing.T) {
 }
 
 func Test_podMetricsMap_LoadOrStore(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		key   string
 		value mpod.Pod
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryPodMetricsMap
 		misses int
@@ -651,8 +724,8 @@ func Test_podMetricsMap_LoadOrStore(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, mpod.Pod, bool) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, gotActual mpod.Pod, gotLoaded bool) error {
 		if !reflect.DeepEqual(gotActual, w.wantActual) {
@@ -673,13 +746,18 @@ func Test_podMetricsMap_LoadOrStore(t *testing.T) {
 		           value: nil,
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -693,13 +771,18 @@ func Test_podMetricsMap_LoadOrStore(t *testing.T) {
 		           value: nil,
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -711,17 +794,16 @@ func Test_podMetricsMap_LoadOrStore(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &podMetricsMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -731,12 +813,12 @@ func Test_podMetricsMap_LoadOrStore(t *testing.T) {
 			if err := checkFunc(test.want, gotActual, gotLoaded); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_entryPodMetricsMap_tryLoadOrStore(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		i mpod.Pod
 	}
@@ -754,8 +836,8 @@ func Test_entryPodMetricsMap_tryLoadOrStore(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, mpod.Pod, bool, bool) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want, gotActual mpod.Pod, gotLoaded bool, gotOk bool) error {
 		if !reflect.DeepEqual(gotActual, w.wantActual) {
@@ -782,6 +864,12 @@ func Test_entryPodMetricsMap_tryLoadOrStore(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -798,6 +886,12 @@ func Test_entryPodMetricsMap_tryLoadOrStore(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -809,10 +903,10 @@ func Test_entryPodMetricsMap_tryLoadOrStore(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -826,30 +920,30 @@ func Test_entryPodMetricsMap_tryLoadOrStore(t *testing.T) {
 			if err := checkFunc(test.want, gotActual, gotLoaded, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_podMetricsMap_Delete(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		key string
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryPodMetricsMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -863,13 +957,18 @@ func Test_podMetricsMap_Delete(t *testing.T) {
 		           key: "",
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -882,13 +981,18 @@ func Test_podMetricsMap_Delete(t *testing.T) {
 		           key: "",
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -900,17 +1004,16 @@ func Test_podMetricsMap_Delete(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &podMetricsMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -925,7 +1028,6 @@ func Test_podMetricsMap_Delete(t *testing.T) {
 }
 
 func Test_entryPodMetricsMap_delete(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		p unsafe.Pointer
 	}
@@ -937,8 +1039,8 @@ func Test_entryPodMetricsMap_delete(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, bool) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, gotHadValue bool) error {
 		if !reflect.DeepEqual(gotHadValue, w.wantHadValue) {
@@ -956,6 +1058,12 @@ func Test_entryPodMetricsMap_delete(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -969,6 +1077,12 @@ func Test_entryPodMetricsMap_delete(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -980,10 +1094,10 @@ func Test_entryPodMetricsMap_delete(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -997,30 +1111,30 @@ func Test_entryPodMetricsMap_delete(t *testing.T) {
 			if err := checkFunc(test.want, gotHadValue); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }
 
 func Test_podMetricsMap_Range(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		f func(key string, value mpod.Pod) bool
 	}
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryPodMetricsMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		args       args
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func(args)
-		afterFunc  func(args)
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -1034,13 +1148,18 @@ func Test_podMetricsMap_Range(t *testing.T) {
 		           f: nil,
 		       },
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -1053,13 +1172,18 @@ func Test_podMetricsMap_Range(t *testing.T) {
 		           f: nil,
 		           },
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1071,17 +1195,16 @@ func Test_podMetricsMap_Range(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc(test.args)
+				test.beforeFunc(tt, test.args)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc(test.args)
+				defer test.afterFunc(tt, test.args)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &podMetricsMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -1096,21 +1219,20 @@ func Test_podMetricsMap_Range(t *testing.T) {
 }
 
 func Test_podMetricsMap_missLocked(t *testing.T) {
-	t.Parallel()
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryPodMetricsMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -1121,13 +1243,18 @@ func Test_podMetricsMap_missLocked(t *testing.T) {
 		   {
 		       name: "test_case_1",
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -1137,13 +1264,18 @@ func Test_podMetricsMap_missLocked(t *testing.T) {
 		       return test {
 		           name: "test_case_2",
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1155,17 +1287,16 @@ func Test_podMetricsMap_missLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &podMetricsMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -1180,21 +1311,20 @@ func Test_podMetricsMap_missLocked(t *testing.T) {
 }
 
 func Test_podMetricsMap_dirtyLocked(t *testing.T) {
-	t.Parallel()
 	type fields struct {
-		mu     sync.Mutex
 		read   atomic.Value
 		dirty  map[string]*entryPodMetricsMap
 		misses int
 	}
-	type want struct{}
+	type want struct {
+	}
 	type test struct {
 		name       string
 		fields     fields
 		want       want
 		checkFunc  func(want) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want) error {
 		return nil
@@ -1205,13 +1335,18 @@ func Test_podMetricsMap_dirtyLocked(t *testing.T) {
 		   {
 		       name: "test_case_1",
 		       fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -1221,13 +1356,18 @@ func Test_podMetricsMap_dirtyLocked(t *testing.T) {
 		       return test {
 		           name: "test_case_2",
 		           fields: fields {
-		           mu: sync.Mutex{},
 		           read: nil,
 		           dirty: nil,
 		           misses: 0,
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1239,17 +1379,16 @@ func Test_podMetricsMap_dirtyLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
 			m := &podMetricsMap{
-				mu:     test.fields.mu,
 				read:   test.fields.read,
 				dirty:  test.fields.dirty,
 				misses: test.fields.misses,
@@ -1264,7 +1403,6 @@ func Test_podMetricsMap_dirtyLocked(t *testing.T) {
 }
 
 func Test_entryPodMetricsMap_tryExpungeLocked(t *testing.T) {
-	t.Parallel()
 	type fields struct {
 		p unsafe.Pointer
 	}
@@ -1276,8 +1414,8 @@ func Test_entryPodMetricsMap_tryExpungeLocked(t *testing.T) {
 		fields     fields
 		want       want
 		checkFunc  func(want, bool) error
-		beforeFunc func()
-		afterFunc  func()
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
 	}
 	defaultCheckFunc := func(w want, gotIsExpunged bool) error {
 		if !reflect.DeepEqual(gotIsExpunged, w.wantIsExpunged) {
@@ -1295,6 +1433,12 @@ func Test_entryPodMetricsMap_tryExpungeLocked(t *testing.T) {
 		       },
 		       want: want{},
 		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
 		   },
 		*/
 
@@ -1308,6 +1452,12 @@ func Test_entryPodMetricsMap_tryExpungeLocked(t *testing.T) {
 		           },
 		           want: want{},
 		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
 		       }
 		   }(),
 		*/
@@ -1319,10 +1469,10 @@ func Test_entryPodMetricsMap_tryExpungeLocked(t *testing.T) {
 			tt.Parallel()
 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
 			if test.beforeFunc != nil {
-				test.beforeFunc()
+				test.beforeFunc(tt)
 			}
 			if test.afterFunc != nil {
-				defer test.afterFunc()
+				defer test.afterFunc(tt)
 			}
 			checkFunc := test.checkFunc
 			if test.checkFunc == nil {
@@ -1336,6 +1486,7 @@ func Test_entryPodMetricsMap_tryExpungeLocked(t *testing.T) {
 			if err := checkFunc(test.want, gotIsExpunged); err != nil {
 				tt.Errorf("error = %v", err)
 			}
+
 		})
 	}
 }

--- a/pkg/discoverer/k8s/service/podmetricsmap_test.go
+++ b/pkg/discoverer/k8s/service/podmetricsmap_test.go
@@ -108,7 +108,6 @@ func Test_newEntryPodMetricsMap(t *testing.T) {
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -219,7 +218,6 @@ func Test_podMetricsMap_Load(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -312,7 +310,6 @@ func Test_entryPodMetricsMap_load(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -327,8 +324,7 @@ func Test_podMetricsMap_Store(t *testing.T) {
 		dirty  map[string]*entryPodMetricsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -516,7 +512,6 @@ func Test_entryPodMetricsMap_tryStore(t *testing.T) {
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -605,7 +600,6 @@ func Test_entryPodMetricsMap_unexpungeLocked(t *testing.T) {
 			if err := checkFunc(test.want, gotWasExpunged); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -617,8 +611,7 @@ func Test_entryPodMetricsMap_storeLocked(t *testing.T) {
 	type fields struct {
 		p unsafe.Pointer
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -813,7 +806,6 @@ func Test_podMetricsMap_LoadOrStore(t *testing.T) {
 			if err := checkFunc(test.want, gotActual, gotLoaded); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -920,7 +912,6 @@ func Test_entryPodMetricsMap_tryLoadOrStore(t *testing.T) {
 			if err := checkFunc(test.want, gotActual, gotLoaded, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -934,8 +925,7 @@ func Test_podMetricsMap_Delete(t *testing.T) {
 		dirty  map[string]*entryPodMetricsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -1111,7 +1101,6 @@ func Test_entryPodMetricsMap_delete(t *testing.T) {
 			if err := checkFunc(test.want, gotHadValue); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -1125,8 +1114,7 @@ func Test_podMetricsMap_Range(t *testing.T) {
 		dirty  map[string]*entryPodMetricsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -1224,8 +1212,7 @@ func Test_podMetricsMap_missLocked(t *testing.T) {
 		dirty  map[string]*entryPodMetricsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		fields     fields
@@ -1316,8 +1303,7 @@ func Test_podMetricsMap_dirtyLocked(t *testing.T) {
 		dirty  map[string]*entryPodMetricsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		fields     fields
@@ -1486,7 +1472,6 @@ func Test_entryPodMetricsMap_tryExpungeLocked(t *testing.T) {
 			if err := checkFunc(test.want, gotIsExpunged); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }

--- a/pkg/discoverer/k8s/service/podmetricsmap_test.go
+++ b/pkg/discoverer/k8s/service/podmetricsmap_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/pkg/errors"
+	"github.com/vdaas/vald/internal/errors"
 	mpod "github.com/vdaas/vald/internal/k8s/metrics/pod"
 	"github.com/vdaas/vald/internal/test/goleak"
 )

--- a/pkg/discoverer/k8s/service/podsmap_test.go
+++ b/pkg/discoverer/k8s/service/podsmap_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/pkg/errors"
+	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/k8s/pod"
 	"github.com/vdaas/vald/internal/test/goleak"
 )

--- a/pkg/discoverer/k8s/service/podsmap_test.go
+++ b/pkg/discoverer/k8s/service/podsmap_test.go
@@ -108,7 +108,6 @@ func Test_newEntryPodsMap(t *testing.T) {
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -219,7 +218,6 @@ func Test_podsMap_Load(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -312,7 +310,6 @@ func Test_entryPodsMap_load(t *testing.T) {
 			if err := checkFunc(test.want, gotValue, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -327,8 +324,7 @@ func Test_podsMap_Store(t *testing.T) {
 		dirty  map[string]*entryPodsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -516,7 +512,6 @@ func Test_entryPodsMap_tryStore(t *testing.T) {
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -605,7 +600,6 @@ func Test_entryPodsMap_unexpungeLocked(t *testing.T) {
 			if err := checkFunc(test.want, gotWasExpunged); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -617,8 +611,7 @@ func Test_entryPodsMap_storeLocked(t *testing.T) {
 	type fields struct {
 		p unsafe.Pointer
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -813,7 +806,6 @@ func Test_podsMap_LoadOrStore(t *testing.T) {
 			if err := checkFunc(test.want, gotActual, gotLoaded); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -920,7 +912,6 @@ func Test_entryPodsMap_tryLoadOrStore(t *testing.T) {
 			if err := checkFunc(test.want, gotActual, gotLoaded, gotOk); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -934,8 +925,7 @@ func Test_podsMap_Delete(t *testing.T) {
 		dirty  map[string]*entryPodsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -1111,7 +1101,6 @@ func Test_entryPodsMap_delete(t *testing.T) {
 			if err := checkFunc(test.want, gotHadValue); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }
@@ -1125,8 +1114,7 @@ func Test_podsMap_Range(t *testing.T) {
 		dirty  map[string]*entryPodsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		args       args
@@ -1224,8 +1212,7 @@ func Test_podsMap_missLocked(t *testing.T) {
 		dirty  map[string]*entryPodsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		fields     fields
@@ -1316,8 +1303,7 @@ func Test_podsMap_dirtyLocked(t *testing.T) {
 		dirty  map[string]*entryPodsMap
 		misses int
 	}
-	type want struct {
-	}
+	type want struct{}
 	type test struct {
 		name       string
 		fields     fields
@@ -1486,7 +1472,6 @@ func Test_entryPodsMap_tryExpungeLocked(t *testing.T) {
 			if err := checkFunc(test.want, gotIsExpunged); err != nil {
 				tt.Errorf("error = %v", err)
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
I have fixed `VET-V0008` under the `pkg/discoverer` directory.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
