### PR TITLE
:recycle: Fix deepsource: VET-V0008 lock erroneously passed by value (internal/net)

### DIFF
--- a/internal/net/dialer_test.go
+++ b/internal/net/dialer_test.go
@@ -275,9 +275,6 @@ func TestNewDialer(t *testing.T) {
 				if x == nil && y == nil {
 					return true
 				}
-				if x == nil || y == nil {
-					return false
-				}
 				return reflect.DeepEqual(x, y)
 			}),
 			cmp.Comparer(func(x, y *tls.Config) bool {

--- a/internal/net/http/client/client_test.go
+++ b/internal/net/http/client/client_test.go
@@ -63,19 +63,25 @@ var (
 		comparator.Comparer(func(x, y func(ctx context.Context, network, addr string) (net.Conn, error)) bool {
 			return reflect.ValueOf(x).Pointer() == reflect.ValueOf(y).Pointer()
 		}),
+		// skipcq: VET-V0008
 		comparator.Comparer(func(x, y sync.Mutex) bool {
+			// skipcq: VET-V0008
 			return reflect.DeepEqual(x, y)
 		}),
 		comparator.Comparer(func(x, y atomic.Value) bool {
 			return reflect.DeepEqual(x.Load(), y.Load())
 		}),
+		// skipcq: VET-V0008
 		comparator.Comparer(func(x, y sync.Once) bool {
+			// skipcq: VET-V0008
 			return reflect.DeepEqual(x, y)
 		}),
 		comparator.Comparer(func(x, y *tls.Config) bool {
 			return reflect.DeepEqual(x, y)
 		}),
+		// skipcq: VET-V0008
 		comparator.Comparer(func(x, y sync.WaitGroup) bool {
+			// skipcq: VET-V0008
 			return reflect.DeepEqual(x, y)
 		}),
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
I have fixed `VET-V0008` under the `internal/net` package.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
