### PR TITLE
Update test template to exclude deepsource warning

### DIFF
--- a/assets/test/templates/common/fill.tmpl
+++ b/assets/test/templates/common/fill.tmpl
@@ -6,6 +6,7 @@
                 (ne $typ "sync.Once")
                 (ne $typ "sync.Map")
                 (ne $typ "sync.WaitGroup")
+                (ne $typ "sync.Cond")
                 (ne $typ "sync.Pool") }}
                         {{ Param . }}:
                         {{- if eq $typ "int8" -}} 0,

--- a/assets/test/templates/common/fill.tmpl
+++ b/assets/test/templates/common/fill.tmpl
@@ -5,8 +5,8 @@
                 (ne $typ "sync.RWMutex")
                 (ne $typ "sync.Once")
                 (ne $typ "sync.Map")
-                (ne $typ  "sync.WaitGroup")
-                (ne $typ "sync.Pool") -}}
+                (ne $typ "sync.WaitGroup")
+                (ne $typ "sync.Pool") }}
                         {{ Param . }}:
                         {{- if eq $typ "int8" -}} 0,
                         {{- else if eq $typ "uint8" -}} 0,

--- a/assets/test/templates/common/fill.tmpl
+++ b/assets/test/templates/common/fill.tmpl
@@ -1,8 +1,6 @@
 {{define "fill" }}
-        {{- range . }}
-                {{ $typ := .Type.String -}}
-                {{- if eq $typ "sync.Map" -}}
-                {{- else -}}
+        {{- range . }} {{ $typ := .Type.String -}}
+                {{- if ne $typ "sync.Map" "sync.Mutex" "sync.RWMutex" "sync.Once" "sync.Map" "sync.WaitGroup" "sync.Pool" -}}
                         {{ Param . }}:
                         {{- if eq $typ "int8" -}} 0,
                         {{- else if eq $typ "uint8" -}} 0,

--- a/assets/test/templates/common/fill.tmpl
+++ b/assets/test/templates/common/fill.tmpl
@@ -1,28 +1,32 @@
 {{define "fill" }}
         {{- range . }}
-                {{ Param . }}: {{ $typ := .Type.String -}}
-                {{- if eq $typ "int8" -}} 0,
-                {{- else if eq $typ "uint8" -}} 0,
-                {{- else if eq $typ "uint16" -}} 0,
-                {{- else if eq $typ "uint32" -}} 0,
-                {{- else if eq $typ "uint64" -}} 0,
-                {{- else if eq $typ "uint" -}} 0,
-                {{- else if eq $typ "uintptr" -}} 0,
-                {{- else if eq $typ "int8" -}} 0,
-                {{- else if eq $typ "int16" -}} 0,
-                {{- else if eq $typ "int32" -}} 0,
-                {{- else if eq $typ "int64" -}} 0,
-                {{- else if eq $typ "int" -}} 0,
-                {{- else if eq $typ "float32" -}} 0,
-                {{- else if eq $typ "float64" -}} 0,
-                {{- else if eq $typ "complex64" -}} 0+0i,
-                {{- else if eq $typ "complex128" -}} 0+0i,
-                {{- else if eq $typ "byte" -}} 0,
-                {{- else if eq $typ "rune" -}} 0,
-                {{- else if eq $typ "string" -}} "",
-                {{- else if eq $typ "bool" -}} false,
-                {{- else if .IsStruct -}} {{.Type.Value}}{},
-                {{- else -}} nil,
+                {{ $typ := .Type.String -}}
+                {{- if eq $typ "sync.Map" -}}
+                {{- else -}}
+                        {{ Param . }}:
+                        {{- if eq $typ "int8" -}} 0,
+                        {{- else if eq $typ "uint8" -}} 0,
+                        {{- else if eq $typ "uint16" -}} 0,
+                        {{- else if eq $typ "uint32" -}} 0,
+                        {{- else if eq $typ "uint64" -}} 0,
+                        {{- else if eq $typ "uint" -}} 0,
+                        {{- else if eq $typ "uintptr" -}} 0,
+                        {{- else if eq $typ "int8" -}} 0,
+                        {{- else if eq $typ "int16" -}} 0,
+                        {{- else if eq $typ "int32" -}} 0,
+                        {{- else if eq $typ "int64" -}} 0,
+                        {{- else if eq $typ "int" -}} 0,
+                        {{- else if eq $typ "float32" -}} 0,
+                        {{- else if eq $typ "float64" -}} 0,
+                        {{- else if eq $typ "complex64" -}} 0+0i,
+                        {{- else if eq $typ "complex128" -}} 0+0i,
+                        {{- else if eq $typ "byte" -}} 0,
+                        {{- else if eq $typ "rune" -}} 0,
+                        {{- else if eq $typ "string" -}} "",
+                        {{- else if eq $typ "bool" -}} false,
+                        {{- else if .IsStruct -}} {{.Type.Value}}{},
+                        {{- else -}} nil,
+                        {{- end -}}
                 {{- end -}}
         {{ end -}}
 {{ end }}

