### PR TITLE
Update RoundTrip retry condition

### DIFF
--- a/internal/net/http/transport/roundtrip.go
+++ b/internal/net/http/transport/roundtrip.go
@@ -94,7 +94,6 @@ func retryableStatusCode(status int) bool {
 	case http.StatusTooManyRequests,
 		http.StatusInternalServerError,
 		http.StatusServiceUnavailable,
-		http.StatusMovedPermanently,
 		http.StatusBadGateway,
 		http.StatusGatewayTimeout:
 		return true

--- a/internal/net/http/transport/roundtrip_test.go
+++ b/internal/net/http/transport/roundtrip_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/vdaas/vald/internal/backoff"
@@ -371,14 +372,14 @@ func Test_ert_doRoundTrip(t *testing.T) {
 				transport: &roundTripMock{
 					RoundTripFunc: func(*http.Request) (*http.Response, error) {
 						return &http.Response{
-							Status: "200",
+							Status: strconv.Itoa(http.StatusOK),
 						}, nil
 					},
 				},
 			},
 			want: want{
 				wantRes: &http.Response{
-					Status: "200",
+					Status: strconv.Itoa(http.StatusOK),
 				},
 			},
 		},
@@ -399,7 +400,7 @@ func Test_ert_doRoundTrip(t *testing.T) {
 			},
 		},
 		{
-			name: "roundtrip return retryable error",
+			name: "roundtrip return retryable error when status code is 502",
 			args: args{
 				req: &http.Request{},
 			},
@@ -415,6 +416,26 @@ func Test_ert_doRoundTrip(t *testing.T) {
 			},
 			want: want{
 				err: errors.ErrTransportRetryable,
+			},
+		},
+		{
+			name: "roundtrip return success when status code is 301",
+			args: args{
+				req: &http.Request{},
+			},
+			fields: fields{
+				transport: &roundTripMock{
+					RoundTripFunc: func(*http.Request) (*http.Response, error) {
+						return &http.Response{
+							Status: strconv.Itoa(http.StatusMovedPermanently),
+						}, nil
+					},
+				},
+			},
+			want: want{
+				wantRes: &http.Response{
+					Status: strconv.Itoa(http.StatusMovedPermanently),
+				},
 			},
 		},
 		{
@@ -496,16 +517,24 @@ func Test_retryableStatusCode(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return true when response status is retryable",
+			name: "return true when response status is 429(TooManyRequest)",
 			args: args{
 				status: http.StatusTooManyRequests,
 			},
 			want: want{
 				want: true,
 			},
+		}, {
+			name: "return false when response status is 301(MovedPermanently)",
+			args: args{
+				status: http.StatusMovedPermanently,
+			},
+			want: want{
+				want: false,
+			},
 		},
 		{
-			name: "return false when response status is not retryable",
+			name: "return false when response status is 200(OK)",
 			args: args{
 				status: http.StatusOK,
 			},

--- a/internal/net/http/transport/roundtrip_test.go
+++ b/internal/net/http/transport/roundtrip_test.go
@@ -524,7 +524,8 @@ func Test_retryableStatusCode(t *testing.T) {
 			want: want{
 				want: true,
 			},
-		}, {
+		},
+		{
 			name: "return false when response status is 301(MovedPermanently)",
 			args: args{
 				status: http.StatusMovedPermanently,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
I have updated the round trip retry condition, which removed MovePermanently from the retry condition.

Because it repeats the round trip with the original URL even though the redirect occurs.
We don't need to do a round trip if a redirect occurs because it will lead to the redirect destination.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->
None

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.3
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.11

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
