### PR TITLE
Fix deepsource: VET-V0008 Lock erroneously passed by value internal/client

### DIFF
--- a/internal/client/v1/client/filter/egress/client_test.go
+++ b/internal/client/v1/client/filter/egress/client_test.go
@@ -20,7 +20,6 @@ package egress
 import (
 	"context"
 	"reflect"
-	"sync"
 	"testing"
 
 	"github.com/vdaas/vald/apis/grpc/v1/filter/egress"
@@ -115,7 +114,6 @@ func Test_client_Start(t *testing.T) {
 	}
 	type fields struct {
 		addrs []string
-		cl    sync.Map
 		c     grpc.Client
 	}
 	type want struct {
@@ -150,7 +148,6 @@ func Test_client_Start(t *testing.T) {
 		       },
 		       fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		       },
 		       want: want{},
@@ -168,7 +165,6 @@ func Test_client_Start(t *testing.T) {
 		           },
 		           fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		           },
 		           want: want{},
@@ -195,7 +191,6 @@ func Test_client_Start(t *testing.T) {
 			}
 			c := &client{
 				addrs: test.fields.addrs,
-				cl:    test.fields.cl,
 				c:     test.fields.c,
 			}
 
@@ -214,7 +209,6 @@ func Test_client_Stop(t *testing.T) {
 	}
 	type fields struct {
 		addrs []string
-		cl    sync.Map
 		c     grpc.Client
 	}
 	type want struct {
@@ -245,7 +239,6 @@ func Test_client_Stop(t *testing.T) {
 		       },
 		       fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		       },
 		       want: want{},
@@ -263,7 +256,6 @@ func Test_client_Stop(t *testing.T) {
 		           },
 		           fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		           },
 		           want: want{},
@@ -290,7 +282,6 @@ func Test_client_Stop(t *testing.T) {
 			}
 			c := &client{
 				addrs: test.fields.addrs,
-				cl:    test.fields.cl,
 				c:     test.fields.c,
 			}
 
@@ -306,7 +297,6 @@ func Test_client_GRPCClient(t *testing.T) {
 	t.Parallel()
 	type fields struct {
 		addrs []string
-		cl    sync.Map
 		c     grpc.Client
 	}
 	type want struct {
@@ -333,7 +323,6 @@ func Test_client_GRPCClient(t *testing.T) {
 		       name: "test_case_1",
 		       fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		       },
 		       want: want{},
@@ -348,7 +337,6 @@ func Test_client_GRPCClient(t *testing.T) {
 		           name: "test_case_2",
 		           fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		           },
 		           want: want{},
@@ -375,7 +363,6 @@ func Test_client_GRPCClient(t *testing.T) {
 			}
 			c := &client{
 				addrs: test.fields.addrs,
-				cl:    test.fields.cl,
 				c:     test.fields.c,
 			}
 
@@ -395,7 +382,6 @@ func Test_client_Target(t *testing.T) {
 	}
 	type fields struct {
 		addrs []string
-		cl    sync.Map
 		c     grpc.Client
 	}
 	type want struct {
@@ -431,7 +417,6 @@ func Test_client_Target(t *testing.T) {
 		       },
 		       fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		       },
 		       want: want{},
@@ -450,7 +435,6 @@ func Test_client_Target(t *testing.T) {
 		           },
 		           fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		           },
 		           want: want{},
@@ -477,7 +461,6 @@ func Test_client_Target(t *testing.T) {
 			}
 			c := &client{
 				addrs: test.fields.addrs,
-				cl:    test.fields.cl,
 				c:     test.fields.c,
 			}
 
@@ -498,7 +481,6 @@ func Test_client_FilterDistance(t *testing.T) {
 	}
 	type fields struct {
 		addrs []string
-		cl    sync.Map
 		c     grpc.Client
 	}
 	type want struct {
@@ -535,7 +517,6 @@ func Test_client_FilterDistance(t *testing.T) {
 		       },
 		       fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		       },
 		       want: want{},
@@ -555,7 +536,6 @@ func Test_client_FilterDistance(t *testing.T) {
 		           },
 		           fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		           },
 		           want: want{},
@@ -582,7 +562,6 @@ func Test_client_FilterDistance(t *testing.T) {
 			}
 			c := &client{
 				addrs: test.fields.addrs,
-				cl:    test.fields.cl,
 				c:     test.fields.c,
 			}
 
@@ -805,7 +784,6 @@ func Test_client_FilterVector(t *testing.T) {
 	}
 	type fields struct {
 		addrs []string
-		cl    sync.Map
 		c     grpc.Client
 	}
 	type want struct {
@@ -842,7 +820,6 @@ func Test_client_FilterVector(t *testing.T) {
 		       },
 		       fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		       },
 		       want: want{},
@@ -862,7 +839,6 @@ func Test_client_FilterVector(t *testing.T) {
 		           },
 		           fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		           },
 		           want: want{},
@@ -889,7 +865,6 @@ func Test_client_FilterVector(t *testing.T) {
 			}
 			c := &client{
 				addrs: test.fields.addrs,
-				cl:    test.fields.cl,
 				c:     test.fields.c,
 			}
 

