### PR TITLE
Fix ChatOpts /gen-test command error

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -334,6 +334,7 @@ jobs:
           git checkout ${HEAD_BRANCH}
 
           make gotests/install
+          PATH=$PATH:$GOPATH/bin
           make -j 4 gotests/gen
 
           git add cmd hack internal pkg

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -318,6 +318,14 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           git_user_signingkey: true
           git_commit_gpgsign: true
+      - name: Fetch golang version
+        run: |
+          GO_VERSION=`make version/go`
+          echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
+        id: golang_version
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ steps.golang_version.outputs.version }}
       - name: Generate tests and push
         if: steps.check_comments_gen_test.outputs.BOOL_TRIGGERED == 'true' && steps.check_permissions.outputs.EXECUTABLE == 'true'
         run: |
@@ -332,9 +340,6 @@ jobs:
           echo "Head branch for PR #${PR_NUM} is ${HEAD_BRANCH}"
 
           git checkout ${HEAD_BRANCH}
-
-          export GOBIN=$GOPATH/bin
-          export PATH=$PATH:$GOBIN
 
           make gotests/install
           make -j 4 gotests/gen

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -333,8 +333,10 @@ jobs:
 
           git checkout ${HEAD_BRANCH}
 
+          export GOBIN=$GOPATH/bin
+          export PATH=$PATH:$GOBIN
+
           make gotests/install
-          export PATH=$PATH:$GOPATH/bin
           make -j 4 gotests/gen
 
           git add cmd hack internal pkg

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -334,7 +334,7 @@ jobs:
           git checkout ${HEAD_BRANCH}
 
           make gotests/install
-          PATH=$PATH:$GOPATH/bin
+          export PATH=$PATH:$GOPATH/bin
           make -j 4 gotests/gen
 
           git add cmd hack internal pkg


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR fixes the ChatOpts command `/gen-test` CI error.

Error log:
https://github.com/vdaas/vald/actions/runs/4592104780/jobs/8108855745
<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.9

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

Since the Github action always triggered base on the main branch due to security reason, the changes of this PR will not be affected until this PR is merged.
After this PR is reviewed and merged, I will create another PR to test the ChatOpts command `/gen-test`.
<!-- Please tell us anything you would like to share to reviewers related this PR -->
