### PR TITLE
Fix E2E actions on PR

### DIFF
--- a/.github/actions/e2e-deploy-vald/action.yaml
+++ b/.github/actions/e2e-deploy-vald/action.yaml
@@ -47,7 +47,7 @@ inputs:
 outputs:
   POD_NAME:
     description: "a pod name that waited for"
-    value: ${{ steps.deploy_vald.outputs.POD_NAME }}
+    value: ${{ steps.get_real_pod_name.outputs.POD_NAME }}
 runs:
   using: "composite"
   steps:
@@ -130,3 +130,16 @@ runs:
         # HELM_EXTRA_OPTIONS: ${{ inputs.helm_extra_options }}
         WAIT_FOR_SELECTOR: ${{ inputs.wait_for_selector }}
         WAIT_FOR_TIMEOUT: ${{ inputs.wait_for_timeout }}
+    - name: get real pod name
+      shell: bash
+      id: get_real_pod_name
+      env:
+        PODNAME_LOCAL_DEPLOY: ${{ steps.deploy_vald_local.outputs.POD_NAME }}
+        PODNAME_REMOTE_DEPLOY: ${{ steps.deploy_vald_remote.outputs.POD_NAME }}
+      # Set GITHUB_OUTPUT to the not empty one, PODNAME_LOCAL_DEPLOY or PODNAME_REMOTE_DEPLOY
+      run: |
+        if [[ -n "${PODNAME_LOCAL_DEPLOY}" ]]; then
+          echo "POD_NAME=${PODNAME_LOCAL_DEPLOY}" >> $GITHUB_OUTPUT
+        else
+          echo "POD_NAME=${PODNAME_REMOTE_DEPLOY}" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/e2e-chaos.yaml
+++ b/.github/workflows/e2e-chaos.yaml
@@ -119,7 +119,7 @@ jobs:
           helm_extra_options: ${{ steps.specify_container_versions.outputs.HELM_EXTRA_OPTIONS }}
           values: .github/helm/values/values-chaos.yaml
           wait_for_selector: app=vald-lb-gateway
-          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}}
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}
       - name: deploy Chaos Mesh
         run: |
           make kubectl/install/linux/v1.23.6
@@ -215,7 +215,7 @@ jobs:
           helm_extra_options: ${{ steps.specify_container_versions.outputs.HELM_EXTRA_OPTIONS }}
           values: .github/helm/values/values-chaos.yaml
           wait_for_selector: app=vald-lb-gateway
-          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}}
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}
       - name: deploy Chaos Mesh
         run: |
           make kubectl/install/linux/v1.23.6
@@ -311,7 +311,7 @@ jobs:
           helm_extra_options: ${{ steps.specify_container_versions.outputs.HELM_EXTRA_OPTIONS }}
           values: .github/helm/values/values-chaos.yaml
           wait_for_selector: app=vald-lb-gateway
-          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}}
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}
       - name: deploy Chaos Mesh
         run: |
           make kubectl/install/linux/v1.23.6
@@ -407,7 +407,7 @@ jobs:
           helm_extra_options: ${{ steps.specify_container_versions.outputs.HELM_EXTRA_OPTIONS }}
           values: .github/helm/values/values-lb.yaml
           wait_for_selector: app=vald-lb-gateway
-          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}}
+          use_local_charts: ${{ needs.setup-workflow-envs.outputs.use_local_charts }}
       - name: deploy Chaos Mesh
         run: |
           make kubectl/install/linux/v1.23.6

--- a/.github/workflows/e2e-chaos.yaml
+++ b/.github/workflows/e2e-chaos.yaml
@@ -114,10 +114,6 @@ jobs:
       - name: Helm version
         run: |
           helm version
-      # DEBUG:
-      - name: Debug print use_local_charts
-        run: |
-          echo "use_local_charts=${{ needs.setup-workflow-envs.outputs.use_local_charts }}"
       - name: deploy Vald
         id: deploy_vald
         uses: ./.github/actions/e2e-deploy-vald

--- a/.github/workflows/e2e-chaos.yaml
+++ b/.github/workflows/e2e-chaos.yaml
@@ -28,8 +28,11 @@ on:
 jobs:
   setup-workflow-envs:
     runs-on: ubuntu-latest
+    outputs:
+      use_local_charts: ${{ steps.check_if_pr.outputs.use_local_charts }}
     steps:
       - name: Setup use_local_charts
+        id: check_if_pr
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             echo "use_local_charts=true" >> $GITHUB_OUTPUT
@@ -111,6 +114,10 @@ jobs:
       - name: Helm version
         run: |
           helm version
+      # DEBUG:
+      - name: Debug print use_local_charts
+        run: |
+          echo "use_local_charts=${{ needs.setup-workflow-envs.outputs.use_local_charts }}"
       - name: deploy Vald
         id: deploy_vald
         uses: ./.github/actions/e2e-deploy-vald

