### PR TITLE
Chatops command /format output message if nothing updated

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -455,6 +455,7 @@ jobs:
         with:
           go-version: ${{ steps.golang_version.outputs.version }}
       - name: update and push
+        id: format_push
         if: steps.check_comments_format.outputs.BOOL_TRIGGERED == 'true' && steps.check_permissions.outputs.EXECUTABLE == 'true'
         run: |
           export PATH=$(go env GOPATH)/bin:$PATH
@@ -478,8 +479,10 @@ jobs:
           git checkout go.mod go.sum
 
           if git diff --quiet --exit-code; then
+            echo "UPDATED=false" >> $GITHUB_OUTPUT
             echo "Nothing updated"
           else
+            echo "UPDATED=true" >> $GITHUB_OUTPUT
             git add .
             git commit -S --signoff -m ":robot: Update license headers / Format go codes and yaml files"
 
@@ -492,6 +495,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
           PR_INFO_URL: ${{ github.event.issue.pull_request.url }}
           PR_NUM: ${{ github.event.issue.number }}
+      - name: no changes
+        if: steps.check_comments_format.outputs.BOOL_TRIGGERED == 'true' && steps.check_permissions.outputs.EXECUTABLE == 'true' && steps.format_push.outputs.UPDATED == 'false'
+        run: |
+          curl --include --verbose --fail \
+          -H "Accept: application/json" \
+          -H "Content-Type:application/json" \
+          -H "Authorization: token ${GITHUB_TOKEN}" \
+          --request POST \
+          --data "{\"body\": \"**[FORMAT]** Nothing to format.\"}" \
+          $API_URL
+        env:
+          GITHUB_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          API_URL: ${{ github.event.issue.comments_url }}
       - name: failure comment
         if: failure()
         run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR update the ChatOps `/format` command to output `**[FORMAT]** Nothing to format.` message if nothing is updated, to let user know the command is finished with success.
<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.3
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.9

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

We cannot test this changes on PR unless we merged this PR. (Github action always use main branch to trigger CI)
<!-- Please tell us anything you would like to share to reviewers related this PR -->
