### PR TITLE
Fix documentaion typo disable_balanced_update

### DIFF
--- a/docs/api/filter-gateway.md
+++ b/docs/api/filter-gateway.md
@@ -485,12 +485,12 @@ service Filter {
 
   - Update.Config
 
-    |          field           | type          | label | required | desc.                                                                                               |
-    | :----------------------: | :------------ | :---- | :------: | :-------------------------------------------------------------------------------------------------- |
-    | skip_strict_exist_check  | bool          |       |          | check the same vector is already updated or not.<br>the ID should be unique if the value is `true`. |
-    |        timestamp         | int64         |       |          | the timestamp of the vector updated.<br>if it is N/A, the current time will be used.                |
-    |         filters          | Filter.Config |       |          | configuration for filter                                                                            |
-    | disabled_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.    |
+    |          field          | type          | label | required | desc.                                                                                               |
+    | :---------------------: | :------------ | :---- | :------: | :-------------------------------------------------------------------------------------------------- |
+    | skip_strict_exist_check | bool          |       |          | check the same vector is already updated or not.<br>the ID should be unique if the value is `true`. |
+    |        timestamp        | int64         |       |          | the timestamp of the vector updated.<br>if it is N/A, the current time will be used.                |
+    |         filters         | Filter.Config |       |          | configuration for filter                                                                            |
+    | disable_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.    |
 
   - Filter.Target
 
@@ -607,12 +607,12 @@ service Filter {
 
   - Update.Config
 
-    |          field           | type          | label | required | desc.                                                                                               |
-    | :----------------------: | :------------ | :---- | :------: | :-------------------------------------------------------------------------------------------------- |
-    | skip_strict_exist_check  | bool          |       |          | check the same vector is already updated or not.<br>the ID should be unique if the value is `true`. |
-    |        timestamp         | int64         |       |          | the timestamp of the vector updated.<br>if it is N/A, the current time will be used.                |
-    |         filters          | Filter.Config |       |          | configuration for filter                                                                            |
-    | disabled_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.    |
+    |          field          | type          | label | required | desc.                                                                                               |
+    | :---------------------: | :------------ | :---- | :------: | :-------------------------------------------------------------------------------------------------- |
+    | skip_strict_exist_check | bool          |       |          | check the same vector is already updated or not.<br>the ID should be unique if the value is `true`. |
+    |        timestamp        | int64         |       |          | the timestamp of the vector updated.<br>if it is N/A, the current time will be used.                |
+    |         filters         | Filter.Config |       |          | configuration for filter                                                                            |
+    | disable_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.    |
 
   - Filter.Target
 
@@ -768,12 +768,12 @@ service Filter {
 
   - Update.Config
 
-    |          field           | type          | label | required | desc.                                                                                               |
-    | :----------------------: | :------------ | :---- | :------: | :-------------------------------------------------------------------------------------------------- |
-    | skip_strict_exist_check  | bool          |       |          | check the same vector is already updated or not.<br>the ID should be unique if the value is `true`. |
-    |        timestamp         | int64         |       |          | the timestamp of the vector updated.<br>if it is N/A, the current time will be used.                |
-    |         filters          | Filter.Config |       |          | configuration for filter                                                                            |
-    | disabled_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.    |
+    |          field          | type          | label | required | desc.                                                                                               |
+    | :---------------------: | :------------ | :---- | :------: | :-------------------------------------------------------------------------------------------------- |
+    | skip_strict_exist_check | bool          |       |          | check the same vector is already updated or not.<br>the ID should be unique if the value is `true`. |
+    |        timestamp        | int64         |       |          | the timestamp of the vector updated.<br>if it is N/A, the current time will be used.                |
+    |         filters         | Filter.Config |       |          | configuration for filter                                                                            |
+    | disable_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.    |
 
   - Filter.Target
 
@@ -900,12 +900,12 @@ service Filter {
 
   - Update.Config
 
-    |          field           | type          | label | required | desc.                                                                                                |
-    | :----------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
-    | skip_strict_exist_check  | bool          |       |          | check the same vector is already upserted or not.<br>the ID should be unique if the value is `true`. |
-    |        timestamp         | int64         |       |          | the timestamp of the vector upserted.<br>if it is N/A, the current time will be used.                |
-    |         filters          | Filter.Config |       |          | configuration for filter                                                                             |
-    | disabled_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
+    |          field          | type          | label | required | desc.                                                                                                |
+    | :---------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
+    | skip_strict_exist_check | bool          |       |          | check the same vector is already upserted or not.<br>the ID should be unique if the value is `true`. |
+    |        timestamp        | int64         |       |          | the timestamp of the vector upserted.<br>if it is N/A, the current time will be used.                |
+    |         filters         | Filter.Config |       |          | configuration for filter                                                                             |
+    | disable_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
 
   - Filter.Target
 
@@ -1019,12 +1019,12 @@ service Filter {
 
   - Update.Config
 
-    |          field           | type          | label | required | desc.                                                                                                |
-    | :----------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
-    | skip_strict_exist_check  | bool          |       |          | check the same vector is already upserted or not.<br>the ID should be unique if the value is `true`. |
-    |        timestamp         | int64         |       |          | the timestamp of the vector upserted.<br>if it is N/A, the current time will be used.                |
-    |         filters          | Filter.Config |       |          | configuration for filter                                                                             |
-    | disabled_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
+    |          field          | type          | label | required | desc.                                                                                                |
+    | :---------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
+    | skip_strict_exist_check | bool          |       |          | check the same vector is already upserted or not.<br>the ID should be unique if the value is `true`. |
+    |        timestamp        | int64         |       |          | the timestamp of the vector upserted.<br>if it is N/A, the current time will be used.                |
+    |         filters         | Filter.Config |       |          | configuration for filter                                                                             |
+    | disable_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
 
   - Filter.Target
 
@@ -1180,12 +1180,12 @@ service Filter {
 
   - Update.Config
 
-    |          field           | type          | label | required | desc.                                                                                                |
-    | :----------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
-    | skip_strict_exist_check  | bool          |       |          | check the same vector is already upserted or not.<br>the ID should be unique if the value is `true`. |
-    |        timestamp         | int64         |       |          | the timestamp of the vector upserted.<br>if it is N/A, the current time will be used.                |
-    |         filters          | Filter.Config |       |          | configuration for filter                                                                             |
-    | disabled_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
+    |          field          | type          | label | required | desc.                                                                                                |
+    | :---------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
+    | skip_strict_exist_check | bool          |       |          | check the same vector is already upserted or not.<br>the ID should be unique if the value is `true`. |
+    |        timestamp        | int64         |       |          | the timestamp of the vector upserted.<br>if it is N/A, the current time will be used.                |
+    |         filters         | Filter.Config |       |          | configuration for filter                                                                             |
+    | disable_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
 
   - Filter.Target
 

--- a/docs/api/update.md
+++ b/docs/api/update.md
@@ -53,12 +53,12 @@ Update RPC is the method to update a single vector.
 
   - Update.Config
 
-    |          field           | type          | label | required | desc.                                                                                                |
-    | :----------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
-    | skip_strict_exist_check  | bool          |       |          | check the same vector is already inserted or not.<br>the ID should be unique if the value is `true`. |
-    |        timestamp         | int64         |       |          | the timestamp of the vector updated.<br>if it is N/A, the current time will be used.                 |
-    |         filters          | Filter.Config |       |          | configuration for filter                                                                             |
-    | disabled_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
+    |          field          | type          | label | required | desc.                                                                                                |
+    | :---------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
+    | skip_strict_exist_check | bool          |       |          | check the same vector is already inserted or not.<br>the ID should be unique if the value is `true`. |
+    |        timestamp        | int64         |       |          | the timestamp of the vector updated.<br>if it is N/A, the current time will be used.                 |
+    |         filters         | Filter.Config |       |          | configuration for filter                                                                             |
+    | disable_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
 
   - Object.Vector
 
@@ -142,12 +142,12 @@ It's the recommended method to update the large amount of vectors.
 
   - Update.Config
 
-    |          field           | type          | label | required | desc.                                                                                                |
-    | :----------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
-    | skip_strict_exist_check  | bool          |       |          | check the same vector is already inserted or not.<br>the ID should be unique if the value is `true`. |
-    |        timestamp         | int64         |       |          | the timestamp of the vector updated.<br>if it is N/A, the current time will be used.                 |
-    |         filters          | Filter.Config |       |          | configuration for filter                                                                             |
-    | disabled_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
+    |          field          | type          | label | required | desc.                                                                                                |
+    | :---------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
+    | skip_strict_exist_check | bool          |       |          | check the same vector is already inserted or not.<br>the ID should be unique if the value is `true`. |
+    |        timestamp        | int64         |       |          | the timestamp of the vector updated.<br>if it is N/A, the current time will be used.                 |
+    |         filters         | Filter.Config |       |          | configuration for filter                                                                             |
+    | disable_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
 
   - Object.Vector
 
@@ -264,12 +264,12 @@ Please be careful that the size of the request exceed the limit.
 
   - Update.Config
 
-    |          field           | type          | label | required | desc.                                                                                                |
-    | :----------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
-    | skip_strict_exist_check  | bool          |       |          | check the same vector is already inserted or not.<br>the ID should be unique if the value is `true`. |
-    |        timestamp         | int64         |       |          | the timestamp of the vector updated.<br>if it is N/A, the current time will be used.                 |
-    |         filters          | Filter.Config |       |          | configuration for filter                                                                             |
-    | disabled_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
+    |          field          | type          | label | required | desc.                                                                                                |
+    | :---------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
+    | skip_strict_exist_check | bool          |       |          | check the same vector is already inserted or not.<br>the ID should be unique if the value is `true`. |
+    |        timestamp        | int64         |       |          | the timestamp of the vector updated.<br>if it is N/A, the current time will be used.                 |
+    |         filters         | Filter.Config |       |          | configuration for filter                                                                             |
+    | disable_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
 
   - Object.Vector
 

--- a/docs/api/upsert.md
+++ b/docs/api/upsert.md
@@ -57,12 +57,12 @@ Upsert RPC is the method to update a single vector and add a new single vector.
 
   - Upsert.Config
 
-    |          field           | type          | label | required | desc.                                                                                                |
-    | :----------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
-    | skip_strict_exist_check  | bool          |       |          | check the same vector is already inserted or not.<br>the ID should be unique if the value is `true`. |
-    |        timestamp         | int64         |       |          | the timestamp of the vector updated/inserted.<br>if it is N/A, the current time will be used.        |
-    |         filters          | Filter.Config |       |          | configuration for filter                                                                             |
-    | disabled_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
+    |          field          | type          | label | required | desc.                                                                                                |
+    | :---------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
+    | skip_strict_exist_check | bool          |       |          | check the same vector is already inserted or not.<br>the ID should be unique if the value is `true`. |
+    |        timestamp        | int64         |       |          | the timestamp of the vector updated/inserted.<br>if it is N/A, the current time will be used.        |
+    |         filters         | Filter.Config |       |          | configuration for filter                                                                             |
+    | disable_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
 
   - Object.Vector
 
@@ -145,12 +145,12 @@ It’s the recommended method to upsert a large number of vectors.
 
   - Upsert.Config
 
-    |          field           | type          | label | required | desc.                                                                                                |
-    | :----------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
-    | skip_strict_exist_check  | bool          |       |          | check the same vector is already inserted or not.<br>the ID should be unique if the value is `true`. |
-    |        timestamp         | int64         |       |          | the timestamp of the vector updated/inserted.<br>if it is N/A, the current time will be used.        |
-    |         filters          | Filter.Config |       |          | configuration for filter                                                                             |
-    | disabled_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
+    |          field          | type          | label | required | desc.                                                                                                |
+    | :---------------------: | :------------ | :---- | :------: | :--------------------------------------------------------------------------------------------------- |
+    | skip_strict_exist_check | bool          |       |          | check the same vector is already inserted or not.<br>the ID should be unique if the value is `true`. |
+    |        timestamp        | int64         |       |          | the timestamp of the vector updated/inserted.<br>if it is N/A, the current time will be used.        |
+    |         filters         | Filter.Config |       |          | configuration for filter                                                                             |
+    | disable_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.     |
 
   - Object.Vector
 
@@ -266,12 +266,12 @@ Please be careful that the size of the request exceeds the limit.
 
   - Upsert.Config
 
-    |          field           | type          | label | required | desc.                                                                                                        |
-    | :----------------------: | :------------ | :---- | :------: | :----------------------------------------------------------------------------------------------------------- |
-    | skip_strict_exist_check  | bool          |       |          | check the same vector is already updated/inserted or not.<br>the ID should be unique if the value is `true`. |
-    |        timestamp         | int64         |       |          | the timestamp of the vector updated/inserted.<br>if it is N/A, the current time will be used.                |
-    |         filters          | Filter.Config |       |          | configuration for filter                                                                                     |
-    | disabled_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.             |
+    |          field          | type          | label | required | desc.                                                                                                        |
+    | :---------------------: | :------------ | :---- | :------: | :----------------------------------------------------------------------------------------------------------- |
+    | skip_strict_exist_check | bool          |       |          | check the same vector is already updated/inserted or not.<br>the ID should be unique if the value is `true`. |
+    |        timestamp        | int64         |       |          | the timestamp of the vector updated/inserted.<br>if it is N/A, the current time will be used.                |
+    |         filters         | Filter.Config |       |          | configuration for filter                                                                                     |
+    | disable_balanced_update | bool          |       |          | A flag to disable balanced update (split remove -&gt; insert operation) during update operation.             |
 
   - Object.Vector
 


### PR DESCRIPTION
I fixed documentaion typo disabled_balanced_update -> disable_balanced_update, an option name added in v1.7.3

### Versions:
Vald v1.7.3

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