--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -27,8 +27,11 @@ on:
 jobs:
   setup-workflow-envs:
     runs-on: ubuntu-latest
+    outputs:
+      use_local_charts: ${{ steps.check_if_pr.outputs.use_local_charts }}
     steps:
       - name: Setup use_local_charts
+        id: check_if_pr
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             echo "use_local_charts=true" >> $GITHUB_OUTPUT
@@ -215,6 +218,10 @@ jobs:
             TAG="\"${ARR[1]}\""
             yq e ".spec.$FIELD=$TAG" -i ./.github/valdrelease/valdrelease.yaml
           done
+      # DEBUG:
+      - name: Debug print use_local_charts
+        run: |
+          echo "use_local_charts=${{ needs.setup-workflow-envs.outputs.use_local_charts }}"
       - name: deploy Vald
         id: deploy_vald
         uses: ./.github/actions/e2e-deploy-vald-helm-operator

--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -218,10 +218,6 @@ jobs:
             TAG="\"${ARR[1]}\""
             yq e ".spec.$FIELD=$TAG" -i ./.github/valdrelease/valdrelease.yaml
           done
-      # DEBUG:
-      - name: Debug print use_local_charts
-        run: |
-          echo "use_local_charts=${{ needs.setup-workflow-envs.outputs.use_local_charts }}"
       - name: deploy Vald
         id: deploy_vald
         uses: ./.github/actions/e2e-deploy-vald-helm-operator

--- a/.github/workflows/e2e-max-dim.yml
+++ b/.github/workflows/e2e-max-dim.yml
@@ -28,8 +28,11 @@ on:
 jobs:
   setup-workflow-envs:
     runs-on: ubuntu-latest
+    outputs:
+      use_local_charts: ${{ steps.check_if_pr.outputs.use_local_charts }}
     steps:
       - name: Setup use_local_charts
+        id: check_if_pr
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             echo "use_local_charts=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/e2e-profiling.yml
+++ b/.github/workflows/e2e-profiling.yml
@@ -28,8 +28,11 @@ on:
 jobs:
   setup-workflow-envs:
     runs-on: ubuntu-latest
+    outputs:
+      use_local_charts: ${{ steps.check_if_pr.outputs.use_local_charts }}
     steps:
       - name: Setup use_local_charts
+        id: check_if_pr
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             echo "use_local_charts=true" >> $GITHUB_OUTPUT

--- a/Makefile.d/k8s.mk
+++ b/Makefile.d/k8s.mk
@@ -71,7 +71,8 @@ k8s/vald/deploy:
 	    --set manager.index.image.repository=$(CRORG)/$(MANAGER_INDEX_IMAGE) \
 	    --output-dir $(TEMP_DIR) \
 	    charts/vald
-	kubectl apply -f $(TEMP_DIR)/vald/templates/manager/index
+	@echo "Permitting error because there's some cases nothing to apply"
+	kubectl apply -f $(TEMP_DIR)/vald/templates/manager/index || true
 	kubectl apply -f $(TEMP_DIR)/vald/templates/agent
 	kubectl apply -f $(TEMP_DIR)/vald/templates/discoverer
 	kubectl apply -f $(TEMP_DIR)/vald/templates/gateway/lb

--- a/Makefile.d/k8s.mk
+++ b/Makefile.d/k8s.mk
@@ -73,9 +73,9 @@ k8s/vald/deploy:
 	    charts/vald
 	@echo "Permitting error because there's some cases nothing to apply"
 	kubectl apply -f $(TEMP_DIR)/vald/templates/manager/index || true
-	kubectl apply -f $(TEMP_DIR)/vald/templates/agent
-	kubectl apply -f $(TEMP_DIR)/vald/templates/discoverer
-	kubectl apply -f $(TEMP_DIR)/vald/templates/gateway/lb
+	kubectl apply -f $(TEMP_DIR)/vald/templates/agent || true
+	kubectl apply -f $(TEMP_DIR)/vald/templates/discoverer || true
+	kubectl apply -f $(TEMP_DIR)/vald/templates/gateway/lb || true
 	rm -rf $(TEMP_DIR)
 	kubectl get pods -o jsonpath="{.items[*].spec.containers[*].image}" | tr " " "\n"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR partially fixes the regression of https://github.com/vdaas/vald/pull/2024 that all the e2e actions fail. With this PR, e2e actions work correctly except for `actions/e2e-max-dim`.

Fixed three things,
1. Wrong usage of `outputs`
2. Output accurate `POD_NAME`
3. Allow empty resources when executing `kubectl apply`

There will be another PR for `actions/e2e-max-dim`.

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.3
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.9

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
