### PR TITLE
Fix deepsource: VET-V0008 lock erroneously passed by value (internal/info test)

### DIFF
--- a/internal/info/info_test.go
+++ b/internal/info/info_test.go
@@ -206,7 +206,9 @@ func TestInit(t *testing.T) {
 	defaultCheckFunc := func(w want, got Info) error {
 		opts := []comparator.Option{
 			comparator.AllowUnexported(info{}),
+			// skipcq: VET-V0008
 			comparator.Comparer(func(x, y sync.Once) bool {
+				// skipcq: VET-V0008
 				return reflect.DeepEqual(x, y)
 			}),
 			comparator.Comparer(func(x, y func(skip int) (pc uintptr, file string, line int, ok bool)) bool {
@@ -379,7 +381,9 @@ func TestNew(t *testing.T) {
 		}
 		opts := []comparator.Option{
 			comparator.AllowUnexported(info{}),
+			// skipcq: VET-V0008
 			comparator.Comparer(func(x, y sync.Once) bool {
+				// skipcq: VET-V0008
 				return reflect.DeepEqual(x, y)
 			}),
 			comparator.Comparer(func(x, y func(skip int) (pc uintptr, file string, line int, ok bool)) bool {
@@ -571,7 +575,6 @@ func TestNew(t *testing.T) {
 func Test_info_String(t *testing.T) {
 	type fields struct {
 		detail      Detail
-		prepOnce    sync.Once
 		rtCaller    func(skip int) (pc uintptr, file string, line int, ok bool)
 		rtFuncForPC func(pc uintptr) *runtime.Func
 	}
@@ -665,7 +668,6 @@ func Test_info_String(t *testing.T) {
 			}
 			i := info{
 				detail:      test.fields.detail,
-				prepOnce:    test.fields.prepOnce,
 				rtCaller:    test.fields.rtCaller,
 				rtFuncForPC: test.fields.rtFuncForPC,
 			}
@@ -796,7 +798,6 @@ func TestDetail_String(t *testing.T) {
 func Test_info_Get(t *testing.T) {
 	type fields struct {
 		detail      Detail
-		prepOnce    sync.Once
 		rtCaller    func(skip int) (pc uintptr, file string, line int, ok bool)
 		rtFuncForPC func(pc uintptr) *runtime.Func
 	}
@@ -1137,7 +1138,6 @@ func Test_info_Get(t *testing.T) {
 			}
 			i := info{
 				detail:      test.fields.detail,
-				prepOnce:    test.fields.prepOnce,
 				rtCaller:    test.fields.rtCaller,
 				rtFuncForPC: test.fields.rtFuncForPC,
 			}
@@ -1153,7 +1153,6 @@ func Test_info_Get(t *testing.T) {
 func Test_info_prepare(t *testing.T) {
 	type fields struct {
 		detail      Detail
-		prepOnce    sync.Once
 		rtCaller    func(skip int) (pc uintptr, file string, line int, ok bool)
 		rtFuncForPC func(pc uintptr) *runtime.Func
 	}
@@ -1168,11 +1167,13 @@ func Test_info_prepare(t *testing.T) {
 		beforeFunc func()
 		afterFunc  func()
 	}
+	// skipcq: VET-V0008
 	defaultCheckFunc := func(got info, w want) error {
 		opts := []comparator.Option{
 			comparator.AllowUnexported(info{}),
 			comparator.IgnoreFields(info{}, "prepOnce"),
 		}
+		// skipcq: VET-V0008
 		if diff := comparator.Diff(w.want, got, opts...); len(diff) != 0 {
 			return errors.Errorf("err: %s", diff)
 		}
@@ -1487,11 +1488,9 @@ func Test_info_prepare(t *testing.T) {
 			}
 			i := &info{
 				detail:      test.fields.detail,
-				prepOnce:    test.fields.prepOnce,
 				rtCaller:    test.fields.rtCaller,
 				rtFuncForPC: test.fields.rtFuncForPC,
 			}
-
 			i.prepare()
 			if err := checkFunc(*i, test.want); err != nil {
 				tt.Errorf("error = %v", err)
@@ -1572,7 +1571,6 @@ func Test_info_get(t *testing.T) {
 	type fields struct {
 		baseURL     string
 		detail      Detail
-		prepOnce    sync.Once
 		rtCaller    func(skip int) (pc uintptr, file string, line int, ok bool)
 		rtFuncForPC func(pc uintptr) *runtime.Func
 	}
@@ -1647,7 +1645,6 @@ func Test_info_get(t *testing.T) {
 			i := info{
 				baseURL:     test.fields.baseURL,
 				detail:      test.fields.detail,
-				prepOnce:    test.fields.prepOnce,
 				rtCaller:    test.fields.rtCaller,
 				rtFuncForPC: test.fields.rtFuncForPC,
 			}

--- a/internal/info/option_test.go
+++ b/internal/info/option_test.go
@@ -128,7 +128,9 @@ func TestWithRuntimeCaller(t *testing.T) {
 
 		opts := []comparator.Option{
 			comparator.AllowUnexported(info{}),
+			// skipcq: VET-V0008
 			comparator.Comparer(func(x, y sync.Once) bool {
+				// skipcq: VET-V0008
 				return reflect.DeepEqual(x, y)
 			}),
 			comparator.Comparer(func(x, y func(skip int) (pc uintptr, file string, line int, ok bool)) bool {
@@ -224,7 +226,9 @@ func TestWithRuntimeFuncForPC(t *testing.T) {
 
 		opts := []comparator.Option{
 			comparator.AllowUnexported(info{}),
+			// skipcp: VET-V0008
 			comparator.Comparer(func(x, y sync.Once) bool {
+				// skipcp: VET-V0008
 				return reflect.DeepEqual(x, y)
 			}),
 			comparator.Comparer(func(x, y func(skip int) (pc uintptr, file string, line int, ok bool)) bool {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
SSIA

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
