### PR TITLE
Fix deepsource: VET-V0008 Lock erroneously passed by value  internal/db, backoff, circuitbreaker

### DIFF
--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"os"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 
@@ -88,7 +87,6 @@ func Test_backoff_addJitter(t *testing.T) {
 		dur float64
 	}
 	type fields struct {
-		wg                    sync.WaitGroup
 		backoffFactor         float64
 		initialDuration       float64
 		jittedInitialDuration float64
@@ -148,7 +146,6 @@ func Test_backoff_addJitter(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 			b := &backoff{
-				wg:                    test.fields.wg,
 				backoffFactor:         test.fields.backoffFactor,
 				initialDuration:       test.fields.initialDuration,
 				jittedInitialDuration: test.fields.jittedInitialDuration,
@@ -170,9 +167,7 @@ func Test_backoff_addJitter(t *testing.T) {
 
 func Test_backoff_Close(t *testing.T) {
 	t.Parallel()
-	type fields struct {
-		wg sync.WaitGroup
-	}
+	type fields struct{}
 	type want struct{}
 	type test struct {
 		name       string
@@ -187,11 +182,9 @@ func Test_backoff_Close(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "success backoff Close",
-			fields: fields{
-				wg: sync.WaitGroup{},
-			},
-			want: want{},
+			name:   "success backoff Close",
+			fields: fields{},
+			want:   want{},
 		},
 	}
 
@@ -210,9 +203,7 @@ func Test_backoff_Close(t *testing.T) {
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
-			b := &backoff{
-				wg: test.fields.wg,
-			}
+			b := &backoff{}
 
 			b.Close()
 			if err := checkFunc(test.want); err != nil {
@@ -229,7 +220,6 @@ func Test_backoff_Do(t *testing.T) {
 		f   func(ctx context.Context) (val interface{}, retryable bool, err error)
 	}
 	type fields struct {
-		wg                    sync.WaitGroup
 		backoffFactor         float64
 		initialDuration       float64
 		jittedInitialDuration float64
@@ -307,7 +297,6 @@ func Test_backoff_Do(t *testing.T) {
 					f:   f,
 				},
 				fields: fields{
-					wg:                    sync.WaitGroup{},
 					backoffFactor:         0,
 					initialDuration:       0,
 					jittedInitialDuration: 0,
@@ -337,7 +326,6 @@ func Test_backoff_Do(t *testing.T) {
 					f:   f,
 				},
 				fields: fields{
-					wg:                    sync.WaitGroup{},
 					backoffFactor:         0,
 					initialDuration:       0,
 					jittedInitialDuration: 0,
@@ -372,7 +360,6 @@ func Test_backoff_Do(t *testing.T) {
 					f:   f,
 				},
 				fields: fields{
-					wg:                    sync.WaitGroup{},
 					backoffFactor:         0,
 					initialDuration:       0,
 					jittedInitialDuration: 0,
@@ -407,7 +394,6 @@ func Test_backoff_Do(t *testing.T) {
 					f:   f,
 				},
 				fields: fields{
-					wg:                    sync.WaitGroup{},
 					backoffFactor:         0,
 					initialDuration:       0,
 					jittedInitialDuration: 0,
@@ -436,7 +422,6 @@ func Test_backoff_Do(t *testing.T) {
 					f:   f,
 				},
 				fields: fields{
-					wg:                    sync.WaitGroup{},
 					backoffFactor:         0,
 					initialDuration:       0,
 					jittedInitialDuration: 0,
@@ -466,7 +451,6 @@ func Test_backoff_Do(t *testing.T) {
 					f:   f,
 				},
 				fields: fields{
-					wg:                    sync.WaitGroup{},
 					backoffFactor:         0,
 					initialDuration:       0,
 					jittedInitialDuration: 0,
@@ -496,7 +480,6 @@ func Test_backoff_Do(t *testing.T) {
 					f:   f,
 				},
 				fields: fields{
-					wg:                    sync.WaitGroup{},
 					backoffFactor:         0,
 					initialDuration:       0,
 					jittedInitialDuration: 0,
@@ -530,7 +513,6 @@ func Test_backoff_Do(t *testing.T) {
 					f:   f,
 				},
 				fields: fields{
-					wg:                    sync.WaitGroup{},
 					backoffFactor:         0,
 					initialDuration:       0,
 					jittedInitialDuration: 0,
@@ -564,7 +546,6 @@ func Test_backoff_Do(t *testing.T) {
 					f:   f,
 				},
 				fields: fields{
-					wg:                    sync.WaitGroup{},
 					backoffFactor:         1.1,
 					initialDuration:       float64(time.Millisecond * 5),
 					jittedInitialDuration: 0,
@@ -598,7 +579,6 @@ func Test_backoff_Do(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 			b := &backoff{
-				wg:                    test.fields.wg,
 				backoffFactor:         test.fields.backoffFactor,
 				initialDuration:       test.fields.initialDuration,
 				jittedInitialDuration: test.fields.jittedInitialDuration,

--- a/internal/circuitbreaker/manager_test.go
+++ b/internal/circuitbreaker/manager_test.go
@@ -16,7 +16,6 @@ package circuitbreaker
 import (
 	"context"
 	"reflect"
-	"sync"
 	"testing"
 
 	"github.com/vdaas/vald/internal/errors"
@@ -107,7 +106,6 @@ func Test_breakerManager_Do(t *testing.T) {
 		fn  func(ctx context.Context) (interface{}, error)
 	}
 	type fields struct {
-		m    sync.Map
 		opts []BreakerOption
 	}
 	type want struct {
@@ -188,7 +186,6 @@ func Test_breakerManager_Do(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 			bm := &breakerManager{
-				m:    test.fields.m,
 				opts: test.fields.opts,
 			}
 

--- a/internal/db/nosql/cassandra/cassandra_test.go
+++ b/internal/db/nosql/cassandra/cassandra_test.go
@@ -80,7 +80,7 @@ var clientComparatorOpts = []comparator.Option{
 		return reflect.ValueOf(x).Pointer() == reflect.ValueOf(y).Pointer()
 	}),
 
-	comparator.Comparer(func(x, y tls.Config) bool {
+	comparator.Comparer(func(x, y *tls.Config) bool {
 		return reflect.DeepEqual(x, y)
 	}),
 }


### PR DESCRIPTION


### Description:

As titled.

the following are refactor targets.
- internal/backoff
- internal/circuitbreaker
- internal/db

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
