### PR TITLE
fix make k8s/metrics/jaeger/deploy failure

### DIFF
--- a/Makefile.d/k8s.mk
+++ b/Makefile.d/k8s.mk
@@ -227,7 +227,7 @@ k8s/metrics/jaeger/deploy:
 	helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
 	helm install jaeger jaegertracing/jaeger-operator --version $(JAEGER_OPERATOR_VERSION)
 	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=jaeger-operator --timeout=60s
-	sleep 5
+	until kubectl run busybox --restart=Never --image=busybox --rm -it -- wget -q -S --spider "https://jaeger-operator-webhook-service.default.svc:443/mutate-jaegertracing-io-v1-jaeger"; do sleep 1; done
 	kubectl apply -f k8s/metrics/jaeger/jaeger.yaml
 
 .PHONY: k8s/metrics/jaeger/delete

--- a/Makefile.d/k8s.mk
+++ b/Makefile.d/k8s.mk
@@ -227,6 +227,7 @@ k8s/metrics/jaeger/deploy:
 	helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
 	helm install jaeger jaegertracing/jaeger-operator --version $(JAEGER_OPERATOR_VERSION)
 	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=jaeger-operator --timeout=60s
+	sleep 5
 	kubectl apply -f k8s/metrics/jaeger/jaeger.yaml
 
 .PHONY: k8s/metrics/jaeger/delete


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
When running `make k8s/metrics/jaeger/deploy`, in my environment, executing `kubectl apply -f k8s/metrics/jaeger/jaeger.yaml` fails with errors below.

```
Error from server (InternalError): error when creating "k8s/metrics/jaeger/jaeger.yaml": Internal error occurred: failed calling webhook "mjaeger.kb.io": Post "https://jaeger-operator-webhook-service.default.svc:443/mutate-jaegertracing-io-v1-jaeger?timeout=10s": dial tcp 10.43.187.78:443: connect: connection refused
```

I watched logs, but I could not find the related error.
So it is my opinion, even if it checks the condition using `kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=jaeger-operator --timeout=60s`, the endpoint will not be ready depending on the performance of the computer.

Finally, in my environment, it could deploy in less than 3 seconds in most situation. And, to be sure, I estimated the buffer to be 5 seconds.

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.5
- Docker Version: 24.0.2
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.12

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
