### PR TITLE
Bugfix grpc status handling for idle connection

### DIFF
--- a/internal/net/grpc/pool/pool.go
+++ b/internal/net/grpc/pool/pool.go
@@ -547,9 +547,12 @@ func isHealthy(conn *ClientConn) bool {
 	switch state {
 	case connectivity.Ready:
 		return true
-	case connectivity.Idle, connectivity.Connecting:
+	case connectivity.Connecting:
 		log.Debugf("grpc target %s's connection status will be Ready soon:\tstatus: %s", conn.Target(), state.String())
 		return true
+	case connectivity.Idle:
+		log.Debugf("grpc target %s's connection status is waiting for target:\tstatus: %s", conn.Target(), state.String())
+		return false
 	case connectivity.Shutdown, connectivity.TransientFailure:
 		log.Errorf("grpc target %s's connection status is unhealthy:\tstatus: %s", conn.Target(), state.String())
 		return false


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

### Description:

### WHAT

When a connection status becomes IDLE, create a new connection and discard the old one.

### WHY

If for some reason the component dropped (scale down ...etc.), the connection remains in an IDLE state at the origin (for a few minutes or so).
Due to the above, attempts to issue a request to a connection in the IDLE state will fail.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.19.4
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.9

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
