### PR TITLE
Fix deepsource: VET-V0008 lock erroneously passed by value internal/iocopy, info, errgroup

### DIFF
--- a/internal/errgroup/group_test.go
+++ b/internal/errgroup/group_test.go
@@ -793,11 +793,9 @@ func Test_group_closeLimitation(t *testing.T) {
 	type fields struct {
 		egctx            context.Context
 		cancel           context.CancelFunc
-		wg               sync.WaitGroup
 		limitation       chan struct{}
 		enableLimitation atomic.Value
 		cancelOnce       sync.Once
-		mu               sync.RWMutex
 		emap             map[string]struct{}
 		errs             []error
 		err              error
@@ -822,11 +820,9 @@ func Test_group_closeLimitation(t *testing.T) {
 		       fields: fields {
 		           egctx: nil,
 		           cancel: nil,
-		           wg: sync.WaitGroup{},
 		           limitation: nil,
 		           enableLimitation: nil,
 		           cancelOnce: sync.Once{},
-		           mu: sync.RWMutex{},
 		           emap: nil,
 		           errs: nil,
 		           err: nil,
@@ -844,11 +840,9 @@ func Test_group_closeLimitation(t *testing.T) {
 		           fields: fields {
 		           egctx: nil,
 		           cancel: nil,
-		           wg: sync.WaitGroup{},
 		           limitation: nil,
 		           enableLimitation: nil,
 		           cancelOnce: sync.Once{},
-		           mu: sync.RWMutex{},
 		           emap: nil,
 		           errs: nil,
 		           err: nil,
@@ -877,11 +871,9 @@ func Test_group_closeLimitation(t *testing.T) {
 			g := &group{
 				egctx:            test.fields.egctx,
 				cancel:           test.fields.cancel,
-				wg:               test.fields.wg,
 				limitation:       test.fields.limitation,
 				enableLimitation: test.fields.enableLimitation,
 				cancelOnce:       test.fields.cancelOnce,
-				mu:               test.fields.mu,
 				emap:             test.fields.emap,
 				errs:             test.fields.errs,
 				err:              test.fields.err,

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -263,7 +263,7 @@ func (i *info) Get() Detail {
 	return i.get()
 }
 
-func (i info) get() Detail {
+func (i *info) get() Detail {
 	i.detail.StackTrace = make([]StackTrace, 0, 10)
 	for j := 2; ; j++ {
 		pc, file, line, ok := i.rtCaller(j)

--- a/internal/io/copy_test.go
+++ b/internal/io/copy_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/vdaas/vald/internal/errors"
@@ -279,7 +280,6 @@ func Test_copier_Copy(t *testing.T) {
 	}
 	type fields struct {
 		bufSize int64
-		pool    sync.Pool
 	}
 	type want struct {
 		wantWritten int64
@@ -326,7 +326,11 @@ func Test_copier_Copy(t *testing.T) {
 			}
 			c := &copier{
 				bufSize: test.fields.bufSize,
-				pool:    test.fields.pool,
+			}
+			c.pool = sync.Pool{
+				New: func() interface{} {
+					return bytes.NewBuffer(make([]byte, int(atomic.LoadInt64(&c.bufSize))))
+				},
 			}
 			dst := &bytes.Buffer{}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
I have fixed `VET-V0008` under the `internal/info`, `internal/iocoppy`, and `internal/errgroup`.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
