### PR TITLE
Remove deprecated functional option (internal/net/grpc)

### DIFF
--- a/internal/net/grpc/option.go
+++ b/internal/net/grpc/option.go
@@ -294,18 +294,6 @@ func WithInsecure(flg bool) Option {
 	}
 }
 
-// func WithDialTimeout(dur string) Option {
-// 	return func(g *gRPCClient) {
-// 		d, err := timeutil.Parse(dur)
-// 		if err != nil {
-// 			return
-// 		}
-// 		g.dopts = append(g.dopts,
-// 			grpc.WithTimeout(d),
-// 		)
-// 	}
-// }
-
 func WithKeepaliveParams(t, to string, permitWithoutStream bool) Option {
 	return func(g *gRPCClient) {
 		if len(t) == 0 || len(to) == 0 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
SSIA

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
