### PR TITLE
Change E2E actions to use local charts on PR

### DIFF
--- a/.github/actions/e2e-deploy-vald-helm-operator/action.yaml
+++ b/.github/actions/e2e-deploy-vald-helm-operator/action.yaml
@@ -36,6 +36,10 @@ inputs:
     description: "timeout used for waiting for pods"
     required: false
     default: "600s"
+  use_local_charts:
+    description: "If you want to use local charts, set this to true."
+    required: false
+    default: "false"
 outputs:
   POD_NAME:
     description: "a pod name that waited for"
@@ -76,14 +80,22 @@ runs:
         fi
       env:
         REQUIRE_MINIO: ${{ inputs.require_minio }}
-    - name: deploy vald helm operator
+    - name: deploy vald helm operator from remote charts
       shell: bash
-      id: deploy_vald_helm_operator
+      id: deploy_vald_helm_operator_remote
+      if: ${{ inputs.use_local_charts == 'false' }}
       run: |
         helm install vald-helm-operator \
           --set image.tag=nightly \
           charts/vald-helm-operator/.
 
+        sleep 3
+    - name: deploy vald helm operator from local charts
+      shell: bash
+      id: deploy_vald_helm_operator_local
+      if: ${{ inputs.use_local_charts == 'true' }}
+      run: |
+        make k8s/vald-helm-operator/deploy
         sleep 3
     - name: deploy vald
       shell: bash

--- a/.github/actions/e2e-deploy-vald/action.yaml
+++ b/.github/actions/e2e-deploy-vald/action.yaml
@@ -40,6 +40,10 @@ inputs:
     description: "timeout used for waiting for pods"
     required: false
     default: "600s"
+  use_local_charts:
+    description: "If you want to use local charts, set this to true."
+    required: false
+    default: "false"
 outputs:
   POD_NAME:
     description: "a pod name that waited for"
@@ -80,9 +84,10 @@ runs:
         fi
       env:
         REQUIRE_MINIO: ${{ inputs.require_minio }}
-    - name: deploy vald
+    - name: deploy vald from remote charts
       shell: bash
-      id: deploy_vald
+      id: deploy_vald_remote
+      if: ${{ inputs.use_local_charts == 'false' }}
       run: |
         helm install \
           --values ${VALUES} \
@@ -101,5 +106,27 @@ runs:
       env:
         VALUES: ${{ inputs.values }}
         HELM_EXTRA_OPTIONS: ${{ inputs.helm_extra_options }}
+        WAIT_FOR_SELECTOR: ${{ inputs.wait_for_selector }}
+        WAIT_FOR_TIMEOUT: ${{ inputs.wait_for_timeout }}
+    - name: deploy vald from local charts
+      shell: bash
+      id: deploy_vald_local
+      if: ${{ inputs.use_local_charts == 'true' }}
+      run: |
+        make k8s/vald/deploy HELM_VALUES=${VALUES}
+
+        sleep 3
+
+        kubectl wait --for=condition=ready pod -l ${WAIT_FOR_SELECTOR} --timeout=${WAIT_FOR_TIMEOUT}
+        
+        kubectl get pods
+
+        podname=`kubectl get pods --selector=${WAIT_FOR_SELECTOR} | tail -1 | awk '{print $1}'`
+        echo "POD_NAME=${podname}" >> $GITHUB_OUTPUT
+      env:
+        VALUES: ${{ inputs.values }}
+        # TODO: currently, we can't pass helm options to the make command.
+        #       Is it really necessary in the first place?
+        # HELM_EXTRA_OPTIONS: ${{ inputs.helm_extra_options }}
         WAIT_FOR_SELECTOR: ${{ inputs.wait_for_selector }}
         WAIT_FOR_TIMEOUT: ${{ inputs.wait_for_timeout }}