--- a/assets/test/templates/common/fill.tmpl
+++ b/assets/test/templates/common/fill.tmpl
@@ -8,7 +8,7 @@
                 (ne $typ "sync.WaitGroup")
                 (ne $typ "sync.Cond")
                 (ne $typ "sync.Pool") }}
-                        {{ Param . }}:
+                {{ Param . }}:
                         {{- if eq $typ "int8" -}} 0,
                         {{- else if eq $typ "uint8" -}} 0,
                         {{- else if eq $typ "uint16" -}} 0,

--- a/assets/test/templates/common/fill.tmpl
+++ b/assets/test/templates/common/fill.tmpl
@@ -1,6 +1,12 @@
 {{define "fill" }}
         {{- range . }} {{ $typ := .Type.String -}}
-                {{- if ne $typ "sync.Map" "sync.Mutex" "sync.RWMutex" "sync.Once" "sync.Map" "sync.WaitGroup" "sync.Pool" -}}
+                {{- if and (ne $typ "sync.Map")
+                (ne $typ "sync.Mutex")
+                (ne $typ "sync.RWMutex")
+                (ne $typ "sync.Once")
+                (ne $typ "sync.Map")
+                (ne $typ  "sync.WaitGroup")
+                (ne $typ "sync.Pool") -}}
                         {{ Param . }}:
                         {{- if eq $typ "int8" -}} 0,
                         {{- else if eq $typ "uint8" -}} 0,

--- a/assets/test/templates/common/function.tmpl
+++ b/assets/test/templates/common/function.tmpl
@@ -15,7 +15,11 @@ func {{ .TestName }}(t *testing.T) {
             {{- if .Fields}}
                 type fields struct { {{ $hasFields = true }}
                     {{- range .Fields }}
-                        {{ Field . }} {{ .Type }}
+                        {{ $typ := .Type.String -}}
+                        {{- if eq $typ "sync.Map" -}}
+                        {{- else -}}
+                            {{ Field . }} {{ .Type }}
+                        {{- end -}}
                     {{- end }}
                 }
             {{- end }}
@@ -139,7 +143,11 @@ func {{ .TestName }}(t *testing.T) {
                     {{- if .IsStruct }}
                         {{ Receiver . }} := {{- if .Type.IsStar }}&{{- end }}{{ .Type.Value }} {
                         {{- range .Fields }}
-                            {{ Field . }}: test.fields.{{ Field . }},
+                            {{ $typ := .Type.String -}}
+                            {{- if eq $typ "sync.Map" -}}
+                            {{- else -}}
+                                {{ Field . }}: test.fields.{{ Field . }},
+                            {{- end }}
                         {{- end }}
                         }
                     {{- end }}

--- a/assets/test/templates/common/function.tmpl
+++ b/assets/test/templates/common/function.tmpl
@@ -20,8 +20,8 @@ func {{ .TestName }}(t *testing.T) {
                         (ne $typ "sync.RWMutex")
                         (ne $typ "sync.Once")
                         (ne $typ "sync.Map")
-                        (ne $typ  "sync.WaitGroup")
-                        (ne $typ "sync.Pool") -}}
+                        (ne $typ "sync.WaitGroup")
+                        (ne $typ "sync.Pool") }}
                             {{ Field . }} {{ .Type }}
                         {{- end -}}
                     {{- end }}
