### PR TITLE
Remove blank when all parameters are not used and Add ErrJobFuncNotFound

### DIFF
--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -170,7 +170,7 @@ func (b *backoff) Close() {
 	b.wg.Wait()
 }
 
-func Metrics(_ context.Context) map[string]int64 {
+func Metrics(context.Context) map[string]int64 {
 	mu.RLock()
 	defer mu.RUnlock()
 

--- a/internal/circuitbreaker/manager.go
+++ b/internal/circuitbreaker/manager.go
@@ -109,7 +109,7 @@ func (bm *breakerManager) Do(ctx context.Context, key string, fn func(ctx contex
 	return val, nil
 }
 
-func Metrics(_ context.Context) map[string]map[State]int64 {
+func Metrics(context.Context) map[string]map[State]int64 {
 	mu.RLock()
 	defer mu.RUnlock()
 

--- a/internal/client/v1/client/vald/vald.go
+++ b/internal/client/v1/client/vald/vald.go
@@ -621,11 +621,11 @@ func (c *client) StreamGetObject(ctx context.Context, opts ...grpc.CallOption) (
 	return res, nil
 }
 
-func (*singleClient) Start(_ context.Context) (<-chan error, error) {
+func (*singleClient) Start(context.Context) (<-chan error, error) {
 	return nil, nil
 }
 
-func (*singleClient) Stop(_ context.Context) error {
+func (*singleClient) Stop(context.Context) error {
 	return nil
 }
 

--- a/internal/db/kvs/redis/redis_mock.go
+++ b/internal/db/kvs/redis/redis_mock.go
@@ -34,7 +34,7 @@ func (m *MockRedis) TxPipeline() redis.Pipeliner {
 	return m.TxPipelineFunc()
 }
 
-func (m *MockRedis) Ping(_ context.Context) *StatusCmd {
+func (m *MockRedis) Ping(context.Context) *StatusCmd {
 	return m.PingFunc()
 }
 
@@ -62,7 +62,7 @@ func (*dummyHook) BeforeProcess(ctx context.Context, _ Cmder) (context.Context, 
 	return ctx, nil
 }
 
-func (*dummyHook) AfterProcess(_ context.Context, _ Cmder) error {
+func (*dummyHook) AfterProcess(context.Context, Cmder) error {
 	return nil
 }
 
@@ -70,7 +70,7 @@ func (*dummyHook) BeforeProcessPipeline(ctx context.Context, _ []Cmder) (context
 	return ctx, nil
 }
 
-func (*dummyHook) AfterProcessPipeline(_ context.Context, _ []Cmder) error {
+func (*dummyHook) AfterProcessPipeline(context.Context, []Cmder) error {
 	return nil
 }
 

--- a/internal/db/nosql/cassandra/cassandra.go
+++ b/internal/db/nosql/cassandra/cassandra.go
@@ -315,7 +315,7 @@ func (c *client) Open(ctx context.Context) (err error) {
 }
 
 // Close closes the session to cassandra.
-func (c *client) Close(_ context.Context) error {
+func (c *client) Close(context.Context) error {
 	c.session.Close()
 	return nil
 }

--- a/internal/db/nosql/cassandra/cassandra.go
+++ b/internal/db/nosql/cassandra/cassandra.go
@@ -379,7 +379,7 @@ func WrapErrorWithKeys(err error, keys ...string) error {
 	case ErrNotFound:
 		return errors.ErrCassandraNotFound(keys...)
 	case ErrUnavailable:
-		return errors.ErrCassandraUnavailable()
+		return errors.ErrCassandraUnavailable
 	case ErrUnsupported:
 		return err
 	case ErrTooManyStmts:

--- a/internal/db/nosql/cassandra/cassandra_mock.go
+++ b/internal/db/nosql/cassandra/cassandra_mock.go
@@ -39,4 +39,4 @@ func (dm *DialerMock) DialContext(ctx context.Context, network, addr string) (ne
 func (dm *DialerMock) GetDialer() func(ctx context.Context, network, addr string) (net.Conn, error) {
 	return dm.DialContextFunc
 }
-func (*DialerMock) StartDialerCache(_ context.Context) {}
+func (*DialerMock) StartDialerCache(context.Context) {}

--- a/internal/db/nosql/cassandra/cassandra_test.go
+++ b/internal/db/nosql/cassandra/cassandra_test.go
@@ -2219,7 +2219,7 @@ func TestWrapErrorWithKeys(t *testing.T) {
 				err: ErrUnavailable,
 			},
 			want: want{
-				err: errors.ErrCassandraUnavailable(),
+				err: errors.ErrCassandraUnavailable,
 			},
 		},
 		{

--- a/internal/db/rdb/mysql/mysql.go
+++ b/internal/db/rdb/mysql/mysql.go
@@ -180,7 +180,7 @@ func (m *mySQLClient) Ping(ctx context.Context) (err error) {
 
 // Close closes the connection of MySQL database.
 // If the connection is already closed or closing connection is failed, it returns error.
-func (m *mySQLClient) Close(_ context.Context) (err error) {
+func (m *mySQLClient) Close(context.Context) (err error) {
 	if m.session == nil {
 		err = errors.ErrMySQLSessionNil
 		m.errorLog(err)

--- a/internal/db/storage/blob/s3/s3.go
+++ b/internal/db/storage/blob/s3/s3.go
@@ -89,7 +89,7 @@ func New(opts ...Option) (b blob.Bucket, err error) {
 }
 
 // Open does nothing. Always returns nil.
-func (*client) Open(_ context.Context) (err error) {
+func (*client) Open(context.Context) (err error) {
 	return nil
 }
 

--- a/internal/errors/cassandra.go
+++ b/internal/errors/cassandra.go
@@ -23,18 +23,14 @@ var (
 		return Errorf("consistetncy type %q is not defined", consistency)
 	}
 
-	// NewErrCassandraNotFoundIdentity represents a function to generate an error of cassandra entry not found.
-	NewErrCassandraNotFoundIdentity = func() error {
-		return &ErrCassandraNotFoundIdentity{
-			err: New("cassandra entry not found"),
-		}
+	// NewErrCassandraNotFoundIdentity generates an error of cassandra entry not found.
+	NewErrCassandraNotFoundIdentity = &ErrCassandraNotFoundIdentity{
+		err: New("cassandra entry not found"),
 	}
 
-	// NewErrCassandraUnavailableIdentity represents a function to generate an error of cassandra unavailable.
-	NewErrCassandraUnavailableIdentity = func() error {
-		return &ErrCassandraUnavailableIdentity{
-			err: New("cassandra unavailable"),
-		}
+	// NewErrCassandraUnavailableIdentity generates an error of cassandra unavailable.
+	NewErrCassandraUnavailableIdentity = &ErrCassandraUnavailableIdentity{
+		err: New("cassandra unavailable"),
 	}
 
 	// ErrCassandraUnavailable represents NewErrCassandraUnavailableIdentity.
@@ -44,9 +40,9 @@ var (
 	ErrCassandraNotFound = func(keys ...string) error {
 		switch {
 		case len(keys) == 1:
-			return Wrapf(NewErrCassandraNotFoundIdentity(), "cassandra key '%s' not found", keys[0])
+			return Wrapf(NewErrCassandraNotFoundIdentity, "cassandra key '%s' not found", keys[0])
 		case len(keys) > 1:
-			return Wrapf(NewErrCassandraNotFoundIdentity(), "cassandra keys '%v' not found", keys)
+			return Wrapf(NewErrCassandraNotFoundIdentity, "cassandra keys '%v' not found", keys)
 		default:
 			return nil
 		}

--- a/internal/errors/cassandra.go
+++ b/internal/errors/cassandra.go
@@ -23,26 +23,26 @@ var (
 		return Errorf("consistetncy type %q is not defined", consistency)
 	}
 
-	// NewErrCassandraNotFoundIdentity generates an error of cassandra entry not found.
-	NewErrCassandraNotFoundIdentity = &ErrCassandraNotFoundIdentity{
+	// ErrCassandraNotFoundIdentity generates an error of cassandra entry not found.
+	ErrCassandraNotFoundIdentity = &CassandraNotFoundIdentityError{
 		err: New("cassandra entry not found"),
 	}
 
-	// NewErrCassandraUnavailableIdentity generates an error of cassandra unavailable.
-	NewErrCassandraUnavailableIdentity = &ErrCassandraUnavailableIdentity{
+	// ErrCassandraUnavailableIdentity generates an error of cassandra unavailable.
+	ErrCassandraUnavailableIdentity = &CassandraUnavailableIdentityError{
 		err: New("cassandra unavailable"),
 	}
 
 	// ErrCassandraUnavailable represents NewErrCassandraUnavailableIdentity.
-	ErrCassandraUnavailable = NewErrCassandraUnavailableIdentity
+	ErrCassandraUnavailable = ErrCassandraUnavailableIdentity
 
 	// ErrCassandraNotFound represents a function to generate an error of cassandra keys not found.
 	ErrCassandraNotFound = func(keys ...string) error {
 		switch {
 		case len(keys) == 1:
-			return Wrapf(NewErrCassandraNotFoundIdentity, "cassandra key '%s' not found", keys[0])
+			return Wrapf(ErrCassandraNotFoundIdentity, "cassandra key '%s' not found", keys[0])
 		case len(keys) > 1:
-			return Wrapf(NewErrCassandraNotFoundIdentity, "cassandra keys '%v' not found", keys)
+			return Wrapf(ErrCassandraNotFoundIdentity, "cassandra keys '%v' not found", keys)
 		default:
 			return nil
 		}
@@ -72,44 +72,44 @@ var (
 	}
 )
 
-// ErrCassandraNotFoundIdentity represents custom error for cassandra not found.
-type ErrCassandraNotFoundIdentity struct {
+// CassandraNotFoundIdentityError represents custom error for cassandra not found.
+type CassandraNotFoundIdentityError struct {
 	err error
 }
 
 // Error returns string of internal error.
-func (e *ErrCassandraNotFoundIdentity) Error() string {
+func (e *CassandraNotFoundIdentityError) Error() string {
 	return e.err.Error()
 }
 
 // Unwrap returns an internal error.
-func (e *ErrCassandraNotFoundIdentity) Unwrap() error {
+func (e *CassandraNotFoundIdentityError) Unwrap() error {
 	return e.err
 }
 
-// IsErrCassandraNotFound reports whether any error in err's chain matches ErrCassandraNotFound.
-func IsErrCassandraNotFound(err error) bool {
-	target := new(ErrCassandraNotFoundIdentity)
+// IsCassandraNotFoundError reports whether any error in err's chain matches CassandraNotFoundError.
+func IsCassandraNotFoundError(err error) bool {
+	target := new(CassandraNotFoundIdentityError)
 	return As(err, &target)
 }
 
-// ErrCassandraUnavailableIdentity represents custom error for cassandra unavailable.
-type ErrCassandraUnavailableIdentity struct {
+// CassandraUnavailableIdentityError represents custom error for cassandra unavailable.
+type CassandraUnavailableIdentityError struct {
 	err error
 }
 
 // Error returns string of internal error.
-func (e *ErrCassandraUnavailableIdentity) Error() string {
+func (e *CassandraUnavailableIdentityError) Error() string {
 	return e.err.Error()
 }
 
 // Unwrap returns internal error.
-func (e *ErrCassandraUnavailableIdentity) Unwrap() error {
+func (e *CassandraUnavailableIdentityError) Unwrap() error {
 	return e.err
 }
 
-// IsErrCassandraUnavailable reports whether any error in err's chain matches ErrCassandraUnavailableIdentity.
-func IsErrCassandraUnavailable(err error) bool {
-	target := new(ErrCassandraUnavailableIdentity)
+// IsCassandraUnavailableError reports whether any error in err's chain matches CassandraUnavailableIdentityError.
+func IsCassandraUnavailableError(err error) bool {
+	target := new(CassandraUnavailableIdentityError)
 	return As(err, &target)
 }

--- a/internal/errors/cassandra_test.go
+++ b/internal/errors/cassandra_test.go
@@ -88,7 +88,7 @@ func TestErrCassandraInvalidConsistencyType(t *testing.T) {
 	}
 }
 
-func TestNewErrCassandraNotFoundIdentity(t *testing.T) {
+func TestErrCassandraNotFoundIdentity(t *testing.T) {
 	type want struct {
 		want error
 	}
@@ -109,7 +109,7 @@ func TestNewErrCassandraNotFoundIdentity(t *testing.T) {
 		{
 			name: "returns cassandra not found identity error",
 			want: want{
-				want: &ErrCassandraNotFoundIdentity{
+				want: &CassandraNotFoundIdentityError{
 					err: New("cassandra entry not found"),
 				},
 			},
@@ -130,7 +130,7 @@ func TestNewErrCassandraNotFoundIdentity(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := NewErrCassandraNotFoundIdentity
+			got := ErrCassandraNotFoundIdentity
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -138,7 +138,7 @@ func TestNewErrCassandraNotFoundIdentity(t *testing.T) {
 	}
 }
 
-func TestNewErrCassandraUnavailableIdentity(t *testing.T) {
+func TestErrCassandraUnavailableIdentity(t *testing.T) {
 	type want struct {
 		want error
 	}
@@ -159,7 +159,7 @@ func TestNewErrCassandraUnavailableIdentity(t *testing.T) {
 		{
 			name: "returns cassandra unavailable identity error",
 			want: want{
-				want: &ErrCassandraUnavailableIdentity{
+				want: &CassandraUnavailableIdentityError{
 					err: New("cassandra unavailable"),
 				},
 			},
@@ -180,7 +180,7 @@ func TestNewErrCassandraUnavailableIdentity(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := NewErrCassandraUnavailableIdentity
+			got := ErrCassandraUnavailableIdentity
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -209,7 +209,7 @@ func TestErrCassandraUnavailable(t *testing.T) {
 		{
 			name: "returns cassandra unavailable identity error",
 			want: want{
-				want: &ErrCassandraUnavailableIdentity{
+				want: &CassandraUnavailableIdentityError{
 					err: New("cassandra unavailable"),
 				},
 			},
@@ -797,7 +797,7 @@ func TestErrCassandraFailedToCreateSession(t *testing.T) {
 	}
 }
 
-func TestErrCassandraNotFoundIdentity_Error(t *testing.T) {
+func TestCassandraNotFoundIdentityError_Error(t *testing.T) {
 	type fields struct {
 		err error
 	}
@@ -843,7 +843,7 @@ func TestErrCassandraNotFoundIdentity_Error(t *testing.T) {
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
-			e := &ErrCassandraNotFoundIdentity{
+			e := &CassandraNotFoundIdentityError{
 				err: test.fields.err,
 			}
 
@@ -855,7 +855,7 @@ func TestErrCassandraNotFoundIdentity_Error(t *testing.T) {
 	}
 }
 
-func TestErrCassandraNotFoundIdentity_Unwrap(t *testing.T) {
+func TestCassandraNotFoundIdentityError_Unwrap(t *testing.T) {
 	type fields struct {
 		err error
 	}
@@ -922,7 +922,7 @@ func TestErrCassandraNotFoundIdentity_Unwrap(t *testing.T) {
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
-			e := &ErrCassandraNotFoundIdentity{
+			e := &CassandraNotFoundIdentityError{
 				err: test.fields.err,
 			}
 
@@ -934,7 +934,7 @@ func TestErrCassandraNotFoundIdentity_Unwrap(t *testing.T) {
 	}
 }
 
-func TestIsErrCassandraNotFound(t *testing.T) {
+func TestIsCassandraNotFoundError(t *testing.T) {
 	type args struct {
 		err error
 	}
@@ -968,7 +968,7 @@ func TestIsErrCassandraNotFound(t *testing.T) {
 		{
 			name: "returns true when error is cassandra not found identity",
 			args: args{
-				err: new(ErrCassandraNotFoundIdentity),
+				err: new(CassandraNotFoundIdentityError),
 			},
 			want: want{
 				want: true,
@@ -990,7 +990,7 @@ func TestIsErrCassandraNotFound(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := IsErrCassandraNotFound(test.args.err)
+			got := IsCassandraNotFoundError(test.args.err)
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -998,7 +998,7 @@ func TestIsErrCassandraNotFound(t *testing.T) {
 	}
 }
 
-func TestErrCassandraUnavailableIdentity_Error(t *testing.T) {
+func TestCassandraUnavailableIdentityError_Error(t *testing.T) {
 	type fields struct {
 		err error
 	}
@@ -1044,7 +1044,7 @@ func TestErrCassandraUnavailableIdentity_Error(t *testing.T) {
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
-			e := &ErrCassandraUnavailableIdentity{
+			e := &CassandraUnavailableIdentityError{
 				err: test.fields.err,
 			}
 
@@ -1056,7 +1056,7 @@ func TestErrCassandraUnavailableIdentity_Error(t *testing.T) {
 	}
 }
 
-func TestErrCassandraUnavailableIdentity_Unwrap(t *testing.T) {
+func TestCassandraUnavailableIdentityError_Unwrap(t *testing.T) {
 	type fields struct {
 		err error
 	}
@@ -1123,7 +1123,7 @@ func TestErrCassandraUnavailableIdentity_Unwrap(t *testing.T) {
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
-			e := &ErrCassandraUnavailableIdentity{
+			e := &CassandraUnavailableIdentityError{
 				err: test.fields.err,
 			}
 
@@ -1135,7 +1135,7 @@ func TestErrCassandraUnavailableIdentity_Unwrap(t *testing.T) {
 	}
 }
 
-func TestIsErrCassandraUnavailable(t *testing.T) {
+func TestIsCassandraUnavailableError(t *testing.T) {
 	type args struct {
 		err error
 	}
@@ -1169,7 +1169,7 @@ func TestIsErrCassandraUnavailable(t *testing.T) {
 		{
 			name: "returns true when error is cassandra unavailable identity",
 			args: args{
-				err: new(ErrCassandraUnavailableIdentity),
+				err: new(CassandraUnavailableIdentityError),
 			},
 			want: want{
 				want: true,
@@ -1191,7 +1191,7 @@ func TestIsErrCassandraUnavailable(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := IsErrCassandraUnavailable(test.args.err)
+			got := IsCassandraUnavailableError(test.args.err)
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/errors/cassandra_test.go
+++ b/internal/errors/cassandra_test.go
@@ -130,7 +130,7 @@ func TestNewErrCassandraNotFoundIdentity(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := NewErrCassandraNotFoundIdentity()
+			got := NewErrCassandraNotFoundIdentity
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -180,7 +180,7 @@ func TestNewErrCassandraUnavailableIdentity(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := NewErrCassandraUnavailableIdentity()
+			got := NewErrCassandraUnavailableIdentity
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -230,7 +230,7 @@ func TestErrCassandraUnavailable(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := ErrCassandraUnavailable()
+			got := ErrCassandraUnavailable
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/errors/compressor.go
+++ b/internal/errors/compressor.go
@@ -40,13 +40,9 @@ var (
 	// ErrDecompressFailed returns an error of decompressing failed.
 	ErrDecompressFailed = New("decompress failed")
 
-	// ErrCompressorRegistererIsNotRunning represents a function to generate an error of compressor registerers is not running.
-	ErrCompressorRegistererIsNotRunning = func() error {
-		return New("compressor registerers is not running")
-	}
+	// ErrCompressorRegistererIsNotRunning generates an error of compressor registerers is not running.
+	ErrCompressorRegistererIsNotRunning = New("compressor registerers is not running")
 
-	// ErrCompressorRegistererChannelIsFull represents a function to generate an error that compressor registerer channel is full.
-	ErrCompressorRegistererChannelIsFull = func() error {
-		return New("compressor registerer channel is full")
-	}
+	// ErrCompressorRegistererChannelIsFull generates an error that compressor registerer channel is full.
+	ErrCompressorRegistererChannelIsFull = New("compressor registerer channel is full")
 )

--- a/internal/errors/compressor_test.go
+++ b/internal/errors/compressor_test.go
@@ -204,7 +204,7 @@ func TestErrCompressorRegistererIsNotRunning(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := ErrCompressorRegistererIsNotRunning()
+			got := ErrCompressorRegistererIsNotRunning
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -252,7 +252,7 @@ func TestErrCompressorRegistererChannelIsFull(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := ErrCompressorRegistererChannelIsFull()
+			got := ErrCompressorRegistererChannelIsFull
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/errors/info.go
+++ b/internal/errors/info.go
@@ -20,7 +20,5 @@ var (
 	}
 
 	// ErrRuntimeFuncNil represents an error that the runtime function is nil.
-	ErrRuntimeFuncNil = func() error {
-		return New("runtime function is nil")
-	}
+	ErrRuntimeFuncNil = New("runtime function is nil")
 )

--- a/internal/errors/info_test.go
+++ b/internal/errors/info_test.go
@@ -123,7 +123,7 @@ func TestErrRuntimeFuncNil(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := ErrRuntimeFuncNil()
+			got := ErrRuntimeFuncNil
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/errors/io.go
+++ b/internal/errors/io.go
@@ -19,17 +19,11 @@ package errors
 
 var (
 	// NewErrContextNotProvided represents a function to generate an error that the context is not provided.
-	NewErrContextNotProvided = func() error {
-		return New("context not provided")
-	}
+	NewErrContextNotProvided = New("context not provided")
 
 	// NewErrReaderNotProvided represents a function to generate an error that the io.Reader is not provided.
-	NewErrReaderNotProvided = func() error {
-		return New("io.Reader not provided")
-	}
+	NewErrReaderNotProvided = New("io.Reader not provided")
 
-	// NewErrWriterNotProvided represents a function to generate an error that the io.Writer is not provided.
-	NewErrWriterNotProvided = func() error {
-		return New("io.Writer not provided")
-	}
+	// NewErrWriterNotProvided represents an error that the io.Writer is not provided.
+	NewErrWriterNotProvided = New("io.Writer not provided")
 )

--- a/internal/errors/io_test.go
+++ b/internal/errors/io_test.go
@@ -55,7 +55,7 @@ func TestNewErrContextNotProvided(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := NewErrContextNotProvided()
+			got := NewErrContextNotProvided
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -103,7 +103,7 @@ func TestNewErrReaderNotProvided(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := NewErrReaderNotProvided()
+			got := NewErrReaderNotProvided
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -151,7 +151,7 @@ func TestNewErrWriterNotProvided(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := NewErrWriterNotProvided()
+			got := NewErrWriterNotProvided
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/errors/mysql.go
+++ b/internal/errors/mysql.go
@@ -21,8 +21,8 @@ var (
 	// ErrMySQLConnectionPingFailed represents an error that the ping failed.
 	ErrMySQLConnectionPingFailed = New("error MySQL connection ping failed")
 
-	// NewErrMySQLNotFoundIdentity generates an error that the element is not found.
-	NewErrMySQLNotFoundIdentity = &ErrMySQLNotFoundIdentity{
+	// ErrMySQLNotFoundIdentity generates an error that the element is not found.
+	ErrMySQLNotFoundIdentity = &MySQLNotFoundIdentityError{
 		err: New("error mysql element not found"),
 	}
 
@@ -34,11 +34,11 @@ var (
 
 	// ErrRequiredElementNotFoundByUUID represents a function to generate an error that the required element is not found.
 	ErrRequiredElementNotFoundByUUID = func(uuid string) error {
-		return Wrapf(NewErrMySQLNotFoundIdentity, "error required element not found, uuid: %s", uuid)
+		return Wrapf(ErrMySQLNotFoundIdentity, "error required element not found, uuid: %s", uuid)
 	}
 
 	// NewErrMySQLInvalidArgumentIdentity generates an error that the argument is invalid.
-	NewErrMySQLInvalidArgumentIdentity = &ErrMySQLInvalidArgumentIdentity{
+	NewErrMySQLInvalidArgumentIdentity = &MySQLInvalidArgumentIdentityError{
 		err: New("error mysql invalid argument"),
 	}
 
@@ -51,44 +51,44 @@ var (
 	ErrMySQLSessionNil = New("error MySQL session is nil")
 )
 
-// ErrMySQLNotFoundIdentity represents a custom error type that the element is not found.
-type ErrMySQLNotFoundIdentity struct {
+// MySQLNotFoundIdentityError represents a custom error type that the element is not found.
+type MySQLNotFoundIdentityError struct {
 	err error
 }
 
 // Error returns the string of internal error.
-func (e *ErrMySQLNotFoundIdentity) Error() string {
+func (e *MySQLNotFoundIdentityError) Error() string {
 	return e.err.Error()
 }
 
 // Unwrap returns the internal error.
-func (e *ErrMySQLNotFoundIdentity) Unwrap() error {
+func (e *MySQLNotFoundIdentityError) Unwrap() error {
 	return e.err
 }
 
-// IsErrMySQLNotFound returns true when the err type is ErrMySQLNotFoundIdentity.
-func IsErrMySQLNotFound(err error) bool {
-	target := new(ErrMySQLNotFoundIdentity)
+// IsMySQLNotFoundError returns true when the err type is MySQLNotFoundIdentityError.
+func IsMySQLNotFoundError(err error) bool {
+	target := new(MySQLNotFoundIdentityError)
 	return As(err, &target)
 }
 
-// ErrMySQLInvalidArgumentIdentity represents a custom error type that the argument is not found.
-type ErrMySQLInvalidArgumentIdentity struct {
+// MySQLInvalidArgumentIdentityError represents a custom error type that the argument is not found.
+type MySQLInvalidArgumentIdentityError struct {
 	err error
 }
 
 // Error returns the string of internal error.
-func (e *ErrMySQLInvalidArgumentIdentity) Error() string {
+func (e *MySQLInvalidArgumentIdentityError) Error() string {
 	return e.err.Error()
 }
 
 // Unwrap returns the internal error.
-func (e *ErrMySQLInvalidArgumentIdentity) Unwrap() error {
+func (e *MySQLInvalidArgumentIdentityError) Unwrap() error {
 	return e.err
 }
 
-// IsErrMySQLInvalidArgument returns true when the err type is ErrMySQLInvalidArgumentIdentity.
-func IsErrMySQLInvalidArgument(err error) bool {
-	target := new(ErrMySQLInvalidArgumentIdentity)
+// IsMySQLInvalidArgumentError returns true when the err type is MySQLInvalidArgumentIdentityError.
+func IsMySQLInvalidArgumentError(err error) bool {
+	target := new(MySQLInvalidArgumentIdentityError)
 	return As(err, &target)
 }

--- a/internal/errors/mysql.go
+++ b/internal/errors/mysql.go
@@ -21,11 +21,9 @@ var (
 	// ErrMySQLConnectionPingFailed represents an error that the ping failed.
 	ErrMySQLConnectionPingFailed = New("error MySQL connection ping failed")
 
-	// NewErrMySQLNotFoundIdentity represents a function to generate an error that the element is not found.
-	NewErrMySQLNotFoundIdentity = func() error {
-		return &ErrMySQLNotFoundIdentity{
-			err: New("error mysql element not found"),
-		}
+	// NewErrMySQLNotFoundIdentity generates an error that the element is not found.
+	NewErrMySQLNotFoundIdentity = &ErrMySQLNotFoundIdentity{
+		err: New("error mysql element not found"),
 	}
 
 	// ErrMySQLConnectionClosed represents a function to generate an error that the connection closed.
@@ -36,19 +34,17 @@ var (
 
 	// ErrRequiredElementNotFoundByUUID represents a function to generate an error that the required element is not found.
 	ErrRequiredElementNotFoundByUUID = func(uuid string) error {
-		return Wrapf(NewErrMySQLNotFoundIdentity(), "error required element not found, uuid: %s", uuid)
+		return Wrapf(NewErrMySQLNotFoundIdentity, "error required element not found, uuid: %s", uuid)
 	}
 
-	// NewErrMySQLInvalidArgumentIdentity represents a function to generate an error that the argument is invalid.
-	NewErrMySQLInvalidArgumentIdentity = func() error {
-		return &ErrMySQLInvalidArgumentIdentity{
-			err: New("error mysql invalid argument"),
-		}
+	// NewErrMySQLInvalidArgumentIdentity generates an error that the argument is invalid.
+	NewErrMySQLInvalidArgumentIdentity = &ErrMySQLInvalidArgumentIdentity{
+		err: New("error mysql invalid argument"),
 	}
 
 	// ErrRequiredMemberNotFilled represents a function to generate an error that the required member is not filled.
 	ErrRequiredMemberNotFilled = func(member string) error {
-		return Wrapf(NewErrMySQLInvalidArgumentIdentity(), "error required member not filled (member: %s)", member)
+		return Wrapf(NewErrMySQLInvalidArgumentIdentity, "error required member not filled (member: %s)", member)
 	}
 
 	// ErrMySQLSessionNil represents a function to generate an error that the MySQL session is nil.

--- a/internal/errors/mysql.go
+++ b/internal/errors/mysql.go
@@ -37,14 +37,14 @@ var (
 		return Wrapf(ErrMySQLNotFoundIdentity, "error required element not found, uuid: %s", uuid)
 	}
 
-	// NewErrMySQLInvalidArgumentIdentity generates an error that the argument is invalid.
-	NewErrMySQLInvalidArgumentIdentity = &MySQLInvalidArgumentIdentityError{
+	// ErrMySQLInvalidArgumentIdentity generates an error that the argument is invalid.
+	ErrMySQLInvalidArgumentIdentity = &MySQLInvalidArgumentIdentityError{
 		err: New("error mysql invalid argument"),
 	}
 
 	// ErrRequiredMemberNotFilled represents a function to generate an error that the required member is not filled.
 	ErrRequiredMemberNotFilled = func(member string) error {
-		return Wrapf(NewErrMySQLInvalidArgumentIdentity, "error required member not filled (member: %s)", member)
+		return Wrapf(ErrMySQLInvalidArgumentIdentity, "error required member not filled (member: %s)", member)
 	}
 
 	// ErrMySQLSessionNil represents a function to generate an error that the MySQL session is nil.

--- a/internal/errors/mysql_test.go
+++ b/internal/errors/mysql_test.go
@@ -296,7 +296,7 @@ func TestErrRequiredElementNotFoundByUUID(t *testing.T) {
 	}
 }
 
-func TestNewErrMySQLInvalidArgumentIdentity(t *testing.T) {
+func TestErrMySQLInvalidArgumentIdentity(t *testing.T) {
 	type want struct {
 		want error
 	}
@@ -340,7 +340,7 @@ func TestNewErrMySQLInvalidArgumentIdentity(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := NewErrMySQLInvalidArgumentIdentity
+			got := ErrMySQLInvalidArgumentIdentity
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/errors/mysql_test.go
+++ b/internal/errors/mysql_test.go
@@ -118,7 +118,7 @@ func TestNewErrMySQLNotFoundIdentity(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := NewErrMySQLNotFoundIdentity()
+			got := NewErrMySQLNotFoundIdentity
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -340,7 +340,7 @@ func TestNewErrMySQLInvalidArgumentIdentity(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := NewErrMySQLInvalidArgumentIdentity()
+			got := NewErrMySQLInvalidArgumentIdentity
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/errors/mysql_test.go
+++ b/internal/errors/mysql_test.go
@@ -74,7 +74,7 @@ func TestErrMySQLConnectionPingFailed(t *testing.T) {
 	}
 }
 
-func TestNewErrMySQLNotFoundIdentity(t *testing.T) {
+func TestErrMySQLNotFoundIdentity(t *testing.T) {
 	type want struct {
 		want error
 	}
@@ -95,7 +95,7 @@ func TestNewErrMySQLNotFoundIdentity(t *testing.T) {
 		{
 			name: "return ErrMySQLNotFoundIdentity error",
 			want: want{
-				want: &ErrMySQLNotFoundIdentity{
+				want: &MySQLNotFoundIdentityError{
 					err: New("error mysql element not found"),
 				},
 			},
@@ -118,7 +118,7 @@ func TestNewErrMySQLNotFoundIdentity(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := NewErrMySQLNotFoundIdentity
+			got := ErrMySQLNotFoundIdentity
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -254,7 +254,7 @@ func TestErrRequiredElementNotFoundByUUID(t *testing.T) {
 				uuid: "ef45b56c-1d90-12a7-c143-2567vaef218d",
 			},
 			want: want{
-				want: &ErrMySQLNotFoundIdentity{
+				want: &MySQLNotFoundIdentityError{
 					err: New("error required element not found, uuid: ef45b56c-1d90-12a7-c143-2567vaef218d: error mysql element not found"),
 				},
 			},
@@ -265,7 +265,7 @@ func TestErrRequiredElementNotFoundByUUID(t *testing.T) {
 				uuid: "",
 			},
 			want: want{
-				want: &ErrMySQLNotFoundIdentity{
+				want: &MySQLNotFoundIdentityError{
 					err: New("error required element not found, uuid: : error mysql element not found"),
 				},
 			},
@@ -317,7 +317,7 @@ func TestNewErrMySQLInvalidArgumentIdentity(t *testing.T) {
 		{
 			name: "return ErrMySQLInvalidArgumentIdentity error",
 			want: want{
-				want: &ErrMySQLInvalidArgumentIdentity{
+				want: &MySQLInvalidArgumentIdentityError{
 					err: New("error mysql invalid argument"),
 				},
 			},
@@ -376,7 +376,7 @@ func TestErrRequiredMemberNotFilled(t *testing.T) {
 				member: "vector",
 			},
 			want: want{
-				want: &ErrMySQLNotFoundIdentity{
+				want: &MySQLNotFoundIdentityError{
 					err: New("error required member not filled (member: vector): error mysql invalid argument"),
 				},
 			},
@@ -387,7 +387,7 @@ func TestErrRequiredMemberNotFilled(t *testing.T) {
 				member: "",
 			},
 			want: want{
-				want: &ErrMySQLNotFoundIdentity{
+				want: &MySQLNotFoundIdentityError{
 					err: New("error required member not filled (member: ): error mysql invalid argument"),
 				},
 			},
@@ -467,7 +467,7 @@ func TestErrMySQLSessionNil(t *testing.T) {
 	}
 }
 
-func TestErrMySQLNotFoundIdentity_Error(t *testing.T) {
+func TestMySQLNotFoundIdentityError_Error(t *testing.T) {
 	type fields struct {
 		err error
 	}
@@ -515,7 +515,7 @@ func TestErrMySQLNotFoundIdentity_Error(t *testing.T) {
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
-			e := &ErrMySQLNotFoundIdentity{
+			e := &MySQLNotFoundIdentityError{
 				err: test.fields.err,
 			}
 
@@ -527,7 +527,7 @@ func TestErrMySQLNotFoundIdentity_Error(t *testing.T) {
 	}
 }
 
-func TestErrMySQLNotFoundIdentity_Unwrap(t *testing.T) {
+func TestMySQLNotFoundIdentityError_Unwrap(t *testing.T) {
 	type fields struct {
 		err error
 	}
@@ -584,7 +584,7 @@ func TestErrMySQLNotFoundIdentity_Unwrap(t *testing.T) {
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
-			e := &ErrMySQLNotFoundIdentity{
+			e := &MySQLNotFoundIdentityError{
 				err: test.fields.err,
 			}
 
@@ -596,7 +596,7 @@ func TestErrMySQLNotFoundIdentity_Unwrap(t *testing.T) {
 	}
 }
 
-func TestIsErrMySQLNotFound(t *testing.T) {
+func TestIsMySQLNotFoundError(t *testing.T) {
 	type args struct {
 		err error
 	}
@@ -621,7 +621,7 @@ func TestIsErrMySQLNotFound(t *testing.T) {
 		{
 			name: "return true when err is ErrMySQLNotFoundIdentity",
 			args: args{
-				err: new(ErrMySQLNotFoundIdentity),
+				err: new(MySQLNotFoundIdentityError),
 			},
 			want: want{
 				want: true,
@@ -663,7 +663,7 @@ func TestIsErrMySQLNotFound(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := IsErrMySQLNotFound(test.args.err)
+			got := IsMySQLNotFoundError(test.args.err)
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -671,7 +671,7 @@ func TestIsErrMySQLNotFound(t *testing.T) {
 	}
 }
 
-func TestErrMySQLInvalidArgumentIdentity_Error(t *testing.T) {
+func TestMySQLInvalidArgumentIdentityError_Error(t *testing.T) {
 	type fields struct {
 		err error
 	}
@@ -719,7 +719,7 @@ func TestErrMySQLInvalidArgumentIdentity_Error(t *testing.T) {
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
-			e := &ErrMySQLInvalidArgumentIdentity{
+			e := &MySQLInvalidArgumentIdentityError{
 				err: test.fields.err,
 			}
 
@@ -731,7 +731,7 @@ func TestErrMySQLInvalidArgumentIdentity_Error(t *testing.T) {
 	}
 }
 
-func TestErrMySQLInvalidArgumentIdentity_Unwrap(t *testing.T) {
+func TestMySQLInvalidArgumentIdentityError_Unwrap(t *testing.T) {
 	type fields struct {
 		err error
 	}
@@ -788,7 +788,7 @@ func TestErrMySQLInvalidArgumentIdentity_Unwrap(t *testing.T) {
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
-			e := &ErrMySQLInvalidArgumentIdentity{
+			e := &MySQLInvalidArgumentIdentityError{
 				err: test.fields.err,
 			}
 
@@ -800,7 +800,7 @@ func TestErrMySQLInvalidArgumentIdentity_Unwrap(t *testing.T) {
 	}
 }
 
-func TestIsErrMySQLInvalidArgument(t *testing.T) {
+func TestIsMySQLInvalidArgumentError(t *testing.T) {
 	type args struct {
 		err error
 	}
@@ -825,7 +825,7 @@ func TestIsErrMySQLInvalidArgument(t *testing.T) {
 		{
 			name: "return true when err is ErrMySQLInvalidArgumentIdentity",
 			args: args{
-				err: new(ErrMySQLInvalidArgumentIdentity),
+				err: new(MySQLInvalidArgumentIdentityError),
 			},
 			want: want{
 				want: true,
@@ -867,7 +867,7 @@ func TestIsErrMySQLInvalidArgument(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := IsErrMySQLInvalidArgument(test.args.err)
+			got := IsMySQLInvalidArgumentError(test.args.err)
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/errors/observability.go
+++ b/internal/errors/observability.go
@@ -17,9 +17,7 @@
 // Package errors provides error types and function
 package errors
 
-// ErrCollectorNotFound represents a function to generate an error that the observability collector is not found.
+// ErrCollectorNotFound represents an error that the observability collector is not found.
 var (
-	ErrCollectorNotFound = func() error {
-		return New("observability.collector not found")
-	}
+	ErrCollectorNotFound = New("observability.collector not found")
 )

--- a/internal/errors/observability_test.go
+++ b/internal/errors/observability_test.go
@@ -61,7 +61,7 @@ func TestErrCollectorNotFound(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := ErrCollectorNotFound()
+			got := ErrCollectorNotFound
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/errors/redis.go
+++ b/internal/errors/redis.go
@@ -24,16 +24,14 @@ var (
 		return Errorf("kv index and vk prefix must be defferent.\t(kv: %s,\tvk: %s)", kv, vk)
 	}
 
-	// NewErrRedisNotFoundIdentity represents a function to generate an ErrRedisNotFoundIdentity error.
-	NewErrRedisNotFoundIdentity = func() error {
-		return &ErrRedisNotFoundIdentity{
-			err: New("error redis entry not found"),
-		}
+	// NewErrRedisNotFoundIdentity generates an ErrRedisNotFoundIdentity error.
+	NewErrRedisNotFoundIdentity = &ErrRedisNotFoundIdentity{
+		err: New("error redis entry not found"),
 	}
 
 	// ErrRedisNotFound represents a function to wrap Redis key not found error and err.
 	ErrRedisNotFound = func(key string) error {
-		return Wrapf(NewErrRedisNotFoundIdentity(), "error redis key '%s' not found", key)
+		return Wrapf(NewErrRedisNotFoundIdentity, "error redis key '%s' not found", key)
 	}
 
 	// ErrRedisInvalidOption generates a new error of Redis invalid option.

--- a/internal/errors/redis.go
+++ b/internal/errors/redis.go
@@ -24,14 +24,14 @@ var (
 		return Errorf("kv index and vk prefix must be defferent.\t(kv: %s,\tvk: %s)", kv, vk)
 	}
 
-	// NewErrRedisNotFoundIdentity generates an ErrRedisNotFoundIdentity error.
-	NewErrRedisNotFoundIdentity = &ErrRedisNotFoundIdentity{
+	// ErrRedisNotFoundIdentity generates an RedisNotFoundIdentityError error.
+	ErrRedisNotFoundIdentity = &RedisNotFoundIdentityError{
 		err: New("error redis entry not found"),
 	}
 
 	// ErrRedisNotFound represents a function to wrap Redis key not found error and err.
 	ErrRedisNotFound = func(key string) error {
-		return Wrapf(NewErrRedisNotFoundIdentity, "error redis key '%s' not found", key)
+		return Wrapf(ErrRedisNotFoundIdentity, "error redis key '%s' not found", key)
 	}
 
 	// ErrRedisInvalidOption generates a new error of Redis invalid option.
@@ -64,26 +64,26 @@ var (
 	ErrRedisConnectionPingFailed = New("error redis connection ping failed")
 )
 
-// ErrRedisNotFoundIdentity represents a struct that includes err and has a method for Redis error handling.
-type ErrRedisNotFoundIdentity struct {
+// RedisNotFoundIdentityError represents a struct that includes err and has a method for Redis error handling.
+type RedisNotFoundIdentityError struct {
 	err error
 }
 
 // Error returns the string of ErrRedisNotFoundIdentity.error.
-func (e *ErrRedisNotFoundIdentity) Error() string {
+func (e *RedisNotFoundIdentityError) Error() string {
 	if e.err == nil {
 		e.err = errExpectedErrIsNil("ErrRedisNotFoundIdentity")
 	}
 	return e.err.Error()
 }
 
-// Unwrap returns the error value of ErrRedisNotFoundIdentity.
-func (e *ErrRedisNotFoundIdentity) Unwrap() error {
+// Unwrap returns the error value of RedisNotFoundIdentityError.
+func (e *RedisNotFoundIdentityError) Unwrap() error {
 	return e.err
 }
 
-// IsErrRedisNotFound compares the input error and ErrRedisNotFoundIdentity.error and returns true or false that is the result of errors.As.
-func IsErrRedisNotFound(err error) bool {
-	target := new(ErrRedisNotFoundIdentity)
+// IsRedisNotFoundError compares the input error and RedisNotFoundIdentityError.error and returns true or false that is the result of errors.As.
+func IsRedisNotFoundError(err error) bool {
+	target := new(RedisNotFoundIdentityError)
 	return As(err, &target)
 }

--- a/internal/errors/redis_test.go
+++ b/internal/errors/redis_test.go
@@ -115,7 +115,7 @@ func TestErrRedisInvalidKVVKPrefic(t *testing.T) {
 	}
 }
 
-func TestNewErrRedisNotFoundIdentity(t *testing.T) {
+func TestErrRedisNotFoundIdentity(t *testing.T) {
 	type want struct {
 		want error
 	}
@@ -137,7 +137,7 @@ func TestNewErrRedisNotFoundIdentity(t *testing.T) {
 			return test{
 				name: "return an NewErrRedisNotFoundIdentity error",
 				want: want{
-					want: &ErrRedisNotFoundIdentity{
+					want: &RedisNotFoundIdentityError{
 						err: New("error redis entry not found"),
 					},
 				},
@@ -159,7 +159,7 @@ func TestNewErrRedisNotFoundIdentity(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := NewErrRedisNotFoundIdentity
+			got := ErrRedisNotFoundIdentity
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -195,14 +195,14 @@ func TestErrRdisNotFound(t *testing.T) {
 				key: "vdaas",
 			},
 			want: want{
-				want: Wrap(NewErrRedisNotFoundIdentity, "error redis key 'vdaas' not found"),
+				want: Wrap(ErrRedisNotFoundIdentity, "error redis key 'vdaas' not found"),
 			},
 		},
 		{
 			name:   "return an ErrRedisNotFound error when key is empty",
 			fields: fields{},
 			want: want{
-				want: Wrap(NewErrRedisNotFoundIdentity, "error redis key '' not found"),
+				want: Wrap(ErrRedisNotFoundIdentity, "error redis key '' not found"),
 			},
 		},
 	}
@@ -741,7 +741,7 @@ func TestErrRedisConnectionPingFailed(t *testing.T) {
 	}
 }
 
-func TestErrRedisNotFoundIdentity_Error(t *testing.T) {
+func TestRedisNotFoundIdentityError_Error(t *testing.T) {
 	type fields struct {
 		err error
 	}
@@ -794,7 +794,7 @@ func TestErrRedisNotFoundIdentity_Error(t *testing.T) {
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
-			e := &ErrRedisNotFoundIdentity{
+			e := &RedisNotFoundIdentityError{
 				err: test.fields.err,
 			}
 
@@ -806,7 +806,7 @@ func TestErrRedisNotFoundIdentity_Error(t *testing.T) {
 	}
 }
 
-func TestErrRedisNotFoundIdentity_Unwrap(t *testing.T) {
+func TestErrRedisNotFoundIdentityError_Unwrap(t *testing.T) {
 	type fields struct {
 		err error
 	}
@@ -859,7 +859,7 @@ func TestErrRedisNotFoundIdentity_Unwrap(t *testing.T) {
 			if test.checkFunc == nil {
 				checkFunc = defaultCheckFunc
 			}
-			e := &ErrRedisNotFoundIdentity{
+			e := &RedisNotFoundIdentityError{
 				err: test.fields.err,
 			}
 
@@ -871,7 +871,7 @@ func TestErrRedisNotFoundIdentity_Unwrap(t *testing.T) {
 	}
 }
 
-func TestIsErrRedisNotFound(t *testing.T) {
+func TestIsRedisNotFoundError(t *testing.T) {
 	type args struct {
 		err error
 	}
@@ -903,7 +903,7 @@ func TestIsErrRedisNotFound(t *testing.T) {
 		{
 			name: "return false when err does not match ErrRedisNotFoundIdentity",
 			args: args{
-				err: &ErrRedisNotFoundIdentity{
+				err: &RedisNotFoundIdentityError{
 					err: New("err: Redis not found identity"),
 				},
 			},
@@ -932,7 +932,7 @@ func TestIsErrRedisNotFound(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := IsErrRedisNotFound(test.args.err)
+			got := IsRedisNotFoundError(test.args.err)
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/errors/redis_test.go
+++ b/internal/errors/redis_test.go
@@ -159,7 +159,7 @@ func TestNewErrRedisNotFoundIdentity(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := NewErrRedisNotFoundIdentity()
+			got := NewErrRedisNotFoundIdentity
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -195,14 +195,14 @@ func TestErrRdisNotFound(t *testing.T) {
 				key: "vdaas",
 			},
 			want: want{
-				want: Wrap(NewErrRedisNotFoundIdentity(), "error redis key 'vdaas' not found"),
+				want: Wrap(NewErrRedisNotFoundIdentity, "error redis key 'vdaas' not found"),
 			},
 		},
 		{
 			name:   "return an ErrRedisNotFound error when key is empty",
 			fields: fields{},
 			want: want{
-				want: Wrap(NewErrRedisNotFoundIdentity(), "error redis key '' not found"),
+				want: Wrap(NewErrRedisNotFoundIdentity, "error redis key '' not found"),
 			},
 		},
 	}

--- a/internal/errors/vald.go
+++ b/internal/errors/vald.go
@@ -18,18 +18,16 @@
 package errors
 
 var (
-	// ErrMetaDataAlreadyExists represents a function to generate an error that vald metadata is already exists.
+	// ErrMetaDataAlreadyExists represents an error that vald metadata is already exists.
 	ErrMetaDataAlreadyExists = func(meta string) error {
 		return Errorf("vald metadata:\t%s\talready exists ", meta)
 	}
 
-	// ErrSameVectorAlreadyExists represents a function to generate an error that vald already has same features vector data.
+	// ErrSameVectorAlreadyExists represents an error that vald already has same features vector data.
 	ErrSameVectorAlreadyExists = func(meta string, n, o []float32) error {
 		return Errorf("vald metadata:\t%s\talready exists reqested: %v, stored: %v", meta, n, o)
 	}
 
-	// ErrMetaDataCannotFetch represents a function to generate an error that vald metadata cannot fetch.
-	ErrMetaDataCannotFetch = func() error {
-		return Errorf("vald metadata cannot fetch")
-	}
+	// ErrMetaDataCannotFetch represents an error that vald metadata cannot fetch.
+	ErrMetaDataCannotFetch = Errorf("vald metadata cannot fetch")
 )

--- a/internal/errors/vald_test.go
+++ b/internal/errors/vald_test.go
@@ -123,7 +123,7 @@ func TestErrMetadataCannotFetch(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			got := ErrMetaDataCannotFetch()
+			got := ErrMetaDataCannotFetch
 			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/errors/worker.go
+++ b/internal/errors/worker.go
@@ -44,7 +44,7 @@ var (
 		return New("JobFunc is nil")
 	}
 
-	// ErrJobFuncIsNil represents a function to generate job function is not found.
+	// ErrJobFuncNotFound represents a function to generate job function is not found.
 	ErrJobFuncNotFound = func() error {
 		return New("JobFunc is not found")
 	}

--- a/internal/errors/worker.go
+++ b/internal/errors/worker.go
@@ -29,23 +29,15 @@ var (
 		return Errorf("worker %s is already running", name)
 	}
 
-	// ErrQueueIsNotRunning represents a function to generate the queue is not running error.
-	ErrQueueIsNotRunning = func() error {
-		return New("queue is not running")
-	}
+	// ErrQueueIsNotRunning represents an error that the queue is not running.
+	ErrQueueIsNotRunning = New("queue is not running")
 
-	// ErrQueueIsAlreadyRunning represents a function to generate the queue is already running error.
-	ErrQueueIsAlreadyRunning = func() error {
-		return New("queue is already running")
-	}
+	// ErrQueueIsAlreadyRunning represents an error that the queue is already running.
+	ErrQueueIsAlreadyRunning = New("queue is already running")
 
-	// ErrJobFuncIsNil represents a function to generate job function is nil error.
-	ErrJobFuncIsNil = func() error {
-		return New("JobFunc is nil")
-	}
+	// ErrJobFuncIsNil represents an error that job function is nil.
+	ErrJobFuncIsNil = New("JobFunc is nil")
 
-	// ErrJobFuncNotFound represents a function to generate job function is not found.
-	ErrJobFuncNotFound = func() error {
-		return New("JobFunc is not found")
-	}
+	// ErrJobFuncNotFound represents an error that job function is not found.
+	ErrJobFuncNotFound = New("JobFunc is not found")
 )

--- a/internal/errors/worker.go
+++ b/internal/errors/worker.go
@@ -43,4 +43,9 @@ var (
 	ErrJobFuncIsNil = func() error {
 		return New("JobFunc is nil")
 	}
+
+	// ErrJobFuncIsNil represents a function to generate job function is not found.
+	ErrJobFuncNotFound = func() error {
+		return New("JobFunc is not found")
+	}
 )

--- a/internal/errors/worker_test.go
+++ b/internal/errors/worker_test.go
@@ -197,7 +197,7 @@ func TestErrQueueIsNotRunning(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			err := ErrQueueIsNotRunning()
+			err := ErrQueueIsNotRunning
 			if err := checkFunc(test.want, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -247,7 +247,7 @@ func TestErrQueueIsAlreadyRunning(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			err := ErrQueueIsAlreadyRunning()
+			err := ErrQueueIsAlreadyRunning
 			if err := checkFunc(test.want, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -297,7 +297,7 @@ func TestErrJobFuncIsNil(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			err := ErrJobFuncIsNil()
+			err := ErrJobFuncIsNil
 			if err := checkFunc(test.want, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -347,7 +347,7 @@ func TestErrJobFuncNotFound(t *testing.T) {
 				checkFunc = defaultCheckFunc
 			}
 
-			err := ErrJobFuncNotFound()
+			err := ErrJobFuncNotFound
 			if err := checkFunc(test.want, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}

--- a/internal/errors/worker_test.go
+++ b/internal/errors/worker_test.go
@@ -304,3 +304,53 @@ func TestErrJobFuncIsNil(t *testing.T) {
 		})
 	}
 }
+
+func TestErrJobFuncNotFound(t *testing.T) {
+	type want struct {
+		err error
+	}
+	type test struct {
+		name       string
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func()
+		afterFunc  func()
+	}
+	defaultCheckFunc := func(w want, err error) error {
+		if !Is(err, w.err) {
+			return Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "return an ErrJobFundNotFound error",
+			want: want{
+				err: New("JobFunc is not found"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		test := tc
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
+			if test.beforeFunc != nil {
+				test.beforeFunc()
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc()
+			}
+			checkFunc := test.checkFunc
+			if test.checkFunc == nil {
+				checkFunc = defaultCheckFunc
+			}
+
+			err := ErrJobFuncNotFound()
+			if err := checkFunc(test.want, err); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/file/watch/watch.go
+++ b/internal/file/watch/watch.go
@@ -197,7 +197,7 @@ func (w *watch) Remove(dirs ...string) (err error) {
 }
 
 // Stop stops watching all named files or directories. If an error occurs, returns the error.
-func (w *watch) Stop(_ context.Context) (err error) {
+func (w *watch) Stop(context.Context) (err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	for dir := range w.dirs {

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -163,7 +163,7 @@ func New(opts ...Option) (Info, error) {
 	}
 
 	if i.rtCaller == nil || i.rtFuncForPC == nil {
-		return nil, errors.ErrRuntimeFuncNil()
+		return nil, errors.ErrRuntimeFuncNil
 	}
 
 	i.prepare()

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -176,7 +176,7 @@ func NewEOFReader() Reader {
 	return &eofReader{}
 }
 
-func (*eofReader) Read(_ []byte) (n int, err error) {
+func (*eofReader) Read([]byte) (n int, err error) {
 	return 0, EOF
 }
 

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -61,11 +61,11 @@ type ctxReader struct {
 
 func NewReaderWithContext(ctx context.Context, r io.Reader) (io.Reader, error) {
 	if ctx == nil {
-		return nil, errors.NewErrContextNotProvided()
+		return nil, errors.NewErrContextNotProvided
 	}
 
 	if r == nil {
-		return nil, errors.NewErrReaderNotProvided()
+		return nil, errors.NewErrReaderNotProvided
 	}
 
 	return &ctxReader{
@@ -76,11 +76,11 @@ func NewReaderWithContext(ctx context.Context, r io.Reader) (io.Reader, error) {
 
 func NewReadCloserWithContext(ctx context.Context, r io.ReadCloser) (io.ReadCloser, error) {
 	if ctx == nil {
-		return nil, errors.NewErrContextNotProvided()
+		return nil, errors.NewErrContextNotProvided
 	}
 
 	if r == nil {
-		return nil, errors.NewErrReaderNotProvided()
+		return nil, errors.NewErrReaderNotProvided
 	}
 
 	return &ctxReader{
@@ -119,11 +119,11 @@ type ctxWriter struct {
 
 func NewWriterWithContext(ctx context.Context, w io.Writer) (io.Writer, error) {
 	if ctx == nil {
-		return nil, errors.NewErrContextNotProvided()
+		return nil, errors.NewErrContextNotProvided
 	}
 
 	if w == nil {
-		return nil, errors.NewErrWriterNotProvided()
+		return nil, errors.NewErrWriterNotProvided
 	}
 
 	return &ctxWriter{
@@ -134,11 +134,11 @@ func NewWriterWithContext(ctx context.Context, w io.Writer) (io.Writer, error) {
 
 func NewWriteCloserWithContext(ctx context.Context, w io.WriteCloser) (io.WriteCloser, error) {
 	if ctx == nil {
-		return nil, errors.NewErrContextNotProvided()
+		return nil, errors.NewErrContextNotProvided
 	}
 
 	if w == nil {
-		return nil, errors.NewErrWriterNotProvided()
+		return nil, errors.NewErrWriterNotProvided
 	}
 
 	return &ctxWriter{

--- a/internal/io/io_test.go
+++ b/internal/io/io_test.go
@@ -78,7 +78,7 @@ func TestNewReaderWithContext(t *testing.T) {
 			},
 			want: want{
 				want: nil,
-				err:  errors.NewErrReaderNotProvided(),
+				err:  errors.NewErrReaderNotProvided,
 			},
 		},
 		{
@@ -89,7 +89,7 @@ func TestNewReaderWithContext(t *testing.T) {
 			},
 			want: want{
 				want: nil,
-				err:  errors.NewErrContextNotProvided(),
+				err:  errors.NewErrContextNotProvided,
 			},
 		},
 	}
@@ -168,7 +168,7 @@ func TestNewReadCloserWithContext(t *testing.T) {
 			},
 			want: want{
 				want: nil,
-				err:  errors.NewErrReaderNotProvided(),
+				err:  errors.NewErrReaderNotProvided,
 			},
 		},
 		{
@@ -179,7 +179,7 @@ func TestNewReadCloserWithContext(t *testing.T) {
 			},
 			want: want{
 				want: nil,
-				err:  errors.NewErrContextNotProvided(),
+				err:  errors.NewErrContextNotProvided,
 			},
 		},
 	}
@@ -459,7 +459,7 @@ func TestNewWriterWithContext(t *testing.T) {
 			},
 			want: want{
 				want: nil,
-				err:  errors.NewErrWriterNotProvided(),
+				err:  errors.NewErrWriterNotProvided,
 			},
 		},
 		{
@@ -470,7 +470,7 @@ func TestNewWriterWithContext(t *testing.T) {
 			},
 			want: want{
 				want: nil,
-				err:  errors.NewErrContextNotProvided(),
+				err:  errors.NewErrContextNotProvided,
 			},
 		},
 	}
@@ -557,7 +557,7 @@ func TestNewWriteCloserWithContext(t *testing.T) {
 			},
 			want: want{
 				want: nil,
-				err:  errors.NewErrWriterNotProvided(),
+				err:  errors.NewErrWriterNotProvided,
 			},
 		},
 		{
@@ -568,7 +568,7 @@ func TestNewWriteCloserWithContext(t *testing.T) {
 			},
 			want: want{
 				want: nil,
-				err:  errors.NewErrContextNotProvided(),
+				err:  errors.NewErrContextNotProvided,
 			},
 		},
 	}

--- a/internal/log/nop/nop.go
+++ b/internal/log/nop/nop.go
@@ -25,49 +25,49 @@ func New() logger.Logger {
 }
 
 // Debug logs the vals at Debug level.
-func (*nopLogger) Debug(_ ...interface{}) {}
+func (*nopLogger) Debug(...interface{}) {}
 
 // Debugf logs the formatted message at Debug level.
-func (*nopLogger) Debugf(_ string, _ ...interface{}) {}
+func (*nopLogger) Debugf(string, ...interface{}) {}
 
 // Debugd logs the message with details at Debug level.
-func (*nopLogger) Debugd(_ string, _ ...interface{}) {}
+func (*nopLogger) Debugd(string, ...interface{}) {}
 
 // Info logs the vals at Info level.
-func (*nopLogger) Info(_ ...interface{}) {}
+func (*nopLogger) Info(...interface{}) {}
 
 // Infof logs the formatted message at Info level.
-func (*nopLogger) Infof(_ string, _ ...interface{}) {}
+func (*nopLogger) Infof(string, ...interface{}) {}
 
 // Infod logs the message with details at Info level.
-func (*nopLogger) Infod(_ string, _ ...interface{}) {}
+func (*nopLogger) Infod(string, ...interface{}) {}
 
 // Warn logs the vals at Warn level.
-func (*nopLogger) Warn(_ ...interface{}) {}
+func (*nopLogger) Warn(...interface{}) {}
 
 // Warnf logs the formatted message at Warn level.
-func (*nopLogger) Warnf(_ string, _ ...interface{}) {}
+func (*nopLogger) Warnf(string, ...interface{}) {}
 
 // Warnd logs the message with details at Warn level.
-func (*nopLogger) Warnd(_ string, _ ...interface{}) {}
+func (*nopLogger) Warnd(string, ...interface{}) {}
 
 // Error logs the vals at Error level.
-func (*nopLogger) Error(_ ...interface{}) {}
+func (*nopLogger) Error(...interface{}) {}
 
 // Errorf logs the formatted message at Error level.
-func (*nopLogger) Errorf(_ string, _ ...interface{}) {}
+func (*nopLogger) Errorf(string, ...interface{}) {}
 
 // Errord logs the message with details at Error level.
-func (*nopLogger) Errord(_ string, _ ...interface{}) {}
+func (*nopLogger) Errord(string, ...interface{}) {}
 
 // Fatal logs the vals at Fatal level, then calls os.Exit(1).
-func (*nopLogger) Fatal(_ ...interface{}) {}
+func (*nopLogger) Fatal(...interface{}) {}
 
 // Fatalf logs the formatted message at Fatal level, then calls os.Exit(1).
-func (*nopLogger) Fatalf(_ string, _ ...interface{}) {}
+func (*nopLogger) Fatalf(string, ...interface{}) {}
 
 // Fatald logs the message with details at Fatal level, then calls os.Exit(1).
-func (*nopLogger) Fatald(_ string, _ ...interface{}) {}
+func (*nopLogger) Fatald(string, ...interface{}) {}
 
 // Close calls finalizer of logger implementations.
 func (*nopLogger) Close() error {

--- a/internal/log/zap/zap_test.go
+++ b/internal/log/zap/zap_test.go
@@ -405,12 +405,12 @@ func Test_toZapEncoder(t *testing.T) {
 		return nil
 	}
 	consoleEnc := zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig())
-	zapcore_NewConsoleEncoder = func(_ zapcore.EncoderConfig) zapcore.Encoder {
+	zapcore_NewConsoleEncoder = func(zapcore.EncoderConfig) zapcore.Encoder {
 		return consoleEnc
 	}
 
 	jsonEnc := zapcore.NewJSONEncoder(zap.NewDevelopmentEncoderConfig())
-	zapcore_NewJSONEncoder = func(_ zapcore.EncoderConfig) zapcore.Encoder {
+	zapcore_NewJSONEncoder = func(zapcore.EncoderConfig) zapcore.Encoder {
 		return jsonEnc
 	}
 

--- a/internal/observability/metrics/grpc/grpc.go
+++ b/internal/observability/metrics/grpc/grpc.go
@@ -59,7 +59,7 @@ func (*grpcServerMetrics) View() ([]*metrics.View, error) {
 	}, nil
 }
 
-func (*grpcServerMetrics) Register(_ metrics.Meter) error {
+func (*grpcServerMetrics) Register(metrics.Meter) error {
 	// The metrics are dynamically registered at the grpc server interceptor package,
 	// so do nothing in this part
 	return nil

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -148,7 +148,7 @@ func (o *observability) PreStart(ctx context.Context) error {
 	return nil
 }
 
-func (*observability) Start(_ context.Context) <-chan error {
+func (*observability) Start(context.Context) <-chan error {
 	return nil
 }
 

--- a/internal/observability/trace/trace.go
+++ b/internal/observability/trace/trace.go
@@ -75,7 +75,7 @@ func New(opts ...TraceOption) (Tracer, error) {
 	return t, nil
 }
 
-func (*tracer) Start(_ context.Context) error {
+func (*tracer) Start(context.Context) error {
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 	return nil
 }

--- a/internal/servers/starter/starter.go
+++ b/internal/servers/starter/starter.go
@@ -138,7 +138,7 @@ func (s *srvs) setupAPIs(cfg *tls.Config) ([]servers.Option, error) {
 	return opts, nil
 }
 
-func (s *srvs) setupHealthCheck(_ *tls.Config) ([]servers.Option, error) {
+func (s *srvs) setupHealthCheck(*tls.Config) ([]servers.Option, error) {
 	opts := make([]servers.Option, 0, len(s.cfg.HealthCheckServers))
 	for _, hsc := range s.cfg.HealthCheckServers {
 		srv, err := server.New(

--- a/internal/worker/queue.go
+++ b/internal/worker/queue.go
@@ -151,7 +151,7 @@ func (q *queue) Pop(ctx context.Context) (JobFunc, error) {
 			}
 		}
 	}
-	return nil, errors.ErrJobFuncIsNil()
+	return nil, errors.ErrJobFuncNotFound()
 }
 
 // Len returns the length of queue.

--- a/internal/worker/queue.go
+++ b/internal/worker/queue.go
@@ -69,7 +69,7 @@ func NewQueue(opts ...QueueOption) (Queue, error) {
 // It returns the error channel that the queueing job return.
 func (q *queue) Start(ctx context.Context) (<-chan error, error) {
 	if q.isRunning() {
-		return nil, errors.ErrQueueIsAlreadyRunning()
+		return nil, errors.ErrQueueIsAlreadyRunning
 	}
 
 	ech := make(chan error, 1)
@@ -117,11 +117,11 @@ func (q *queue) isRunning() bool {
 // If JobFunc is nil or queue is not running, Push returns error.
 func (q *queue) Push(ctx context.Context, job JobFunc) error {
 	if job == nil {
-		return errors.ErrJobFuncIsNil()
+		return errors.ErrJobFuncIsNil
 	}
 
 	if !q.isRunning() {
-		return errors.ErrQueueIsNotRunning()
+		return errors.ErrQueueIsNotRunning
 	}
 
 	select {
@@ -139,7 +139,7 @@ func (q *queue) Pop(ctx context.Context) (JobFunc, error) {
 
 	for i := 0; i < tryCnt; i++ {
 		if !q.isRunning() {
-			return nil, errors.ErrQueueIsNotRunning()
+			return nil, errors.ErrQueueIsNotRunning
 		}
 
 		select {
@@ -151,7 +151,7 @@ func (q *queue) Pop(ctx context.Context) (JobFunc, error) {
 			}
 		}
 	}
-	return nil, errors.ErrJobFuncNotFound()
+	return nil, errors.ErrJobFuncNotFound
 }
 
 // Len returns the length of queue.

--- a/internal/worker/queue_test.go
+++ b/internal/worker/queue_test.go
@@ -254,7 +254,7 @@ func Test_queue_Start(t *testing.T) {
 					}(),
 				},
 				want: want{
-					err: errors.ErrQueueIsAlreadyRunning(),
+					err: errors.ErrQueueIsAlreadyRunning,
 				},
 				checkFunc: defaultCheckFunc,
 			}
@@ -502,7 +502,7 @@ func Test_queue_Push(t *testing.T) {
 					job: nil,
 				},
 				want: want{
-					err: errors.ErrJobFuncIsNil(),
+					err: errors.ErrJobFuncIsNil,
 				},
 			}
 		}(),
@@ -522,7 +522,7 @@ func Test_queue_Push(t *testing.T) {
 					}(),
 				},
 				want: want{
-					err: errors.ErrQueueIsNotRunning(),
+					err: errors.ErrQueueIsNotRunning,
 				},
 			}
 		}(),
@@ -687,7 +687,7 @@ func Test_queue_Pop(t *testing.T) {
 			},
 			want: want{
 				want: nil,
-				err:  errors.ErrQueueIsNotRunning(),
+				err:  errors.ErrQueueIsNotRunning,
 			},
 		},
 		func() test {
@@ -754,7 +754,7 @@ func Test_queue_Pop(t *testing.T) {
 				},
 				want: want{
 					want: nil,
-					err:  errors.ErrJobFuncNotFound(),
+					err:  errors.ErrJobFuncNotFound,
 				},
 				beforeFunc: func(args) {
 					outCh <- nil

--- a/internal/worker/queue_test.go
+++ b/internal/worker/queue_test.go
@@ -754,7 +754,7 @@ func Test_queue_Pop(t *testing.T) {
 				},
 				want: want{
 					want: nil,
-					err:  errors.ErrJobFuncIsNil(),
+					err:  errors.ErrJobFuncNotFound(),
 				},
 				beforeFunc: func(args) {
 					outCh <- nil

--- a/pkg/agent/sidecar/service/observer/observer.go
+++ b/pkg/agent/sidecar/service/observer/observer.go
@@ -388,7 +388,7 @@ func (*observer) terminate() error {
 	return p.Signal(syscall.SIGTERM)
 }
 
-func (o *observer) requestBackup(_ context.Context) error {
+func (o *observer) requestBackup(context.Context) error {
 	select {
 	case o.ch <- struct{}{}:
 	default:

--- a/pkg/agent/sidecar/service/storage/storage.go
+++ b/pkg/agent/sidecar/service/storage/storage.go
@@ -167,7 +167,7 @@ func (b *bs) Start(ctx context.Context) (<-chan error, error) {
 	return ech, nil
 }
 
-func (b *bs) Stop(_ context.Context) error {
+func (b *bs) Stop(context.Context) error {
 	if b.bucket != nil {
 		return b.bucket.Close()
 	}

--- a/pkg/agent/sidecar/usecase/initcontainer/initcontainer.go
+++ b/pkg/agent/sidecar/usecase/initcontainer/initcontainer.go
@@ -268,6 +268,6 @@ func (r *run) Stop(ctx context.Context) error {
 	return r.server.Shutdown(ctx)
 }
 
-func (*run) PostStop(_ context.Context) error {
+func (*run) PostStop(context.Context) error {
 	return nil
 }

--- a/pkg/agent/sidecar/usecase/sidecar/sidecar.go
+++ b/pkg/agent/sidecar/usecase/sidecar/sidecar.go
@@ -266,7 +266,7 @@ func (r *run) Start(ctx context.Context) (<-chan error, error) {
 	return ech, nil
 }
 
-func (*run) PreStop(_ context.Context) error {
+func (*run) PreStop(context.Context) error {
 	return nil
 }
 

--- a/pkg/discoverer/k8s/handler/grpc/handler.go
+++ b/pkg/discoverer/k8s/handler/grpc/handler.go
@@ -69,7 +69,7 @@ func New(opts ...Option) (ds DiscovererServer, err error) {
 	return s, nil
 }
 
-func (*server) Start(_ context.Context) {
+func (*server) Start(context.Context) {
 }
 
 func (s *server) Pods(ctx context.Context, req *payload.Discoverer_Request) (*payload.Info_Pods, error) {

--- a/pkg/discoverer/k8s/usecase/discovered.go
+++ b/pkg/discoverer/k8s/usecase/discovered.go
@@ -188,7 +188,7 @@ func (r *run) Start(ctx context.Context) (<-chan error, error) {
 	return ech, nil
 }
 
-func (*run) PreStop(_ context.Context) error {
+func (*run) PreStop(context.Context) error {
 	return nil
 }
 
@@ -199,6 +199,6 @@ func (r *run) Stop(ctx context.Context) error {
 	return r.server.Shutdown(ctx)
 }
 
-func (*run) PostStop(_ context.Context) error {
+func (*run) PostStop(context.Context) error {
 	return nil
 }

--- a/pkg/gateway/filter/usecase/vald.go
+++ b/pkg/gateway/filter/usecase/vald.go
@@ -229,7 +229,7 @@ func (r *run) Start(ctx context.Context) (<-chan error, error) {
 	return ech, nil
 }
 
-func (*run) PreStop(_ context.Context) error {
+func (*run) PreStop(context.Context) error {
 	return nil
 }
 

--- a/pkg/gateway/lb/usecase/vald.go
+++ b/pkg/gateway/lb/usecase/vald.go
@@ -195,7 +195,7 @@ func (r *run) Start(ctx context.Context) (<-chan error, error) {
 	return ech, nil
 }
 
-func (*run) PreStop(_ context.Context) error {
+func (*run) PreStop(context.Context) error {
 	return nil
 }
 
@@ -206,6 +206,6 @@ func (r *run) Stop(ctx context.Context) error {
 	return r.server.Shutdown(ctx)
 }
 
-func (*run) PostStop(_ context.Context) error {
+func (*run) PostStop(context.Context) error {
 	return nil
 }

--- a/pkg/manager/index/service/indexer.go
+++ b/pkg/manager/index/service/indexer.go
@@ -159,8 +159,8 @@ func (idx *index) Start(ctx context.Context) (<-chan error, error) {
 				return
 			case addr := <-idx.saveIndexTargetAddrCh:
 				idx.schMap.Delete(addr)
-				_, err = idx.client.GetClient().
-					Do(grpc.WithGRPCMethod(ctx, "core.v1.Agent/SaveIndex"), addr, func(ctx context.Context, conn *grpc.ClientConn, copts ...grpc.CallOption) (_ interface{}, err error) {
+				_, err := idx.client.GetClient().
+					Do(grpc.WithGRPCMethod(ctx, "core.v1.Agent/SaveIndex"), addr, func(ctx context.Context, conn *grpc.ClientConn, copts ...grpc.CallOption) (interface{}, error) {
 						return agent.NewAgentClient(conn).SaveIndex(ctx, &payload.Empty{}, copts...)
 					})
 				if err != nil {

--- a/pkg/manager/index/usecase/indexer.go
+++ b/pkg/manager/index/usecase/indexer.go
@@ -208,7 +208,7 @@ func (r *run) Start(ctx context.Context) (<-chan error, error) {
 	return ech, nil
 }
 
-func (*run) PreStop(_ context.Context) error {
+func (*run) PreStop(context.Context) error {
 	return nil
 }
 
@@ -219,6 +219,6 @@ func (r *run) Stop(ctx context.Context) error {
 	return r.server.Shutdown(ctx)
 }
 
-func (*run) PostStop(_ context.Context) error {
+func (*run) PostStop(context.Context) error {
 	return nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
I have removed the blank `_` when all the parameters are not used in the target function or method.
And more, I have added the `ErrJobFuncNotFound` to return the `not found error` at the `internal/worker/queue.go`.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 1.14.8

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
