### PR TITLE
Bug fix: fix range concurrency branch rule

### DIFF
--- a/internal/net/grpc/client.go
+++ b/internal/net/grpc/client.go
@@ -400,7 +400,7 @@ func (g *gRPCClient) RangeConcurrent(ctx context.Context,
 			span.End()
 		}
 	}()
-	if concurrency < 2 {
+	if concurrency == 0 || concurrency == 1 {
 		return g.Range(ctx, f)
 	}
 	eg, egctx := errgroup.New(sctx)

--- a/internal/net/grpc/context.go
+++ b/internal/net/grpc/context.go
@@ -13,7 +13,10 @@
 // limitations under the License.
 package grpc
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 type contextKey string
 
@@ -24,6 +27,9 @@ func WrapGRPCMethod(ctx context.Context, method string) context.Context {
 	m := FromGRPCMethod(ctx)
 	if m == "" {
 		return context.WithValue(ctx, grpcMethodContextKey, method)
+	}
+	if strings.HasSuffix(m, method) {
+		return ctx
 	}
 	return context.WithValue(ctx, grpcMethodContextKey, m+"/"+method)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->
I have fixed the concurrency branch rule at the `internal/net/grpc/client.go`.
Thanks to #1953  , the backoff problem is resolved.
However, the concurrency branch rule affects the lb service.
Ref: https://github.com/vdaas/vald/blob/main/pkg/gateway/lb/service/gateway.go#L72-L86

So, I have fixed it with @hlts2 and @kpango .

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.9

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