--- a/.github/actions/e2e-deploy-vald/action.yaml
+++ b/.github/actions/e2e-deploy-vald/action.yaml
@@ -118,7 +118,7 @@ runs:
         sleep 3
 
         kubectl wait --for=condition=ready pod -l ${WAIT_FOR_SELECTOR} --timeout=${WAIT_FOR_TIMEOUT}
-        
+
         kubectl get pods
 
         podname=`kubectl get pods --selector=${WAIT_FOR_SELECTOR} | tail -1 | awk '{print $1}'`

--- a/.github/workflows/e2e-chaos.yaml
+++ b/.github/workflows/e2e-chaos.yaml
@@ -26,6 +26,16 @@ on:
       - "labeled"
 
 jobs:
+  setup-workflow-envs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup use_local_charts
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "use_local_charts=true" >> $GITHUB_OUTPUT
+          else
+            echo "use_local_charts=false" >> $GITHUB_OUTPUT
+          fi
   dump_contexts_to_log:
     runs-on: ubuntu-latest
     steps:
@@ -57,6 +67,7 @@ jobs:
   agent-failure:
     name: "E2E chaos test (Agent failure: to test insert/search works even if one of the agents is failing)"
     runs-on: ubuntu-latest
+    needs: setup-workflow-envs
     timeout-minutes: 60
     if: startsWith( github.ref, 'refs/tags/') || github.event.action == 'labeled' && github.event.label.name == 'actions/e2e-chaos'
     steps:
@@ -108,6 +119,7 @@ jobs:
           helm_extra_options: ${{ steps.specify_container_versions.outputs.HELM_EXTRA_OPTIONS }}
           values: .github/helm/values/values-chaos.yaml
           wait_for_selector: app=vald-lb-gateway
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}}
       - name: deploy Chaos Mesh
         run: |
           make kubectl/install/linux/v1.23.6
@@ -151,6 +163,7 @@ jobs:
   random-pod-failure:
     name: "E2E chaos test (random Pod failure: to test redundancy)"
     runs-on: ubuntu-latest
+    needs: setup-workflow-envs
     timeout-minutes: 60
     if: startsWith( github.ref, 'refs/tags/') || github.event.action == 'labeled' && github.event.label.name == 'actions/e2e-chaos'
     steps:
@@ -202,6 +215,7 @@ jobs:
           helm_extra_options: ${{ steps.specify_container_versions.outputs.HELM_EXTRA_OPTIONS }}
           values: .github/helm/values/values-chaos.yaml
           wait_for_selector: app=vald-lb-gateway
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}}
       - name: deploy Chaos Mesh
         run: |
           make kubectl/install/linux/v1.23.6
@@ -245,6 +259,7 @@ jobs:
   agent-network-partition:
     name: "E2E chaos test (agent network partition: to test retries)"
     runs-on: ubuntu-latest
+    needs: setup-workflow-envs
     timeout-minutes: 60
     if: startsWith( github.ref, 'refs/tags/') || github.event.action == 'labeled' && github.event.label.name == 'actions/e2e-chaos'
     steps:
@@ -296,6 +311,7 @@ jobs:
           helm_extra_options: ${{ steps.specify_container_versions.outputs.HELM_EXTRA_OPTIONS }}
           values: .github/helm/values/values-chaos.yaml
           wait_for_selector: app=vald-lb-gateway
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}}
       - name: deploy Chaos Mesh
         run: |
           make kubectl/install/linux/v1.23.6
@@ -339,6 +355,7 @@ jobs:
   clusterwide-network-bandwidth:
     name: "E2E chaos test (network bandwidth: to test it works properly under bandwidth limitation)"
     runs-on: ubuntu-latest
+    needs: setup-workflow-envs
     timeout-minutes: 60
     if: startsWith( github.ref, 'refs/tags/') || github.event.action == 'labeled' && github.event.label.name == 'actions/e2e-chaos'
     steps:
