### PR TITLE
fix deepsource: [CRT-D0001] append possibly assigns to a wrong variable

### DIFF
--- a/internal/test/data/request/insert_test.go
+++ b/internal/test/data/request/insert_test.go
@@ -52,6 +52,7 @@ func TestGenMultiInsertReq(t *testing.T) {
 		afterFunc  func(args)
 	}
 	dim := 10
+	// skipcq: CRT-D0001
 	comparators := append(defaultMultiInsertReqComparators, comparator.IgnoreFields(payload.Object_Vector{}, "Vector"))
 
 	defaultCheckFunc := func(w want, got *payload.Insert_MultiRequest, err error) error {

--- a/pkg/gateway/lb/handler/grpc/handler.go
+++ b/pkg/gateway/lb/handler/grpc/handler.go
@@ -554,6 +554,7 @@ func (s *server) search(ctx context.Context, cfg *payload.Search_Config,
 			case pos == rl-1:
 				res.Results = append(res.GetResults(), dist)
 			case pos >= 0:
+				// skipcq: CRT-D0001
 				res.Results = append(res.GetResults()[:pos+1], res.GetResults()[pos:]...)
 				res.Results[pos+1] = dist
 			}

--- a/pkg/gateway/lb/usecase/vald.go
+++ b/pkg/gateway/lb/usecase/vald.go
@@ -55,6 +55,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	if err != nil {
 		return nil, err
 	}
+	// skipcq: CRT-D0001
 	dopts := append(
 		cOpts,
 		grpc.WithErrGroup(eg))
@@ -62,6 +63,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	if err != nil {
 		return nil, err
 	}
+	// skipcq: CRT-D0001
 	aopts := append(
 		acOpts,
 		grpc.WithErrGroup(eg))

--- a/pkg/manager/index/usecase/indexer.go
+++ b/pkg/manager/index/usecase/indexer.go
@@ -56,6 +56,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	if err != nil {
 		return nil, err
 	}
+	// skipcq: CRT-D0001
 	dopts := append(
 		cOpts,
 		grpc.WithErrGroup(eg))
@@ -64,6 +65,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	if err != nil {
 		return nil, err
 	}
+	// skipcq: CRT-D0001
 	aopts := append(
 		acOpts,
 		grpc.WithErrGroup(eg))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
SSIA

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
