### PR TITLE
Output error log to ChatOpts comment

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -327,6 +327,7 @@ jobs:
         with:
           go-version: ${{ steps.golang_version.outputs.version }}
       - name: Generate tests and push
+        id: gen_test
         if: steps.check_comments_gen_test.outputs.BOOL_TRIGGERED == 'true' && steps.check_permissions.outputs.EXECUTABLE == 'true'
         run: |
           curl -s ${PR_INFO_URL} > /tmp/pr_info.json
@@ -342,7 +343,7 @@ jobs:
           git checkout ${HEAD_BRANCH}
 
           make gotests/install
-          make -j 4 gotests/gen
+          GITHUB_OUTPUT=$(make gotests/gen 2>&1 >/dev/null)
 
           git add cmd hack internal pkg
           git commit -S --signoff -m ":robot: Add automatically generated tests"
@@ -361,12 +362,13 @@ jobs:
       - name: failure comment
         if: failure()
         run: |
+          ERR_LOG=${{ steps.gen_test.outputs }}
           curl --include --verbose --fail \
           -H "Accept: application/json" \
           -H "Content-Type:application/json" \
           -H "Authorization: token ${GITHUB_TOKEN}" \
           --request POST \
-          --data "{\"body\": \"**[GEN TEST]** Failed to generate tests.\"}" \
+          --data "{\"body\": \"**[GEN TEST]** Failed to generate tests. Error: $ERR_LOG\"}" \
           $API_URL
         env:
           GITHUB_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/Makefile.d/functions.mk
+++ b/Makefile.d/functions.mk
@@ -134,6 +134,11 @@ define gen-go-test-sources
 	@for f in $(GO_SOURCES); do \
 		echo "Generating go test file: $$f"; \
 		gotests -w -template_dir $(ROOTDIR)/assets/test/templates/common -all $(patsubst %_test.go,%.go,$$f); \
+		RESULT=$$?; \
+		if [ ! $$RESULT -eq 0 ]; then \
+			echo $$RESULT; \
+			exit 1; \
+		fi; \
 	done
 endef
 
@@ -141,5 +146,10 @@ define gen-go-option-test-sources
 	@for f in $(GO_OPTION_SOURCES); do \
 		echo "Generating go option test file: $$f"; \
 		gotests -w -template_dir $(ROOTDIR)/assets/test/templates/common -all $(patsubst %_test.go,%.go,$$f); \
+		RESULT=$$?; \
+		if [ ! $$RESULT -eq 0 ]; then \
+			echo $$RESULT; \
+			exit 1; \
+		fi; \
 	done
 endef


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR include the following changes:
- Output error to chatops comment if `/gen-test` command failed
- Fix `/gen-test` chatops  command failure
<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.2
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.9

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

I have tested the command on my local PC but for the CI to pass the error message to another step, I am not sure if it works or not since the changes will not be effective before this PR is merged.
<!-- Please tell us anything you would like to share to reviewers related this PR -->
