### PR TITLE
Fix deepsource: DOK-W1001 found consecutive run command

### DIFF
--- a/dockers/operator/helm/Dockerfile
+++ b/dockers/operator/helm/Dockerfile
@@ -78,24 +78,23 @@ COPY Makefile.d .
 WORKDIR ${GOPATH}/src/github.com/${ORG}/${REPO}
 COPY Makefile .
 
-RUN make helm/schema/vald helm/schema/vald-helm-operator
-
-RUN cp -r charts /charts
+RUN make helm/schema/vald helm/schema/vald-helm-operator \
+    && cp -r charts /charts
 
 # skipcq: DOK-DL3008
 RUN apt-get clean \
     && rm -rf \
         /var/lib/apt/lists/* \
         /var/cache/* \
-    && apt update -y \
-    && apt upgrade -y \
-    && apt install -y --no-install-recommends --fix-missing \
+    && apt-get update -y \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends --fix-missing \
     upx \
-    && apt clean \
+    && apt-get clean \
     && rm -rf \
         /var/lib/apt/lists/* \
         /var/cache/* \
-    && apt autoremove
+    && apt-get autoremove
 
 ENV APP_NAME helm-operator
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
I have fixed the new `DOK-W1001` warning.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