@@ -390,6 +407,7 @@ jobs:
           helm_extra_options: ${{ steps.specify_container_versions.outputs.HELM_EXTRA_OPTIONS }}
           values: .github/helm/values/values-lb.yaml
           wait_for_selector: app=vald-lb-gateway
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}}
       - name: deploy Chaos Mesh
         run: |
           make kubectl/install/linux/v1.23.6

--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -24,8 +24,17 @@ on:
   pull_request:
     types:
       - "labeled"
-
 jobs:
+  setup-workflow-envs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup use_local_charts
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "use_local_charts=true" >> $GITHUB_OUTPUT
+          else
+            echo "use_local_charts=false" >> $GITHUB_OUTPUT
+          fi
   dump_contexts_to_log:
     runs-on: ubuntu-latest
     steps:
@@ -57,6 +66,7 @@ jobs:
   e2e-stream-crud:
     name: "E2E test (Stream CRUD)"
     runs-on: ubuntu-latest
+    needs: setup-workflow-envs
     timeout-minutes: 60
     if: startsWith( github.ref, 'refs/tags/') || github.event.action == 'labeled' && github.event.label.name == 'actions/e2e-deploy'
     steps:
@@ -107,6 +117,7 @@ jobs:
           helm_extra_options: ${{ steps.specify_container_versions.outputs.HELM_EXTRA_OPTIONS }}
           values: .github/helm/values/values-lb.yaml
           wait_for_selector: app=vald-lb-gateway
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}
       - name: Fetch golang version
         run: |
           GO_VERSION=`make version/go`
@@ -252,6 +263,7 @@ jobs:
   e2e-stream-crud-skip-exist-check:
     name: "E2E test (Stream CRUD: skip strict exist check)"
     runs-on: ubuntu-latest
+    needs: setup-workflow-envs
     timeout-minutes: 60
     if: startsWith( github.ref, 'refs/tags/') || github.event.action == 'labeled' && github.event.label.name == 'actions/e2e-deploy'
     steps:
@@ -302,6 +314,7 @@ jobs:
           helm_extra_options: ${{ steps.specify_container_versions.outputs.HELM_EXTRA_OPTIONS }}
           values: .github/helm/values/values-lb.yaml
           wait_for_selector: app=vald-lb-gateway
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}
       - name: Fetch golang version
         run: |
           GO_VERSION=`make version/go`
@@ -339,6 +352,7 @@ jobs:
   e2e-multiapis-crud:
     name: "E2E test (Multi-APIs CRUD)"
     runs-on: ubuntu-latest
+    needs: setup-workflow-envs
     timeout-minutes: 60
     if: startsWith( github.ref, 'refs/tags/') || github.event.action == 'labeled' && github.event.label.name == 'actions/e2e-deploy'
     steps:
@@ -389,6 +403,7 @@ jobs:
           helm_extra_options: ${{ steps.specify_container_versions.outputs.HELM_EXTRA_OPTIONS }}
           values: .github/helm/values/values-lb.yaml
           wait_for_selector: app=vald-lb-gateway
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}
       - name: Fetch golang version
         run: |
           GO_VERSION=`make version/go`
@@ -423,6 +438,7 @@ jobs:
   e2e-agent-and-sidecar:
     name: "E2E Agent & Sidecar test"
     runs-on: ubuntu-latest
+    needs: setup-workflow-envs
     timeout-minutes: 60
     if: startsWith( github.ref, 'refs/tags/') || github.event.action == 'labeled' && github.event.label.name == 'actions/e2e-deploy'
     steps:
@@ -482,6 +498,7 @@ jobs:
           values: .github/helm/values/values-agent-sidecar.yaml
           wait_for_selector: app=vald-agent-ngt
           wait_for_timeout: 29m
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}
       - name: Fetch golang version
         run: |
           GO_VERSION=`make version/go`

--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -159,6 +159,7 @@ jobs:
   e2e-stream-crud-for-operator:
     name: "E2E test (Stream CRUD) for operator"
     runs-on: ubuntu-latest
