### PR TITLE
Fix deepsource: VET-V0008 Lock erroneously passed by value (internal/test, singleflight, observability)

### DIFF
--- a/internal/observability/metrics/agent/sidecar/sidecar_test.go
+++ b/internal/observability/metrics/agent/sidecar/sidecar_test.go
@@ -16,7 +16,6 @@ package sidecar
 import (
 	"context"
 	"reflect"
-	"sync"
 	"testing"
 
 	"github.com/vdaas/vald/internal/errors"
@@ -96,7 +95,6 @@ func Test_sidecarMetrics_Register(t *testing.T) {
 		storageTypeKey string
 		bucketNameKey  string
 		filenameKey    string
-		mu             sync.Mutex
 		info           *observer.BackupInfo
 	}
 	type want struct {
@@ -129,7 +127,6 @@ func Test_sidecarMetrics_Register(t *testing.T) {
 		           storageTypeKey: "",
 		           bucketNameKey: "",
 		           filenameKey: "",
-		           mu: nil,
 		           info: nil,
 		       },
 		       want: want{},
@@ -149,7 +146,6 @@ func Test_sidecarMetrics_Register(t *testing.T) {
 		           storageTypeKey: "",
 		           bucketNameKey: "",
 		           filenameKey: "",
-		           mu: nil,
 		           info: nil,
 		           },
 		           want: want{},
@@ -178,7 +174,6 @@ func Test_sidecarMetrics_Register(t *testing.T) {
 				storageTypeKey: test.fields.storageTypeKey,
 				bucketNameKey:  test.fields.bucketNameKey,
 				filenameKey:    test.fields.filenameKey,
-				mu:             test.fields.mu,
 				info:           test.fields.info,
 			}
 
@@ -199,7 +194,6 @@ func Test_sidecarMetrics_BeforeProcess(t *testing.T) {
 		storageTypeKey string
 		bucketNameKey  string
 		filenameKey    string
-		mu             sync.Mutex
 		info           *observer.BackupInfo
 	}
 	type want struct {
@@ -237,7 +231,6 @@ func Test_sidecarMetrics_BeforeProcess(t *testing.T) {
 		           storageTypeKey: "",
 		           bucketNameKey: "",
 		           filenameKey: "",
-		           mu: nil,
 		           info: nil,
 		       },
 		       want: want{},
@@ -258,7 +251,6 @@ func Test_sidecarMetrics_BeforeProcess(t *testing.T) {
 		           storageTypeKey: "",
 		           bucketNameKey: "",
 		           filenameKey: "",
-		           mu: nil,
 		           info: nil,
 		           },
 		           want: want{},
@@ -287,7 +279,6 @@ func Test_sidecarMetrics_BeforeProcess(t *testing.T) {
 				storageTypeKey: test.fields.storageTypeKey,
 				bucketNameKey:  test.fields.bucketNameKey,
 				filenameKey:    test.fields.filenameKey,
-				mu:             test.fields.mu,
 				info:           test.fields.info,
 			}
 
@@ -308,7 +299,6 @@ func Test_sidecarMetrics_AfterProcess(t *testing.T) {
 		storageTypeKey string
 		bucketNameKey  string
 		filenameKey    string
-		mu             sync.Mutex
 		info           *observer.BackupInfo
 	}
 	type want struct {
@@ -342,7 +332,6 @@ func Test_sidecarMetrics_AfterProcess(t *testing.T) {
 		           storageTypeKey: "",
 		           bucketNameKey: "",
 		           filenameKey: "",
-		           mu: nil,
 		           info: nil,
 		       },
 		       want: want{},
@@ -363,7 +352,6 @@ func Test_sidecarMetrics_AfterProcess(t *testing.T) {
 		           storageTypeKey: "",
 		           bucketNameKey: "",
 		           filenameKey: "",
-		           mu: nil,
 		           info: nil,
 		           },
 		           want: want{},
@@ -392,7 +380,6 @@ func Test_sidecarMetrics_AfterProcess(t *testing.T) {
 				storageTypeKey: test.fields.storageTypeKey,
 				bucketNameKey:  test.fields.bucketNameKey,
 				filenameKey:    test.fields.filenameKey,
-				mu:             test.fields.mu,
 				info:           test.fields.info,
 			}
 
@@ -409,7 +396,6 @@ func Test_sidecarMetrics_View(t *testing.T) {
 		storageTypeKey string
 		bucketNameKey  string
 		filenameKey    string
-		mu             sync.Mutex
 		info           *observer.BackupInfo
 	}
 	type want struct {
@@ -442,7 +428,6 @@ func Test_sidecarMetrics_View(t *testing.T) {
 		           storageTypeKey: "",
 		           bucketNameKey: "",
 		           filenameKey: "",
-		           mu: nil,
 		           info: nil,
 		       },
 		       want: want{},
@@ -459,7 +444,6 @@ func Test_sidecarMetrics_View(t *testing.T) {
 		           storageTypeKey: "",
 		           bucketNameKey: "",
 		           filenameKey: "",
-		           mu: nil,
 		           info: nil,
 		           },
 		           want: want{},
@@ -488,7 +472,6 @@ func Test_sidecarMetrics_View(t *testing.T) {
 				storageTypeKey: test.fields.storageTypeKey,
 				bucketNameKey:  test.fields.bucketNameKey,
 				filenameKey:    test.fields.filenameKey,
-				mu:             test.fields.mu,
 				info:           test.fields.info,
 			}
 

--- a/internal/singleflight/singleflight_test.go
+++ b/internal/singleflight/singleflight_test.go
@@ -86,7 +86,6 @@ func Test_group_Do(t *testing.T) {
 		key string
 		fn  func() (interface{}, error)
 	}
-	type fields struct{}
 	type want struct {
 		wantV      interface{}
 		wantShared bool
@@ -95,7 +94,6 @@ func Test_group_Do(t *testing.T) {
 	type test struct {
 		name       string
 		args       args
-		fields     fields
 		want       want
 		beforeFunc func(args)
 		execFunc   func(*testing.T, *group, args) (interface{}, bool, error)

--- a/internal/singleflight/singleflight_test.go
+++ b/internal/singleflight/singleflight_test.go
@@ -86,9 +86,7 @@ func Test_group_Do(t *testing.T) {
 		key string
 		fn  func() (interface{}, error)
 	}
-	type fields struct {
-		m sync.Map
-	}
+	type fields struct{}
 	type want struct {
 		wantV      interface{}
 		wantShared bool
@@ -278,9 +276,7 @@ func Test_group_Do(t *testing.T) {
 				test.beforeFunc(test.args)
 			}
 
-			g := &group{
-				m: test.fields.m,
-			}
+			g := &group{}
 
 			execFunc := defaultExecFunc
 			if test.execFunc != nil {

--- a/internal/test/comparator/comparators.go
+++ b/internal/test/comparator/comparators.go
@@ -25,7 +25,9 @@ var (
 		return reflect.DeepEqual(x, y)
 	})
 
+	// skipcq: VET-V0008
 	MutexComparer = Comparer(func(x, y sync.Mutex) bool {
+		// skipcq: VET-V0008
 		return reflect.DeepEqual(x, y)
 	})
 
@@ -37,11 +39,15 @@ var (
 		return errors.Is(x, y)
 	})
 
+	// skipcq: VET-V0008
 	OnceComparer = Comparer(func(x, y sync.Once) bool {
+		// skipcq: VET-V0008
 		return reflect.DeepEqual(x, y)
 	})
 
+	// skipcq: VET-V0008
 	WaitGroupComparer = Comparer(func(x, y sync.WaitGroup) bool {
+		// skipcq: VET-V0008
 		return reflect.DeepEqual(x, y)
 	})
 )


### PR DESCRIPTION


### Description:

As titled

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