@@ -152,8 +152,8 @@ func {{ .TestName }}(t *testing.T) {
                             (ne $typ "sync.RWMutex")
                             (ne $typ "sync.Once")
                             (ne $typ "sync.Map")
-                            (ne $typ  "sync.WaitGroup")
-                            (ne $typ "sync.Pool") -}}
+                            (ne $typ "sync.WaitGroup")
+                            (ne $typ "sync.Pool") }}
                                 {{ Field . }}: test.fields.{{ Field . }},
                             {{- end }}
                         {{- end }}

--- a/assets/test/templates/common/function.tmpl
+++ b/assets/test/templates/common/function.tmpl
@@ -15,7 +15,13 @@ func {{ .TestName }}(t *testing.T) {
             {{- if .Fields}}
                 type fields struct { {{ $hasFields = true }}
                     {{- range .Fields }} {{ $typ := .Type.String -}}
-                        {{- if ne $typ "sync.Map" "sync.Mutex" "sync.RWMutex" "sync.Once" "sync.Map" "sync.WaitGroup" "sync.Pool" -}}
+                        {{- if and (ne $typ "sync.Map")
+                        (ne $typ "sync.Mutex")
+                        (ne $typ "sync.RWMutex")
+                        (ne $typ "sync.Once")
+                        (ne $typ "sync.Map")
+                        (ne $typ  "sync.WaitGroup")
+                        (ne $typ "sync.Pool") -}}
                             {{ Field . }} {{ .Type }}
                         {{- end -}}
                     {{- end }}
@@ -141,7 +147,13 @@ func {{ .TestName }}(t *testing.T) {
                     {{- if .IsStruct }}
                         {{ Receiver . }} := {{- if .Type.IsStar }}&{{- end }}{{ .Type.Value }} {
                         {{- range .Fields }} {{ $typ := .Type.String -}}
-                            {{- if ne $typ "sync.Map" "sync.Mutex" "sync.RWMutex" "sync.Once" "sync.Map" "sync.WaitGroup" "sync.Pool" -}}
+                            {{- if and (ne $typ "sync.Map")
+                            (ne $typ "sync.Mutex")
+                            (ne $typ "sync.RWMutex")
+                            (ne $typ "sync.Once")
+                            (ne $typ "sync.Map")
+                            (ne $typ  "sync.WaitGroup")
+                            (ne $typ "sync.Pool") -}}
                                 {{ Field . }}: test.fields.{{ Field . }},
                             {{- end }}
                         {{- end }}

--- a/assets/test/templates/common/function.tmpl
+++ b/assets/test/templates/common/function.tmpl
@@ -21,6 +21,7 @@ func {{ .TestName }}(t *testing.T) {
                         (ne $typ "sync.Once")
                         (ne $typ "sync.Map")
                         (ne $typ "sync.WaitGroup")
+                        (ne $typ "sync.Cond")
                         (ne $typ "sync.Pool") }}
                             {{ Field . }} {{ .Type }}
                         {{- end -}}
@@ -153,6 +154,7 @@ func {{ .TestName }}(t *testing.T) {
                             (ne $typ "sync.Once")
                             (ne $typ "sync.Map")
                             (ne $typ "sync.WaitGroup")
+                            (ne $typ "sync.Cond")
                             (ne $typ "sync.Pool") }}
                                 {{ Field . }}: test.fields.{{ Field . }},
                             {{- end }}

--- a/assets/test/templates/common/function.tmpl
+++ b/assets/test/templates/common/function.tmpl
@@ -14,10 +14,8 @@ func {{ .TestName }}(t *testing.T) {
         {{- if .IsStruct }}
             {{- if .Fields}}
                 type fields struct { {{ $hasFields = true }}
-                    {{- range .Fields }}
-                        {{ $typ := .Type.String -}}
-                        {{- if eq $typ "sync.Map" -}}
-                        {{- else -}}
+                    {{- range .Fields }} {{ $typ := .Type.String -}}
+                        {{- if ne $typ "sync.Map" "sync.Mutex" "sync.RWMutex" "sync.Once" "sync.Map" "sync.WaitGroup" "sync.Pool" -}}
                             {{ Field . }} {{ .Type }}
                         {{- end -}}
                     {{- end }}
@@ -142,10 +140,8 @@ func {{ .TestName }}(t *testing.T) {
                 {{- with .Receiver }}
                     {{- if .IsStruct }}
                         {{ Receiver . }} := {{- if .Type.IsStar }}&{{- end }}{{ .Type.Value }} {
-                        {{- range .Fields }}
-                            {{ $typ := .Type.String -}}
-                            {{- if eq $typ "sync.Map" -}}
-                            {{- else -}}
+                        {{- range .Fields }} {{ $typ := .Type.String -}}
+                            {{- if ne $typ "sync.Map" "sync.Mutex" "sync.RWMutex" "sync.Once" "sync.Map" "sync.WaitGroup" "sync.Pool" -}}
                                 {{ Field . }}: test.fields.{{ Field . }},
                             {{- end }}
                         {{- end }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR update the gotests test template to exclude the type on the generated test file.
These types are warned in deepsource before, including the following type:

- sync.Map
- sync.Mutex
- sync.RWMutex
- sync.Once
- sync.Map
- sync.WaitGroup
- sync.Pool
- sync.Cond
- (other custom type contains lock)

Custom type exclusion will not be included in this PR.

You can verify this changes by using `make gotests/gen` command to generate the missing test impl and verify the changes using `git diff [file]`.
e.g. `git diff internal/circuitbreaker/manager_test.go`

```go
func Test_breakerManager_Do(t *testing.T) {
        type args struct {
                ctx context.Context
                key string
                fn  func(ctx context.Context) (interface{}, error)
        }
        type fields struct {
                opts []BreakerOption
        }
        type want struct {
                wantVal interface{}
                err     error
        }
        type test struct {
                name       string
                args       args
                fields     fields
                want       want
                checkFunc  func(want, interface{}, error) error
                beforeFunc func(*testing.T, args)
                afterFunc  func(*testing.T, args)
        }
        defaultCheckFunc := func(w want, gotVal interface{}, err error) error {
                if !errors.Is(err, w.err) {
                        return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
                }
                if !reflect.DeepEqual(gotVal, w.wantVal) {
                        return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", gotVal, w.wantVal)
                }
                return nil
        }
        tests := []test{
                // TODO test cases
                /*
                   {
                       name: "test_case_1",
                       args: args {
                           ctx:nil,
                           key:"",
                           fn:nil,
                       },
                       fields: fields {
                           opts:nil,
                       },
                       want: want{},
                       checkFunc: defaultCheckFunc,
                       beforeFunc: func(t *testing.T, args args) {
                           t.Helper()
                       },
                       afterFunc: func(t *testing.T, args args) {
                           t.Helper()
                       },
                   },
                */

                // TODO test cases
                /*
                   func() test {
                       return test {
                           name: "test_case_2",
                           args: args {
                           ctx:nil,
                           key:"",
                           fn:nil,
                           },
                           fields: fields {
                           opts:nil,
                           },
                           want: want{},
                           checkFunc: defaultCheckFunc,
                           beforeFunc: func(t *testing.T, args args) {
                               t.Helper()
                           },
                           afterFunc: func(t *testing.T, args args) {
                               t.Helper()
                           },
                       }
                   }(),
                */
        }

        for _, tc := range tests {
                test := tc
                t.Run(test.name, func(tt *testing.T) {
                        tt.Parallel()
                        defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
                        if test.beforeFunc != nil {
                                test.beforeFunc(tt, test.args)
                        }
                        if test.afterFunc != nil {
                                defer test.afterFunc(tt, test.args)
                        }
                        checkFunc := test.checkFunc
                        if test.checkFunc == nil {
                                checkFunc = defaultCheckFunc
                        }
                        bm := &breakerManager{
                                opts: test.fields.opts,
                        }

                        gotVal, err := bm.Do(test.args.ctx, test.args.key, test.args.fn)
                        if err := checkFunc(test.want, gotVal, err); err != nil {
                                tt.Errorf("error = %v", err)
                        }

                })
        }
}
```
<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.9

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