+    needs: setup-workflow-envs
     timeout-minutes: 60
     if: startsWith( github.ref, 'refs/tags/') || github.event.action == 'labeled' && github.event.label.name == 'actions/e2e-deploy'
     steps:
@@ -221,6 +222,7 @@ jobs:
           require_libhdf5: "true"
           valdrelease: ./.github/valdrelease/valdrelease.yaml
           wait_for_selector: app=vald-lb-gateway
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}
       - name: Fetch golang version
         run: |
           GO_VERSION=`make version/go`

--- a/.github/workflows/e2e-max-dim.yml
+++ b/.github/workflows/e2e-max-dim.yml
@@ -26,6 +26,16 @@ on:
       - "labeled"
 
 jobs:
+  setup-workflow-envs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup use_local_charts
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "use_local_charts=true" >> $GITHUB_OUTPUT
+          else
+            echo "use_local_charts=false" >> $GITHUB_OUTPUT
+          fi
   dump_contexts_to_log:
     runs-on: ubuntu-latest
     steps:
@@ -57,6 +67,7 @@ jobs:
   e2e-max-dimension-insert:
     name: "E2E test (Max Dimension Insert: skip strict exist check)"
     runs-on: ubuntu-latest
+    needs: setup-workflow-envs
     timeout-minutes: 60
     if: startsWith( github.ref, 'refs/tags/') || github.event.action == 'labeled' && github.event.label.name == 'actions/e2e-max-dim'
     steps:
@@ -106,6 +117,7 @@ jobs:
           helm_extra_options: ${{ steps.specify_container_versions.outputs.HELM_EXTRA_OPTIONS }}
           values: .github/helm/values/values-max-dim.yaml
           wait_for_selector: app=vald-lb-gateway
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}
       - name: Fetch golang version
         run: |
           GO_VERSION=`make version/go`

--- a/.github/workflows/e2e-profiling.yml
+++ b/.github/workflows/e2e-profiling.yml
@@ -26,6 +26,16 @@ on:
       - "labeled"
 
 jobs:
+  setup-workflow-envs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup use_local_charts
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "use_local_charts=true" >> $GITHUB_OUTPUT
+          else
+            echo "use_local_charts=false" >> $GITHUB_OUTPUT
+          fi
   dump_contexts_to_log:
     runs-on: ubuntu-latest
     steps:
@@ -57,6 +67,7 @@ jobs:
   e2e-profiling:
     name: "E2E profiling"
     runs-on: ubuntu-latest
+    needs: setup-workflow-envs
     timeout-minutes: 60
     if: startsWith( github.ref, 'refs/tags/') || github.event.action == 'labeled' && github.event.label.name == 'actions/e2e-profiling'
     steps:
@@ -107,6 +118,7 @@ jobs:
           helm_extra_options: ${{ steps.specify_container_versions.outputs.HELM_EXTRA_OPTIONS }}
           values: .github/helm/values/values-profile.yaml
           wait_for_selector: app=vald-lb-gateway
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}
       - name: deploy profefe
         run: |
           make k8s/metrics/profefe/deploy

--- a/Makefile.d/k8s.mk
+++ b/Makefile.d/k8s.mk
@@ -71,7 +71,6 @@ k8s/vald/deploy:
 	    --set manager.index.image.repository=$(CRORG)/$(MANAGER_INDEX_IMAGE) \
 	    --output-dir $(TEMP_DIR) \
 	    charts/vald
-	@echo "Permitting error because there's nothing to apply when network policy is disabled"
 	kubectl apply -f $(TEMP_DIR)/vald/templates/manager/index
 	kubectl apply -f $(TEMP_DIR)/vald/templates/agent
 	kubectl apply -f $(TEMP_DIR)/vald/templates/discoverer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
To test helm templates changes, this PR changes E2E actions to use local charts on PR triggers.

This needs to be tested on `main` branch.

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.3
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.9

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
