### PR TITLE
Update internal/info test and add new case for coverage

### DIFF
--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -111,10 +111,13 @@ var (
 )
 
 const (
-	goSrc    = "go/src/"
-	goSrcLen = len(goSrc)
-	goMod    = "go/pkg/mod/"
-	goModLen = len(goMod)
+	goSrc      = "go/src/"
+	goSrcLen   = len(goSrc)
+	goMod      = "go/pkg/mod/"
+	goModLen   = len(goMod)
+	cgoTrue    = "true"
+	cgoFalse   = "false"
+	cgoUnknown = "unknown"
 )
 
 // Init initializes Detail object only once.
@@ -351,12 +354,12 @@ func (i *info) prepare() {
 			i.detail.CGOEnabled = CGOEnabled
 		}
 		switch i.detail.CGOEnabled {
-		case "0", "false":
-			i.detail.CGOEnabled = "false"
-		case "1", "true":
-			i.detail.CGOEnabled = "true"
+		case "0", cgoFalse:
+			i.detail.CGOEnabled = cgoFalse
+		case "1", cgoTrue:
+			i.detail.CGOEnabled = cgoTrue
 		default:
-			i.detail.CGOEnabled = "unknown"
+			i.detail.CGOEnabled = cgoUnknown
 		}
 		if len(i.detail.NGTVersion) == 0 && len(NGTVersion) != 0 {
 			i.detail.NGTVersion = NGTVersion

--- a/internal/info/info_test.go
+++ b/internal/info/info_test.go
@@ -89,13 +89,13 @@ func TestString(t *testing.T) {
 				want: &Detail{
 					Version:           "v0.0.1",
 					ServerName:        "",
-					GitCommit:         "main",
+					GitCommit:         GitCommit,
 					BuildTime:         "",
 					GoVersion:         runtime.Version(),
 					GoOS:              runtime.GOOS,
 					GoArch:            runtime.GOARCH,
 					GoRoot:            runtime.GOROOT(),
-					CGOEnabled:        "unknown",
+					CGOEnabled:        cgoUnknown,
 					NGTVersion:        "",
 					BuildCPUInfoFlags: nil,
 					StackTrace:        nil,
@@ -121,13 +121,13 @@ func TestString(t *testing.T) {
 				want: &Detail{
 					Version:           "",
 					ServerName:        "",
-					GitCommit:         "main",
+					GitCommit:         GitCommit,
 					BuildTime:         "",
 					GoVersion:         runtime.Version(),
 					GoOS:              runtime.GOOS,
 					GoArch:            runtime.GOARCH,
 					GoRoot:            runtime.GOROOT(),
-					CGOEnabled:        "unknown",
+					CGOEnabled:        cgoUnknown,
 					NGTVersion:        "",
 					BuildCPUInfoFlags: nil,
 					StackTrace:        nil,
@@ -192,14 +192,14 @@ func TestGet(t *testing.T) {
 			want: want{
 				want: Detail{
 					ServerName:        "",
-					Version:           "v0.0.1",
+					Version:           Version,
 					BuildTime:         "",
-					GitCommit:         "main",
+					GitCommit:         GitCommit,
 					GoVersion:         runtime.Version(),
 					GoOS:              runtime.GOOS,
 					GoArch:            runtime.GOARCH,
 					GoRoot:            runtime.GOROOT(),
-					CGOEnabled:        "unknown",
+					CGOEnabled:        cgoUnknown,
 					NGTVersion:        "",
 					BuildCPUInfoFlags: []string{""},
 					StackTrace:        make([]StackTrace, 0, 10),
@@ -290,7 +290,7 @@ func TestInit(t *testing.T) {
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: "true",
+						CGOEnabled: cgoTrue,
 						NGTVersion: "v1.11.6",
 						BuildCPUInfoFlags: []string{
 							"avx512f", "avx512dq",
@@ -310,7 +310,7 @@ func TestInit(t *testing.T) {
 				GitCommit = "gitcommit"
 				Version = ""
 				BuildTime = "1s"
-				CGOEnabled = "true"
+				CGOEnabled = cgoTrue
 				NGTVersion = "v1.11.6"
 				BuildCPUInfoFlags = "\t\tavx512f avx512dq\t"
 			},
@@ -344,7 +344,7 @@ func TestInit(t *testing.T) {
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: "true",
+						CGOEnabled: cgoTrue,
 						NGTVersion: "v1.11.6",
 						BuildCPUInfoFlags: []string{
 							"avx512f", "avx512dq",
@@ -364,7 +364,7 @@ func TestInit(t *testing.T) {
 				GitCommit = "gitcommit"
 				Version = ""
 				BuildTime = "1s"
-				CGOEnabled = "true"
+				CGOEnabled = cgoTrue
 				NGTVersion = "v1.11.6"
 				BuildCPUInfoFlags = "\t\tavx512f avx512dq\t"
 			},
@@ -462,7 +462,7 @@ func TestNew(t *testing.T) {
 						GoOS:              runtime.GOOS,
 						GoArch:            runtime.GOARCH,
 						GoRoot:            runtime.GOROOT(),
-						CGOEnabled:        "unknown",
+						CGOEnabled:        cgoUnknown,
 						NGTVersion:        NGTVersion,
 						BuildCPUInfoFlags: strings.Split(strings.TrimSpace(BuildCPUInfoFlags), " "),
 						StackTrace:        nil,
@@ -495,7 +495,7 @@ func TestNew(t *testing.T) {
 						GoOS:              runtime.GOOS,
 						GoArch:            runtime.GOARCH,
 						GoRoot:            runtime.GOROOT(),
-						CGOEnabled:        "unknown",
+						CGOEnabled:        cgoUnknown,
 						NGTVersion:        NGTVersion,
 						BuildCPUInfoFlags: strings.Split(strings.TrimSpace(BuildCPUInfoFlags), " "),
 					},
@@ -531,7 +531,7 @@ func TestNew(t *testing.T) {
 						GoOS:              runtime.GOOS,
 						GoArch:            runtime.GOARCH,
 						GoRoot:            runtime.GOROOT(),
-						CGOEnabled:        "unknown",
+						CGOEnabled:        cgoUnknown,
 						NGTVersion:        NGTVersion,
 						BuildCPUInfoFlags: strings.Split(strings.TrimSpace(BuildCPUInfoFlags), " "),
 						StackTrace:        nil,
@@ -566,7 +566,7 @@ func TestNew(t *testing.T) {
 						GoOS:              runtime.GOOS,
 						GoArch:            runtime.GOARCH,
 						GoRoot:            runtime.GOROOT(),
-						CGOEnabled:        "unknown",
+						CGOEnabled:        cgoUnknown,
 						NGTVersion:        NGTVersion,
 						BuildCPUInfoFlags: strings.Split(strings.TrimSpace(BuildCPUInfoFlags), " "),
 						StackTrace:        nil,
@@ -665,7 +665,7 @@ func Test_info_String(t *testing.T) {
 					GoOS:              "goos",
 					GoArch:            "goarch",
 					GoRoot:            "/usr/local/go",
-					CGOEnabled:        "true",
+					CGOEnabled:        cgoTrue,
 					NGTVersion:        "1.2",
 					BuildCPUInfoFlags: nil,
 					StackTrace: []StackTrace{
@@ -688,7 +688,7 @@ func Test_info_String(t *testing.T) {
 					GoOS:              "goos",
 					GoArch:            "goarch",
 					GoRoot:            "/usr/local/go",
-					CGOEnabled:        "true",
+					CGOEnabled:        cgoTrue,
 					NGTVersion:        "1.2",
 					BuildCPUInfoFlags: nil,
 					StackTrace: []StackTrace{
@@ -714,7 +714,7 @@ func Test_info_String(t *testing.T) {
 					GoOS:              "goos",
 					GoArch:            "goarch",
 					GoRoot:            "/usr/local/go",
-					CGOEnabled:        "true",
+					CGOEnabled:        cgoTrue,
 					NGTVersion:        "1.2",
 					BuildCPUInfoFlags: nil,
 					StackTrace:        []StackTrace{},
@@ -733,7 +733,7 @@ func Test_info_String(t *testing.T) {
 					GoOS:              "goos",
 					GoArch:            "goarch",
 					GoRoot:            "/usr/local/go",
-					CGOEnabled:        "true",
+					CGOEnabled:        cgoTrue,
 					NGTVersion:        "1.2",
 					BuildCPUInfoFlags: nil,
 					StackTrace:        nil,
@@ -823,7 +823,7 @@ func TestDetail_String(t *testing.T) {
 				GoVersion:         "1.1",
 				GoOS:              "goos",
 				GoArch:            "goarch",
-				CGOEnabled:        "true",
+				CGOEnabled:        cgoTrue,
 				NGTVersion:        "1.2",
 				BuildCPUInfoFlags: nil,
 				StackTrace: []StackTrace{
@@ -844,7 +844,7 @@ func TestDetail_String(t *testing.T) {
 					GoVersion:         "1.1",
 					GoOS:              "goos",
 					GoArch:            "goarch",
-					CGOEnabled:        "true",
+					CGOEnabled:        cgoTrue,
 					NGTVersion:        "1.2",
 					BuildCPUInfoFlags: nil,
 					StackTrace: []StackTrace{
@@ -868,7 +868,7 @@ func TestDetail_String(t *testing.T) {
 				GoVersion:         "1.1",
 				GoOS:              "goos",
 				GoArch:            "goarch",
-				CGOEnabled:        "true",
+				CGOEnabled:        cgoTrue,
 				NGTVersion:        "1.2",
 				BuildCPUInfoFlags: nil,
 				StackTrace:        []StackTrace{},
@@ -882,7 +882,7 @@ func TestDetail_String(t *testing.T) {
 					GoVersion:         "1.1",
 					GoOS:              "goos",
 					GoArch:            "goarch",
-					CGOEnabled:        "true",
+					CGOEnabled:        cgoTrue,
 					NGTVersion:        "1.2",
 					BuildCPUInfoFlags: nil,
 					StackTrace:        nil,
@@ -962,12 +962,12 @@ func Test_info_Get(t *testing.T) {
 				want: Detail{
 					ServerName: "",
 					Version:    "",
-					GitCommit:  "main",
+					GitCommit:  GitCommit,
 					GoVersion:  runtime.Version(),
 					GoOS:       runtime.GOOS,
 					GoArch:     runtime.GOARCH,
 					GoRoot:     runtime.GOROOT(),
-					CGOEnabled: "unknown",
+					CGOEnabled: cgoUnknown,
 					StackTrace: []StackTrace{},
 					NGTVersion: NGTVersion,
 					BuildTime:  BuildTime,
@@ -1001,12 +1001,12 @@ func Test_info_Get(t *testing.T) {
 				want: Detail{
 					ServerName: "",
 					Version:    "",
-					GitCommit:  "main",
+					GitCommit:  GitCommit,
 					GoVersion:  runtime.Version(),
 					GoOS:       runtime.GOOS,
 					GoArch:     runtime.GOARCH,
 					GoRoot:     runtime.GOROOT(),
-					CGOEnabled: "unknown",
+					CGOEnabled: cgoUnknown,
 					StackTrace: []StackTrace{
 						{
 							URL:      "https://github.com/vdaas/vald/tree/main",
@@ -1047,12 +1047,12 @@ func Test_info_Get(t *testing.T) {
 				want: Detail{
 					ServerName: "",
 					Version:    "",
-					GitCommit:  "main",
+					GitCommit:  GitCommit,
 					GoVersion:  runtime.Version(),
 					GoOS:       runtime.GOOS,
 					GoArch:     runtime.GOARCH,
 					GoRoot:     runtime.GOROOT(),
-					CGOEnabled: "unknown",
+					CGOEnabled: cgoUnknown,
 					StackTrace: []StackTrace{
 						{
 							URL:      "https://github.com/golang/go/blob/" + runtime.Version() + "/src/info_test.go#L100",
@@ -1092,12 +1092,12 @@ func Test_info_Get(t *testing.T) {
 			want: want{
 				want: Detail{
 					Version:    "",
-					GitCommit:  "main",
+					GitCommit:  GitCommit,
 					GoVersion:  runtime.Version(),
 					GoOS:       runtime.GOOS,
 					GoArch:     runtime.GOARCH,
 					GoRoot:     runtime.GOROOT(),
-					CGOEnabled: "unknown",
+					CGOEnabled: cgoUnknown,
 					StackTrace: []StackTrace{
 						{
 							URL:      "https://github.com/vdaas/vald/internal/info_test.go#L100",
@@ -1137,12 +1137,12 @@ func Test_info_Get(t *testing.T) {
 			want: want{
 				want: Detail{
 					Version:    "",
-					GitCommit:  "main",
+					GitCommit:  GitCommit,
 					GoVersion:  runtime.Version(),
 					GoOS:       runtime.GOOS,
 					GoArch:     runtime.GOARCH,
 					GoRoot:     runtime.GOROOT(),
-					CGOEnabled: "unknown",
+					CGOEnabled: cgoUnknown,
 					StackTrace: []StackTrace{
 						{
 							URL:      "https://github.com/vdaas/blob/v0.0.0-20171023180738-a3a6125de932/vald/internal/info_test.go#L100",
@@ -1182,12 +1182,12 @@ func Test_info_Get(t *testing.T) {
 			want: want{
 				want: Detail{
 					Version:    "",
-					GitCommit:  "main",
+					GitCommit:  GitCommit,
 					GoVersion:  runtime.Version(),
 					GoOS:       runtime.GOOS,
 					GoArch:     runtime.GOARCH,
 					GoRoot:     runtime.GOROOT(),
-					CGOEnabled: "unknown",
+					CGOEnabled: cgoUnknown,
 					StackTrace: []StackTrace{
 						{
 							URL:      "https://github.com/vdaas/blob/main/vald/internal/info_test.go#L100",
@@ -1227,12 +1227,12 @@ func Test_info_Get(t *testing.T) {
 			want: want{
 				want: Detail{
 					Version:    "",
-					GitCommit:  "main",
+					GitCommit:  GitCommit,
 					GoVersion:  runtime.Version(),
 					GoOS:       runtime.GOOS,
 					GoArch:     runtime.GOARCH,
 					GoRoot:     runtime.GOROOT(),
-					CGOEnabled: "unknown",
+					CGOEnabled: cgoUnknown,
 					StackTrace: []StackTrace{
 						{
 							URL:      "https://github.com/vdaas/vald/blob/main/internal/info_test.go#L100",
@@ -1318,14 +1318,14 @@ func Test_info_prepare(t *testing.T) {
 				want: info{
 					baseURL: "https://github.com/vdaas/vald/tree/main",
 					detail: Detail{
-						GitCommit:  "main",
+						GitCommit:  GitCommit,
 						Version:    "",
 						BuildTime:  BuildTime,
 						GoVersion:  runtime.Version(),
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: "unknown",
+						CGOEnabled: cgoUnknown,
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1355,7 +1355,7 @@ func Test_info_prepare(t *testing.T) {
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: "unknown",
+						CGOEnabled: cgoUnknown,
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1378,14 +1378,14 @@ func Test_info_prepare(t *testing.T) {
 				want: info{
 					baseURL: "https://github.com/vdaas/vald/tree/main",
 					detail: Detail{
-						GitCommit:  "main",
+						GitCommit:  GitCommit,
 						Version:    "v1.0.0",
 						BuildTime:  BuildTime,
 						GoVersion:  runtime.Version(),
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: "unknown",
+						CGOEnabled: cgoUnknown,
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1408,14 +1408,14 @@ func Test_info_prepare(t *testing.T) {
 				want: info{
 					baseURL: "https://github.com/vdaas/vald/tree/main",
 					detail: Detail{
-						GitCommit:  "main",
+						GitCommit:  GitCommit,
 						Version:    "",
 						BuildTime:  "10s",
 						GoVersion:  runtime.Version(),
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: "unknown",
+						CGOEnabled: cgoUnknown,
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1438,14 +1438,14 @@ func Test_info_prepare(t *testing.T) {
 				want: info{
 					baseURL: "https://github.com/vdaas/vald/tree/main",
 					detail: Detail{
-						GitCommit:  "main",
+						GitCommit:  GitCommit,
 						Version:    "",
 						BuildTime:  BuildTime,
 						GoVersion:  "1.14",
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: "unknown",
+						CGOEnabled: cgoUnknown,
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1468,14 +1468,14 @@ func Test_info_prepare(t *testing.T) {
 				want: info{
 					baseURL: "https://github.com/vdaas/vald/tree/main",
 					detail: Detail{
-						GitCommit:  "main",
+						GitCommit:  GitCommit,
 						Version:    "",
 						BuildTime:  BuildTime,
 						GoVersion:  runtime.Version(),
 						GoOS:       "linux",
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: "unknown",
+						CGOEnabled: cgoUnknown,
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1498,14 +1498,14 @@ func Test_info_prepare(t *testing.T) {
 				want: info{
 					baseURL: "https://github.com/vdaas/vald/tree/main",
 					detail: Detail{
-						GitCommit:  "main",
+						GitCommit:  GitCommit,
 						Version:    "",
 						BuildTime:  BuildTime,
 						GoVersion:  runtime.Version(),
 						GoOS:       runtime.GOOS,
 						GoArch:     "amd",
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: "unknown",
+						CGOEnabled: cgoUnknown,
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1528,14 +1528,14 @@ func Test_info_prepare(t *testing.T) {
 				want: info{
 					baseURL: "https://github.com/vdaas/vald/tree/main",
 					detail: Detail{
-						GitCommit:  "main",
+						GitCommit:  GitCommit,
 						Version:    "",
 						BuildTime:  BuildTime,
 						GoVersion:  runtime.Version(),
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: "true",
+						CGOEnabled: cgoTrue,
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1558,14 +1558,14 @@ func Test_info_prepare(t *testing.T) {
 				want: info{
 					baseURL: "https://github.com/vdaas/vald/tree/main",
 					detail: Detail{
-						GitCommit:  "main",
+						GitCommit:  GitCommit,
 						Version:    "",
 						BuildTime:  BuildTime,
 						GoVersion:  runtime.Version(),
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: "false",
+						CGOEnabled: cgoFalse,
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1588,14 +1588,14 @@ func Test_info_prepare(t *testing.T) {
 				want: info{
 					baseURL: "https://github.com/vdaas/vald/tree/main",
 					detail: Detail{
-						GitCommit:  "main",
+						GitCommit:  GitCommit,
 						Version:    "",
 						BuildTime:  BuildTime,
 						GoVersion:  runtime.Version(),
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: "unknown",
+						CGOEnabled: cgoUnknown,
 						NGTVersion: "v1.11.5",
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1618,14 +1618,14 @@ func Test_info_prepare(t *testing.T) {
 				want: info{
 					baseURL: "https://github.com/vdaas/vald/tree/main",
 					detail: Detail{
-						GitCommit:         "main",
+						GitCommit:         GitCommit,
 						Version:           "",
 						BuildTime:         BuildTime,
 						GoVersion:         runtime.Version(),
 						GoOS:              runtime.GOOS,
 						GoArch:            runtime.GOARCH,
 						GoRoot:            runtime.GOROOT(),
-						CGOEnabled:        "unknown",
+						CGOEnabled:        cgoUnknown,
 						NGTVersion:        NGTVersion,
 						BuildCPUInfoFlags: []string{"avx512f"},
 					},

--- a/internal/info/info_test.go
+++ b/internal/info/info_test.go
@@ -75,7 +75,7 @@ func TestString(t *testing.T) {
 				infoProvider = nil
 			},
 			want: want{
-				want: "\nbuild cpu info flags ->\t[]\ngit commit           ->\tmain\ngo arch              ->\t" + runtime.GOARCH + "\ngo os                ->\t" + runtime.GOOS + "\ngo root              ->\t" + runtime.GOROOT() + "\ngo version           ->\t" + runtime.Version() + "\nvald version         ->\t\x1b[1mv0.0.1\x1b[22m",
+				want: "\nbuild cpu info flags ->\t[]\ncgo enabled          ->\tunknown\ngit commit           ->\tmain\ngo arch              ->\t" + runtime.GOARCH + "\ngo os                ->\t" + runtime.GOOS + "\ngo root              ->\t" + runtime.GOROOT() + "\ngo version           ->\t" + runtime.Version() + "\nvald version         ->\t\x1b[1mv0.0.1\x1b[22m",
 			},
 		},
 
@@ -95,7 +95,7 @@ func TestString(t *testing.T) {
 				infoProvider = nil
 			},
 			want: want{
-				want: "\nbuild cpu info flags ->\t[]\ngit commit           ->\tmain\ngo arch              ->\t" + runtime.GOARCH + "\ngo os                ->\t" + runtime.GOOS + "\ngo root              ->\t" + runtime.GOROOT() + "\ngo version           ->\t" + runtime.Version() + "\nvald version         ->\t\x1b[1m\x1b[22m",
+				want: "\nbuild cpu info flags ->\t[]\ncgo enabled          ->\tunknown\ngit commit           ->\tmain\ngo arch              ->\t" + runtime.GOARCH + "\ngo os                ->\t" + runtime.GOOS + "\ngo root              ->\t" + runtime.GOROOT() + "\ngo version           ->\t" + runtime.Version() + "\nvald version         ->\t\x1b[1m\x1b[22m",
 			},
 		},
 	}
@@ -163,7 +163,7 @@ func TestGet(t *testing.T) {
 					GoOS:              runtime.GOOS,
 					GoArch:            runtime.GOARCH,
 					GoRoot:            runtime.GOROOT(),
-					CGOEnabled:        "",
+					CGOEnabled:        "unknown",
 					NGTVersion:        "",
 					BuildCPUInfoFlags: []string{""},
 					StackTrace:        make([]StackTrace, 0, 10),
@@ -426,7 +426,7 @@ func TestNew(t *testing.T) {
 						GoOS:              runtime.GOOS,
 						GoArch:            runtime.GOARCH,
 						GoRoot:            runtime.GOROOT(),
-						CGOEnabled:        CGOEnabled,
+						CGOEnabled:        "unknown",
 						NGTVersion:        NGTVersion,
 						BuildCPUInfoFlags: strings.Split(strings.TrimSpace(BuildCPUInfoFlags), " "),
 						StackTrace:        nil,
@@ -459,7 +459,7 @@ func TestNew(t *testing.T) {
 						GoOS:              runtime.GOOS,
 						GoArch:            runtime.GOARCH,
 						GoRoot:            runtime.GOROOT(),
-						CGOEnabled:        CGOEnabled,
+						CGOEnabled:        "unknown",
 						NGTVersion:        NGTVersion,
 						BuildCPUInfoFlags: strings.Split(strings.TrimSpace(BuildCPUInfoFlags), " "),
 					},
@@ -495,7 +495,7 @@ func TestNew(t *testing.T) {
 						GoOS:              runtime.GOOS,
 						GoArch:            runtime.GOARCH,
 						GoRoot:            runtime.GOROOT(),
-						CGOEnabled:        CGOEnabled,
+						CGOEnabled:        "unknown",
 						NGTVersion:        NGTVersion,
 						BuildCPUInfoFlags: strings.Split(strings.TrimSpace(BuildCPUInfoFlags), " "),
 						StackTrace:        nil,
@@ -530,7 +530,7 @@ func TestNew(t *testing.T) {
 						GoOS:              runtime.GOOS,
 						GoArch:            runtime.GOARCH,
 						GoRoot:            runtime.GOROOT(),
-						CGOEnabled:        CGOEnabled,
+						CGOEnabled:        "unknown",
 						NGTVersion:        NGTVersion,
 						BuildCPUInfoFlags: strings.Split(strings.TrimSpace(BuildCPUInfoFlags), " "),
 						StackTrace:        nil,
@@ -845,7 +845,7 @@ func Test_info_Get(t *testing.T) {
 					GoOS:       runtime.GOOS,
 					GoArch:     runtime.GOARCH,
 					GoRoot:     runtime.GOROOT(),
-					CGOEnabled: CGOEnabled,
+					CGOEnabled: "unknown",
 					StackTrace: []StackTrace{},
 					NGTVersion: NGTVersion,
 					BuildTime:  BuildTime,
@@ -884,7 +884,7 @@ func Test_info_Get(t *testing.T) {
 					GoOS:       runtime.GOOS,
 					GoArch:     runtime.GOARCH,
 					GoRoot:     runtime.GOROOT(),
-					CGOEnabled: CGOEnabled,
+					CGOEnabled: "unknown",
 					StackTrace: []StackTrace{
 						{
 							URL:      "https://github.com/vdaas/vald/tree/main",
@@ -930,7 +930,7 @@ func Test_info_Get(t *testing.T) {
 					GoOS:       runtime.GOOS,
 					GoArch:     runtime.GOARCH,
 					GoRoot:     runtime.GOROOT(),
-					CGOEnabled: CGOEnabled,
+					CGOEnabled: "unknown",
 					StackTrace: []StackTrace{
 						{
 							URL:      "https://github.com/golang/go/blob/" + runtime.Version() + "/src/info_test.go#L100",
@@ -975,7 +975,7 @@ func Test_info_Get(t *testing.T) {
 					GoOS:       runtime.GOOS,
 					GoArch:     runtime.GOARCH,
 					GoRoot:     runtime.GOROOT(),
-					CGOEnabled: CGOEnabled,
+					CGOEnabled: "unknown",
 					StackTrace: []StackTrace{
 						{
 							URL:      "https://github.com/vdaas/vald/internal/info_test.go#L100",
@@ -1020,7 +1020,7 @@ func Test_info_Get(t *testing.T) {
 					GoOS:       runtime.GOOS,
 					GoArch:     runtime.GOARCH,
 					GoRoot:     runtime.GOROOT(),
-					CGOEnabled: CGOEnabled,
+					CGOEnabled: "unknown",
 					StackTrace: []StackTrace{
 						{
 							URL:      "https://github.com/vdaas/blob/v0.0.0-20171023180738-a3a6125de932/vald/internal/info_test.go#L100",
@@ -1065,7 +1065,7 @@ func Test_info_Get(t *testing.T) {
 					GoOS:       runtime.GOOS,
 					GoArch:     runtime.GOARCH,
 					GoRoot:     runtime.GOROOT(),
-					CGOEnabled: CGOEnabled,
+					CGOEnabled: "unknown",
 					StackTrace: []StackTrace{
 						{
 							URL:      "https://github.com/vdaas/blob/main/vald/internal/info_test.go#L100",
@@ -1110,7 +1110,7 @@ func Test_info_Get(t *testing.T) {
 					GoOS:       runtime.GOOS,
 					GoArch:     runtime.GOARCH,
 					GoRoot:     runtime.GOROOT(),
-					CGOEnabled: CGOEnabled,
+					CGOEnabled: "unknown",
 					StackTrace: []StackTrace{
 						{
 							URL:      "https://github.com/vdaas/vald/blob/main/internal/info_test.go#L100",
@@ -1203,7 +1203,7 @@ func Test_info_prepare(t *testing.T) {
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: CGOEnabled,
+						CGOEnabled: "unknown",
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1233,7 +1233,7 @@ func Test_info_prepare(t *testing.T) {
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: CGOEnabled,
+						CGOEnabled: "unknown",
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1263,7 +1263,7 @@ func Test_info_prepare(t *testing.T) {
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: CGOEnabled,
+						CGOEnabled: "unknown",
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1293,7 +1293,7 @@ func Test_info_prepare(t *testing.T) {
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: CGOEnabled,
+						CGOEnabled: "unknown",
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1323,7 +1323,7 @@ func Test_info_prepare(t *testing.T) {
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: CGOEnabled,
+						CGOEnabled: "unknown",
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1353,7 +1353,7 @@ func Test_info_prepare(t *testing.T) {
 						GoOS:       "linux",
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: CGOEnabled,
+						CGOEnabled: "unknown",
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1383,7 +1383,7 @@ func Test_info_prepare(t *testing.T) {
 						GoOS:       runtime.GOOS,
 						GoArch:     "amd",
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: CGOEnabled,
+						CGOEnabled: "unknown",
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1396,7 +1396,7 @@ func Test_info_prepare(t *testing.T) {
 			},
 		},
 		{
-			name: "set success with CGOEnabled set",
+			name: "set success with CGOEnabled set as true",
 			fields: fields{
 				detail: Detail{
 					CGOEnabled: "1",
@@ -1413,7 +1413,37 @@ func Test_info_prepare(t *testing.T) {
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: "1",
+						CGOEnabled: "true",
+						NGTVersion: NGTVersion,
+						BuildCPUInfoFlags: func() []string {
+							if len(BuildCPUInfoFlags) == 0 {
+								return nil
+							}
+							return strings.Split(strings.TrimSpace(BuildCPUInfoFlags), " ")
+						}(),
+					},
+				},
+			},
+		},
+		{
+			name: "set success with CGOEnabled set as false",
+			fields: fields{
+				detail: Detail{
+					CGOEnabled: "0",
+				},
+			},
+			want: want{
+				want: info{
+					baseURL: "https://github.com/vdaas/vald/tree/main",
+					detail: Detail{
+						GitCommit:  "main",
+						Version:    "",
+						BuildTime:  BuildTime,
+						GoVersion:  runtime.Version(),
+						GoOS:       runtime.GOOS,
+						GoArch:     runtime.GOARCH,
+						GoRoot:     runtime.GOROOT(),
+						CGOEnabled: "false",
 						NGTVersion: NGTVersion,
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1443,7 +1473,7 @@ func Test_info_prepare(t *testing.T) {
 						GoOS:       runtime.GOOS,
 						GoArch:     runtime.GOARCH,
 						GoRoot:     runtime.GOROOT(),
-						CGOEnabled: CGOEnabled,
+						CGOEnabled: "unknown",
 						NGTVersion: "v1.11.5",
 						BuildCPUInfoFlags: func() []string {
 							if len(BuildCPUInfoFlags) == 0 {
@@ -1473,7 +1503,7 @@ func Test_info_prepare(t *testing.T) {
 						GoOS:              runtime.GOOS,
 						GoArch:            runtime.GOARCH,
 						GoRoot:            runtime.GOROOT(),
-						CGOEnabled:        CGOEnabled,
+						CGOEnabled:        "unknown",
 						NGTVersion:        NGTVersion,
 						BuildCPUInfoFlags: []string{"avx512f"},
 					},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->
I have updated the `internal/info` test cuz `internal/info` has been updated by #2002

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.3
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.9

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