--- a/internal/client/v1/client/filter/ingress/client_test.go
+++ b/internal/client/v1/client/filter/ingress/client_test.go
@@ -20,7 +20,6 @@ package ingress
 import (
 	"context"
 	"reflect"
-	"sync"
 	"testing"
 
 	"github.com/vdaas/vald/apis/grpc/v1/filter/ingress"
@@ -115,7 +114,6 @@ func Test_client_Start(t *testing.T) {
 	}
 	type fields struct {
 		addrs []string
-		cl    sync.Map
 		c     grpc.Client
 	}
 	type want struct {
@@ -150,7 +148,6 @@ func Test_client_Start(t *testing.T) {
 		       },
 		       fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		       },
 		       want: want{},
@@ -168,7 +165,6 @@ func Test_client_Start(t *testing.T) {
 		           },
 		           fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		           },
 		           want: want{},
@@ -195,7 +191,6 @@ func Test_client_Start(t *testing.T) {
 			}
 			c := &client{
 				addrs: test.fields.addrs,
-				cl:    test.fields.cl,
 				c:     test.fields.c,
 			}
 
@@ -214,7 +209,6 @@ func Test_client_Stop(t *testing.T) {
 	}
 	type fields struct {
 		addrs []string
-		cl    sync.Map
 		c     grpc.Client
 	}
 	type want struct {
@@ -245,7 +239,6 @@ func Test_client_Stop(t *testing.T) {
 		       },
 		       fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		       },
 		       want: want{},
@@ -263,7 +256,6 @@ func Test_client_Stop(t *testing.T) {
 		           },
 		           fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		           },
 		           want: want{},
@@ -290,7 +282,6 @@ func Test_client_Stop(t *testing.T) {
 			}
 			c := &client{
 				addrs: test.fields.addrs,
-				cl:    test.fields.cl,
 				c:     test.fields.c,
 			}
 
@@ -306,7 +297,6 @@ func Test_client_GRPCClient(t *testing.T) {
 	t.Parallel()
 	type fields struct {
 		addrs []string
-		cl    sync.Map
 		c     grpc.Client
 	}
 	type want struct {
@@ -333,7 +323,6 @@ func Test_client_GRPCClient(t *testing.T) {
 		       name: "test_case_1",
 		       fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		       },
 		       want: want{},
@@ -348,7 +337,6 @@ func Test_client_GRPCClient(t *testing.T) {
 		           name: "test_case_2",
 		           fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		           },
 		           want: want{},
@@ -375,7 +363,6 @@ func Test_client_GRPCClient(t *testing.T) {
 			}
 			c := &client{
 				addrs: test.fields.addrs,
-				cl:    test.fields.cl,
 				c:     test.fields.c,
 			}
 
@@ -395,7 +382,6 @@ func Test_client_Target(t *testing.T) {
 	}
 	type fields struct {
 		addrs []string
-		cl    sync.Map
 		c     grpc.Client
 	}
 	type want struct {
@@ -431,7 +417,6 @@ func Test_client_Target(t *testing.T) {
 		       },
 		       fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		       },
 		       want: want{},
@@ -450,7 +435,6 @@ func Test_client_Target(t *testing.T) {
 		           },
 		           fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		           },
 		           want: want{},
@@ -477,7 +461,6 @@ func Test_client_Target(t *testing.T) {
 			}
 			c := &client{
 				addrs: test.fields.addrs,
-				cl:    test.fields.cl,
 				c:     test.fields.c,
 			}
 
@@ -498,7 +481,6 @@ func Test_client_GenVector(t *testing.T) {
 	}
 	type fields struct {
 		addrs []string
-		cl    sync.Map
 		c     grpc.Client
 	}
 	type want struct {
@@ -535,7 +517,6 @@ func Test_client_GenVector(t *testing.T) {
 		       },
 		       fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		       },
 		       want: want{},
@@ -555,7 +536,6 @@ func Test_client_GenVector(t *testing.T) {
 		           },
 		           fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		           },
 		           want: want{},
@@ -582,7 +562,6 @@ func Test_client_GenVector(t *testing.T) {
 			}
 			c := &client{
 				addrs: test.fields.addrs,
-				cl:    test.fields.cl,
 				c:     test.fields.c,
 			}
 
@@ -603,7 +582,6 @@ func Test_client_FilterVector(t *testing.T) {
 	}
 	type fields struct {
 		addrs []string
-		cl    sync.Map
 		c     grpc.Client
 	}
 	type want struct {
@@ -640,7 +618,6 @@ func Test_client_FilterVector(t *testing.T) {
 		       },
 		       fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		       },
 		       want: want{},
@@ -660,7 +637,6 @@ func Test_client_FilterVector(t *testing.T) {
 		           },
 		           fields: fields {
 		           addrs: nil,
-		           cl: sync.Map{},
 		           c: nil,
 		           },
 		           want: want{},
@@ -687,7 +663,6 @@ func Test_client_FilterVector(t *testing.T) {
 			}
 			c := &client{
 				addrs: test.fields.addrs,
-				cl:    test.fields.cl,
 				c:     test.fields.c,
 			}
 


### PR DESCRIPTION


### Description:

As titled

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
