### PR TITLE
Fix CI chatops format workflow

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -471,16 +471,9 @@ jobs:
 
           git checkout ${HEAD_BRANCH}
 
-          echo "Install format dependencies"
-
-          make golines/install gofumpt/install goimports/install strictgoimports/install
-          sudo make prettier/install
-
           echo "Update license headers and format go codes/yaml"
 
-          make format/go
-          make format/yaml
-          make license
+          sudo make format/go
 
           git checkout go.mod go.sum
 

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -473,7 +473,7 @@ jobs:
 
           echo "Update license headers and format go codes/yaml"
 
-          sudo make format/go
+          sudo make format
 
           git checkout go.mod go.sum
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
I have fixed the format (chatops) workflow.
`make license` should be run before `make format/go` to format all files, but the current workflow runs `make license` after `make format/go`.
So, I have fixed this issue in this PR.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.3
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.9

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
