### PR TITLE
Fix to create index_path when it does not exists

### DIFF
--- a/internal/errors/agent.go
+++ b/internal/errors/agent.go
@@ -104,4 +104,9 @@ var (
 	ErrObjectNotFound = func(err error, uuid string) error {
 		return Wrapf(err, "uuid %s's object not found", uuid)
 	}
+
+	// ErrAgentMigrationFailed represents a function to generate an error that agent migration failed.
+	ErrAgentMigrationFailed = func(err error) error {
+		return Wrap(err, "index_path migration failed")
+	}
 )

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -80,6 +80,11 @@ var (
 		return Wrapf(err, "failed to output %s logs", str)
 	}
 
+	// ErrAgentMigrationFailed represents a function to generate an error that agent migration failed.
+	ErrAgentMigrationFailed = func(err error) error {
+		return Wrap(err, "migration failed")
+	}
+
 	// New represents a function to generate the new error with a message.
 	// When the message is nil, it will return nil instead of an error.
 	New = func(msg string) error {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -80,11 +80,6 @@ var (
 		return Wrapf(err, "failed to output %s logs", str)
 	}
 
-	// ErrIndexPathNotExists represents a function to generate an error that the index path is not exists.
-	ErrIndexPathNotExists = func(path string) error {
-		return Errorf("index path %s not exists", path)
-	}
-
 	// New represents a function to generate the new error with a message.
 	// When the message is nil, it will return nil instead of an error.
 	New = func(msg string) error {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -80,11 +80,6 @@ var (
 		return Wrapf(err, "failed to output %s logs", str)
 	}
 
-	// ErrAgentMigrationFailed represents a function to generate an error that agent migration failed.
-	ErrAgentMigrationFailed = func(err error) error {
-		return Wrap(err, "migration failed")
-	}
-
 	// New represents a function to generate the new error with a message.
 	// When the message is nil, it will return nil instead of an error.
 	New = func(msg string) error {

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -171,9 +171,6 @@ func New(cfg *config.NGT, opts ...Option) (nn NGT, err error) {
 
 	// prepare directories to store index only when it not in-memory mode
 	if !n.inMem {
-		// if !file.Exists(n.path) {
-		// 	return nil, errors.ErrIndexPathNotExists(n.path)
-		// }
 		ctx := context.Background()
 		err = n.prepareFolders(ctx)
 		if err != nil {

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -171,9 +171,9 @@ func New(cfg *config.NGT, opts ...Option) (nn NGT, err error) {
 
 	// prepare directories to store index only when it not in-memory mode
 	if !n.inMem {
-		if !file.Exists(n.path) {
-			return nil, errors.ErrIndexPathNotExists(n.path)
-		}
+		// if !file.Exists(n.path) {
+		// 	return nil, errors.ErrIndexPathNotExists(n.path)
+		// }
 		ctx := context.Background()
 		err = n.prepareFolders(ctx)
 		if err != nil {

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -219,7 +219,7 @@ func migrate(ctx context.Context, path string) (err error) {
 	}
 	files, err := file.ListInDir(path)
 	if err != nil {
-		return fmt.Errorf("failed to list in %v: %w", path, err)
+		return errors.ErrAgentMigrationFailed(err)
 	}
 	if len(files) == 0 {
 		// empty directory doesn't need migration
@@ -240,23 +240,23 @@ func migrate(ctx context.Context, path string) (err error) {
 	// first move all contents to temporary directory because it's not possible to directly move directory to its subdirectory
 	tp, err := file.MkdirTemp("")
 	if err != nil {
-		return err
+		return errors.ErrAgentMigrationFailed(err)
 	}
 	err = file.MoveDir(ctx, path, tp)
 	if err != nil {
-		return err
+		return errors.ErrAgentMigrationFailed(err)
 	}
 
 	// recreate the path again to move contents to `path/origin` lately
 	err = file.MkdirAll(path, fs.ModePerm)
 	if err != nil {
-		return err
+		return errors.ErrAgentMigrationFailed(err)
 	}
 
 	// finally move to `path/origin` directory
 	err = file.MoveDir(ctx, tp, file.Join(path, originIndexDirName))
 	if err != nil {
-		return err
+		return errors.ErrAgentMigrationFailed(err)
 	}
 
 	return nil

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -222,7 +222,7 @@ func migrate(ctx context.Context, path string) (err error) {
 	}
 	files, err := file.ListInDir(path)
 	if err != nil {
-		return fmt.Errorf("failed to list in file: %w", err)
+		return fmt.Errorf("failed to list in %v: %w", path, err)
 	}
 	if len(files) == 0 {
 		// empty directory doesn't need migration

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -216,12 +216,17 @@ func New(cfg *config.NGT, opts ...Option) (nn NGT, err error) {
 // which indicates that the user has NOT been using CoW mode and the index directory is not migrated yet.
 func migrate(ctx context.Context, path string) (err error) {
 	// check if migration is required
+	if !file.Exists(path) {
+		log.Infof("the path %v does not exist. no need to migrate since it's probably the initial state", path)
+		return nil
+	}
 	files, err := file.ListInDir(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list in file: %w", err)
 	}
 	if len(files) == 0 {
 		// empty directory doesn't need migration
+		log.Infof("the path %v is empty. no need to migrate", path)
 		return nil
 	}
 	od := filepath.Join(path, originIndexDirName)

--- a/pkg/agent/core/ngt/service/ngt_test.go
+++ b/pkg/agent/core/ngt/service/ngt_test.go
@@ -469,20 +469,20 @@ func TestNew(t *testing.T) {
 				},
 			}
 		}(),
-		func() test {
-			return test{
-				name: "New fails with not existing index path",
-				args: args{
-					cfg: &defaultConfig,
-					opts: []Option{
-						WithIndexPath("/dev/null/ghost"),
-					},
-				},
-				want: want{
-					err: errors.ErrIndexPathNotExists("/dev/null/ghost"),
-				},
-			}
-		}(),
+		// func() test {
+		// 	return test{
+		// 		name: "New fails with not existing index path",
+		// 		args: args{
+		// 			cfg: &defaultConfig,
+		// 			opts: []Option{
+		// 				WithIndexPath("/dev/null/ghost"),
+		// 			},
+		// 		},
+		// 		want: want{
+		// 			err: errors.ErrIndexPathNotExists("/dev/null/ghost"),
+		// 		},
+		// 	}
+		// }(),
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR fixes the regression that introduced  in https://github.com/vdaas/vald/pull/2034.

When `index_path` does not exist, it used to create the directory and https://github.com/vdaas/vald/pull/2034 made it an error. This PR reverts it.

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.3
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.11

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
