### PR TITLE
Add broken index count metrics

### DIFF
--- a/charts/vald/values/dev-broken-index-backup.yaml
+++ b/charts/vald/values/dev-broken-index-backup.yaml
@@ -1,0 +1,98 @@
+#
+# Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defaults:
+  image:
+    tag: nightly
+  server_config:
+    metrics:
+      pprof:
+        enabled: true
+    servers:
+      grpc:
+        server:
+          grpc:
+            interceptors:
+              - RecoverInterceptor
+              - TraceInterceptor
+              - MetricInterceptor
+  grpc:
+    client:
+      dial_option:
+        interceptors:
+          - TraceInterceptor
+  observability:
+    enabled: true
+    otlp:
+      collector_endpoint: "opentelemetry-collector-collector.default.svc.cluster.local:4317"
+    trace:
+      enabled: true
+
+gateway:
+  lb:
+    podAnnotations:
+      profefe.com/enable: "true"
+      profefe.com/port: "6060"
+      profefe.com/service: "vald-lb-gateway"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 50Mi
+
+agent:
+  podAnnotations:
+    profefe.com/enable: "true"
+    profefe.com/port: "6060"
+    profefe.com/service: "vald-agent-ngt"
+  minReplicas: 5
+  maxReplicas: 10
+  podManagementPolicy: Parallel
+  resources:
+    requests:
+      cpu: 100m
+      memory: 50Mi
+  ngt:
+    dimension: 784
+    index_path: "/var/ngt/index"
+    enable_in_memory_mode: false
+    broken_index_history_limit: 3
+  persistentVolume:
+    enabled: true
+    # For local-path-provisioner, we cannot use ReadWriteOncePod because it is not supported.
+    accessMode: ReadWriteOnce
+    storageClass: local-path
+    size: 1Gi
+
+discoverer:
+  podAnnotations:
+    profefe.com/enable: "true"
+    profefe.com/port: "6060"
+    profefe.com/service: "vald-discoverer"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 50Mi
+
+manager:
+  index:
+    podAnnotations:
+      profefe.com/enable: "true"
+      profefe.com/port: "6060"
+      profefe.com/service: "vald-manager-index"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 30Mi

--- a/example/client/agent/main.go
+++ b/example/client/agent/main.go
@@ -134,10 +134,9 @@ func main() {
 		t := train[i]
 		var sum float64
 		for i := range r {
-			fmt.Println("r, t: ", r[i], t[i])
 			sum += math.Pow(float64(t[i]-r[i]), 2)
 		}
-		fmt.Println(sum)
+		glg.Infof("Euclidean distance of r and t: %v", sum)
 	}
 	glg.Info("Finish getting object")
 

--- a/example/client/agent/main.go
+++ b/example/client/agent/main.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"fmt"
 	"math"
 	"time"
 

--- a/internal/observability/metrics/agent/core/ngt/ngt.go
+++ b/internal/observability/metrics/agent/core/ngt/ngt.go
@@ -47,7 +47,7 @@ const (
 	isSavingMetricsName        = "agent_core_ngt_is_saving"
 	isSavingMetricsDescription = "Currently saving or not"
 
-	brokenIndexStoreCountMetricsName = "agent_core_ngt_broken_index_store_count"
+	brokenIndexStoreCountMetricsName        = "agent_core_ngt_broken_index_store_count"
 	brokenIndexStoreCountMetricsDescription = "How many broken index generations have been stored"
 )
 

--- a/k8s/metrics/grafana/dashboards/01-vald-agent.yaml
+++ b/k8s/metrics/grafana/dashboards/01-vald-agent.yaml
@@ -108,7 +108,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -186,7 +186,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -264,7 +264,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -346,7 +346,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -430,7 +430,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -509,7 +509,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -587,7 +587,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -669,7 +669,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -750,7 +750,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -832,7 +832,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "repeatDirection": "h",
           "targets": [
             {
@@ -914,7 +914,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -995,7 +995,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -1072,7 +1072,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -1146,7 +1146,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -1221,7 +1221,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -1274,7 +1274,7 @@ data:
           },
           "gridPos": {
             "h": 3,
-            "w": 6,
+            "w": 3,
             "x": 18,
             "y": 12
           },
@@ -1296,7 +1296,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -1314,6 +1314,71 @@ data:
             }
           ],
           "title": "Object Type",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 21,
+            "y": 12
+          },
+          "id": 43,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "10.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum(agent_core_ngt_broken_index_store_count{exported_kubernetes_namespace=\"$Namespace\", kubernetes_name=~\"$ReplicaSet\", target_pod=~\"$PodName\"})",
+              "instant": false,
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "broken index store count",
           "type": "stat"
         },
         {
@@ -1357,7 +1422,7 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1482,7 +1547,7 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1607,7 +1672,7 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1703,7 +1768,7 @@ data:
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.3",
+          "pluginVersion": "10.0.0",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2390,7 +2455,7 @@ data:
         }
       ],
       "refresh": "",
-      "schemaVersion": 37,
+      "schemaVersion": 38,
       "style": "dark",
       "tags": [],
       "templating": {
@@ -2491,7 +2556,7 @@ data:
             "auto_count": 30,
             "auto_min": "10s",
             "current": {
-              "selected": false,
+              "selected": true,
               "text": "5m",
               "value": "5m"
             },

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -301,6 +301,7 @@ func (n *ngt) prepareFolders(ctx context.Context) (err error) {
 		log.Warnf("failed to list files in broken index backup directory: %v", err)
 	}
 	atomic.SwapUint64(&n.nobic, uint64(len(files)))
+	log.Debugf("broken index count: %v", n.nobic)
 
 	if n.enableCopyOnWrite && len(n.path) != 0 {
 		err = file.MkdirAll(n.oldPath, fs.ModePerm)
@@ -524,6 +525,7 @@ func (n *ngt) backupBroken(ctx context.Context) error {
 		return err
 	}
 	atomic.SwapUint64(&n.nobic, uint64(len(files)))
+	log.Debugf("broken index count updated: %v", n.nobic)
 
 	return nil
 }

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -81,6 +81,7 @@ type NGT interface {
 	InsertVQueueBufferLen() uint64
 	GetDimensionSize() int
 	Close(ctx context.Context) error
+	BrokenIndexCount() uint64
 }
 
 type ngt struct {
@@ -102,6 +103,7 @@ type ngt struct {
 	nocie uint64 // number of create index execution
 	nogce uint64 // number of proactive GC execution
 	wfci  uint64 // wait for create indexing
+	nobic uint64 // number of broken index count
 
 	// configurations
 	inMem bool // in-memory mode
@@ -293,6 +295,13 @@ func (n *ngt) prepareFolders(ctx context.Context) (err error) {
 		log.Warnf("failed to create a folder for broken index backup: %v", err)
 	}
 
+	// update broken index count
+	files, err := file.ListInDir(n.brokenPath)
+	if err != nil {
+		log.Warnf("failed to list files in broken index backup directory: %v", err)
+	}
+	atomic.SwapUint64(&n.nobic, uint64(len(files)))
+
 	if n.enableCopyOnWrite && len(n.path) != 0 {
 		err = file.MkdirAll(n.oldPath, fs.ModePerm)
 		if err != nil {
@@ -472,13 +481,13 @@ func (n *ngt) load(ctx context.Context, path string, opts ...core.Option) (err e
 // backupBroken backup index at originPath into brokenDir.
 // The name of the directory will be timestamp(UnixNano).
 // If it exeeds the limit, backupBroken removes the oldest backup directory.
-func backupBroken(ctx context.Context, originPath string, brokenDir string, limit int) error {
-	if limit <= 0 {
+func (n *ngt) backupBroken(ctx context.Context) error {
+	if n.historyLimit <= 0 {
 		return nil
 	}
 
 	// do nothing when origin path is empty
-	files, err := file.ListInDir(originPath)
+	files, err := file.ListInDir(n.path)
 	if err != nil {
 		return err
 	}
@@ -486,15 +495,13 @@ func backupBroken(ctx context.Context, originPath string, brokenDir string, limi
 		return nil
 	}
 
-	// how many generation exists in the path?
-	files, err = file.ListInDir(brokenDir)
+	files, err = file.ListInDir(n.brokenPath)
 	if err != nil {
 		return err
 	}
-
-	if len(files) >= limit {
+	if len(files) >= n.historyLimit {
 		// remove the oldest
-		log.Infof("There's already more than %v broken index generations stored. Thus removing the oldest.", limit)
+		log.Infof("There's already more than %v broken index generations stored. Thus removing the oldest.", n.historyLimit)
 		slices.Sort(files)
 		if err := os.RemoveAll(files[0]); err != nil {
 			return err
@@ -503,13 +510,21 @@ func backupBroken(ctx context.Context, originPath string, brokenDir string, limi
 
 	// create directory for new generation broken index
 	name := time.Now().UnixNano()
-	dest := filepath.Join(brokenDir, fmt.Sprint(name))
+	dest := filepath.Join(n.brokenPath, fmt.Sprint(name))
 
 	// move index to the new directory
-	err = file.MoveDir(ctx, originPath, dest)
+	err = file.MoveDir(ctx, n.path, dest)
 	if err != nil {
 		return err
 	}
+
+	// update broken index count
+	files, err = file.ListInDir(n.brokenPath)
+	if err != nil {
+		return err
+	}
+	atomic.SwapUint64(&n.nobic, uint64(len(files)))
+
 	return nil
 }
 
@@ -566,7 +581,7 @@ func (n *ngt) rebuild(ctx context.Context, path string, opts ...core.Option) (er
 	// backup when it is required
 	if needsBackup(n.path) {
 		log.Infof("starting to backup broken index at %v", n.path)
-		err = backupBroken(ctx, n.path, n.brokenPath, n.historyLimit)
+		err = n.backupBroken(ctx)
 		if err != nil {
 			log.Warnf("failed to backup broken index. will remove it and restart: %v", err)
 		} else {
@@ -1677,4 +1692,8 @@ func (n *ngt) Close(ctx context.Context) (err error) {
 	}
 	n.core.Close()
 	return
+}
+
+func (n *ngt) BrokenIndexCount() uint64 {
+	return atomic.LoadUint64(&n.nobic)
 }

--- a/pkg/agent/core/ngt/service/ngt_test.go
+++ b/pkg/agent/core/ngt/service/ngt_test.go
@@ -1194,6 +1194,7 @@ func Test_ngt_prepareFolders(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -1257,6 +1258,7 @@ func Test_ngt_prepareFolders(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -1313,6 +1315,7 @@ func Test_ngt_prepareFolders(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -1378,6 +1381,7 @@ func Test_ngt_prepareFolders(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -1430,6 +1434,7 @@ func Test_ngt_load(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -1495,6 +1500,7 @@ func Test_ngt_load(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -1553,6 +1559,7 @@ func Test_ngt_load(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -1618,6 +1625,7 @@ func Test_ngt_load(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -1652,105 +1660,9 @@ func Test_ngt_load(t *testing.T) {
 	}
 }
 
-func Test_backupBroken(t *testing.T) {
+func Test_ngt_backupBroken(t *testing.T) {
 	type args struct {
-		ctx        context.Context
-		originPath string
-		brokenDir  string
-		limit      int
-	}
-	type want struct {
-		err error
-	}
-	type test struct {
-		name       string
-		args       args
-		want       want
-		checkFunc  func(want, error) error
-		beforeFunc func(*testing.T, args)
-		afterFunc  func(*testing.T, args)
-	}
-	defaultCheckFunc := func(w want, err error) error {
-		if !errors.Is(err, w.err) {
-			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-		}
-		return nil
-	}
-	tests := []test{
-		// TODO test cases
-		/*
-		   {
-		       name: "test_case_1",
-		       args: args {
-		           ctx:nil,
-		           originPath:"",
-		           brokenDir:"",
-		           limit:0,
-		       },
-		       want: want{},
-		       checkFunc: defaultCheckFunc,
-		       beforeFunc: func(t *testing.T, args args) {
-		           t.Helper()
-		       },
-		       afterFunc: func(t *testing.T, args args) {
-		           t.Helper()
-		       },
-		   },
-		*/
-
-		// TODO test cases
-		/*
-		   func() test {
-		       return test {
-		           name: "test_case_2",
-		           args: args {
-		           ctx:nil,
-		           originPath:"",
-		           brokenDir:"",
-		           limit:0,
-		           },
-		           want: want{},
-		           checkFunc: defaultCheckFunc,
-		           beforeFunc: func(t *testing.T, args args) {
-		               t.Helper()
-		           },
-		           afterFunc: func(t *testing.T, args args) {
-		               t.Helper()
-		           },
-		       }
-		   }(),
-		*/
-	}
-
-	for _, tc := range tests {
-		test := tc
-		t.Run(test.name, func(tt *testing.T) {
-			tt.Parallel()
-			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
-			if test.beforeFunc != nil {
-				test.beforeFunc(tt, test.args)
-			}
-			if test.afterFunc != nil {
-				defer test.afterFunc(tt, test.args)
-			}
-			checkFunc := test.checkFunc
-			if test.checkFunc == nil {
-				checkFunc = defaultCheckFunc
-			}
-
-			err := backupBroken(test.args.ctx, test.args.originPath, test.args.brokenDir, test.args.limit)
-			if err := checkFunc(test.want, err); err != nil {
-				tt.Errorf("error = %v", err)
-			}
-		})
-	}
-}
-
-func Test_ngt_rebuild(t *testing.T) {
-	type args struct {
-		ctx  context.Context
-		path string
-		opts []core.Option
+		ctx context.Context
 	}
 	type fields struct {
 		core              core.NGT
@@ -1764,6 +1676,7 @@ func Test_ngt_rebuild(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -1814,8 +1727,6 @@ func Test_ngt_rebuild(t *testing.T) {
 		       name: "test_case_1",
 		       args: args {
 		           ctx:nil,
-		           path:"",
-		           opts:nil,
 		       },
 		       fields: fields {
 		           core:nil,
@@ -1829,6 +1740,7 @@ func Test_ngt_rebuild(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -1872,8 +1784,6 @@ func Test_ngt_rebuild(t *testing.T) {
 		           name: "test_case_2",
 		           args: args {
 		           ctx:nil,
-		           path:"",
-		           opts:nil,
 		           },
 		           fields: fields {
 		           core:nil,
@@ -1887,6 +1797,7 @@ func Test_ngt_rebuild(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -1952,6 +1863,251 @@ func Test_ngt_rebuild(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
+				inMem:             test.fields.inMem,
+				dim:               test.fields.dim,
+				alen:              test.fields.alen,
+				lim:               test.fields.lim,
+				dur:               test.fields.dur,
+				sdur:              test.fields.sdur,
+				minLit:            test.fields.minLit,
+				maxLit:            test.fields.maxLit,
+				litFactor:         test.fields.litFactor,
+				enableProactiveGC: test.fields.enableProactiveGC,
+				enableCopyOnWrite: test.fields.enableCopyOnWrite,
+				path:              test.fields.path,
+				tmpPath:           test.fields.tmpPath,
+				oldPath:           test.fields.oldPath,
+				basePath:          test.fields.basePath,
+				brokenPath:        test.fields.brokenPath,
+				backupGen:         test.fields.backupGen,
+				poolSize:          test.fields.poolSize,
+				radius:            test.fields.radius,
+				epsilon:           test.fields.epsilon,
+				idelay:            test.fields.idelay,
+				dcd:               test.fields.dcd,
+				kvsdbConcurrency:  test.fields.kvsdbConcurrency,
+				historyLimit:      test.fields.historyLimit,
+			}
+
+			err := n.backupBroken(test.args.ctx)
+			if err := checkFunc(test.want, err); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func Test_ngt_rebuild(t *testing.T) {
+	type args struct {
+		ctx  context.Context
+		path string
+		opts []core.Option
+	}
+	type fields struct {
+		core              core.NGT
+		eg                errgroup.Group
+		kvs               kvs.BidiMap
+		fmap              map[string]int64
+		vq                vqueue.Queue
+		indexing          atomic.Value
+		saving            atomic.Value
+		lastNocie         uint64
+		nocie             uint64
+		nogce             uint64
+		wfci              uint64
+		nobic             uint64
+		inMem             bool
+		dim               int
+		alen              int
+		lim               time.Duration
+		dur               time.Duration
+		sdur              time.Duration
+		minLit            time.Duration
+		maxLit            time.Duration
+		litFactor         time.Duration
+		enableProactiveGC bool
+		enableCopyOnWrite bool
+		path              string
+		tmpPath           atomic.Value
+		oldPath           string
+		basePath          string
+		brokenPath        string
+		backupGen         uint64
+		poolSize          uint32
+		radius            float32
+		epsilon           float32
+		idelay            time.Duration
+		dcd               bool
+		kvsdbConcurrency  int
+		historyLimit      int
+	}
+	type want struct {
+		err error
+	}
+	type test struct {
+		name       string
+		args       args
+		fields     fields
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
+	}
+	defaultCheckFunc := func(w want, err error) error {
+		if !errors.Is(err, w.err) {
+			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		return nil
+	}
+	tests := []test{
+		// TODO test cases
+		/*
+		   {
+		       name: "test_case_1",
+		       args: args {
+		           ctx:nil,
+		           path:"",
+		           opts:nil,
+		       },
+		       fields: fields {
+		           core:nil,
+		           eg:nil,
+		           kvs:nil,
+		           fmap:nil,
+		           vq:nil,
+		           indexing:nil,
+		           saving:nil,
+		           lastNocie:0,
+		           nocie:0,
+		           nogce:0,
+		           wfci:0,
+		           nobic:0,
+		           inMem:false,
+		           dim:0,
+		           alen:0,
+		           lim:nil,
+		           dur:nil,
+		           sdur:nil,
+		           minLit:nil,
+		           maxLit:nil,
+		           litFactor:nil,
+		           enableProactiveGC:false,
+		           enableCopyOnWrite:false,
+		           path:"",
+		           tmpPath:nil,
+		           oldPath:"",
+		           basePath:"",
+		           brokenPath:"",
+		           backupGen:0,
+		           poolSize:0,
+		           radius:0,
+		           epsilon:0,
+		           idelay:nil,
+		           dcd:false,
+		           kvsdbConcurrency:0,
+		           historyLimit:0,
+		       },
+		       want: want{},
+		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T, args args) {
+		           t.Helper()
+		       },
+		   },
+		*/
+
+		// TODO test cases
+		/*
+		   func() test {
+		       return test {
+		           name: "test_case_2",
+		           args: args {
+		           ctx:nil,
+		           path:"",
+		           opts:nil,
+		           },
+		           fields: fields {
+		           core:nil,
+		           eg:nil,
+		           kvs:nil,
+		           fmap:nil,
+		           vq:nil,
+		           indexing:nil,
+		           saving:nil,
+		           lastNocie:0,
+		           nocie:0,
+		           nogce:0,
+		           wfci:0,
+		           nobic:0,
+		           inMem:false,
+		           dim:0,
+		           alen:0,
+		           lim:nil,
+		           dur:nil,
+		           sdur:nil,
+		           minLit:nil,
+		           maxLit:nil,
+		           litFactor:nil,
+		           enableProactiveGC:false,
+		           enableCopyOnWrite:false,
+		           path:"",
+		           tmpPath:nil,
+		           oldPath:"",
+		           basePath:"",
+		           brokenPath:"",
+		           backupGen:0,
+		           poolSize:0,
+		           radius:0,
+		           epsilon:0,
+		           idelay:nil,
+		           dcd:false,
+		           kvsdbConcurrency:0,
+		           historyLimit:0,
+		           },
+		           want: want{},
+		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T, args args) {
+		               t.Helper()
+		           },
+		       }
+		   }(),
+		*/
+	}
+
+	for _, tc := range tests {
+		test := tc
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
+			if test.beforeFunc != nil {
+				test.beforeFunc(tt, test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(tt, test.args)
+			}
+			checkFunc := test.checkFunc
+			if test.checkFunc == nil {
+				checkFunc = defaultCheckFunc
+			}
+			n := &ngt{
+				core:              test.fields.core,
+				eg:                test.fields.eg,
+				kvs:               test.fields.kvs,
+				fmap:              test.fields.fmap,
+				vq:                test.fields.vq,
+				indexing:          test.fields.indexing,
+				saving:            test.fields.saving,
+				lastNocie:         test.fields.lastNocie,
+				nocie:             test.fields.nocie,
+				nogce:             test.fields.nogce,
+				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -2002,6 +2158,7 @@ func Test_ngt_initNGT(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -2065,6 +2222,7 @@ func Test_ngt_initNGT(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -2121,6 +2279,7 @@ func Test_ngt_initNGT(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -2186,6 +2345,7 @@ func Test_ngt_initNGT(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -2238,6 +2398,7 @@ func Test_ngt_loadKVS(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -2303,6 +2464,7 @@ func Test_ngt_loadKVS(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -2361,6 +2523,7 @@ func Test_ngt_loadKVS(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -2426,6 +2589,7 @@ func Test_ngt_loadKVS(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -2476,6 +2640,7 @@ func Test_ngt_Start(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -2539,6 +2704,7 @@ func Test_ngt_Start(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -2595,6 +2761,7 @@ func Test_ngt_Start(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -2660,6 +2827,7 @@ func Test_ngt_Start(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -2713,6 +2881,7 @@ func Test_ngt_Search(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -2783,6 +2952,7 @@ func Test_ngt_Search(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -2842,6 +3012,7 @@ func Test_ngt_Search(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -2907,6 +3078,7 @@ func Test_ngt_Search(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -2960,6 +3132,7 @@ func Test_ngt_SearchByID(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -3034,6 +3207,7 @@ func Test_ngt_SearchByID(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -3093,6 +3267,7 @@ func Test_ngt_SearchByID(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -3158,6 +3333,7 @@ func Test_ngt_SearchByID(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -3209,6 +3385,7 @@ func Test_ngt_LinearSearch(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -3277,6 +3454,7 @@ func Test_ngt_LinearSearch(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -3334,6 +3512,7 @@ func Test_ngt_LinearSearch(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -3399,6 +3578,7 @@ func Test_ngt_LinearSearch(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -3450,6 +3630,7 @@ func Test_ngt_LinearSearchByID(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -3522,6 +3703,7 @@ func Test_ngt_LinearSearchByID(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -3579,6 +3761,7 @@ func Test_ngt_LinearSearchByID(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -3644,6 +3827,7 @@ func Test_ngt_LinearSearchByID(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -3695,6 +3879,7 @@ func Test_ngt_Insert(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -3759,6 +3944,7 @@ func Test_ngt_Insert(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -3816,6 +4002,7 @@ func Test_ngt_Insert(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -3881,6 +4068,7 @@ func Test_ngt_Insert(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -3933,6 +4121,7 @@ func Test_ngt_InsertWithTime(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -3998,6 +4187,7 @@ func Test_ngt_InsertWithTime(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -4056,6 +4246,7 @@ func Test_ngt_InsertWithTime(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -4121,6 +4312,7 @@ func Test_ngt_InsertWithTime(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -4174,6 +4366,7 @@ func Test_ngt_insert(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -4240,6 +4433,7 @@ func Test_ngt_insert(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -4299,6 +4493,7 @@ func Test_ngt_insert(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -4364,6 +4559,7 @@ func Test_ngt_insert(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -4414,6 +4610,7 @@ func Test_ngt_InsertMultiple(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -4477,6 +4674,7 @@ func Test_ngt_InsertMultiple(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -4533,6 +4731,7 @@ func Test_ngt_InsertMultiple(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -4598,6 +4797,7 @@ func Test_ngt_InsertMultiple(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -4649,6 +4849,7 @@ func Test_ngt_InsertMultipleWithTime(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -4713,6 +4914,7 @@ func Test_ngt_InsertMultipleWithTime(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -4770,6 +4972,7 @@ func Test_ngt_InsertMultipleWithTime(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -4835,6 +5038,7 @@ func Test_ngt_InsertMultipleWithTime(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -4887,6 +5091,7 @@ func Test_ngt_insertMultiple(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -4952,6 +5157,7 @@ func Test_ngt_insertMultiple(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -5010,6 +5216,7 @@ func Test_ngt_insertMultiple(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -5075,6 +5282,7 @@ func Test_ngt_insertMultiple(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -5126,6 +5334,7 @@ func Test_ngt_Update(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -5190,6 +5399,7 @@ func Test_ngt_Update(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -5247,6 +5457,7 @@ func Test_ngt_Update(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -5312,6 +5523,7 @@ func Test_ngt_Update(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -5364,6 +5576,7 @@ func Test_ngt_UpdateWithTime(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -5429,6 +5642,7 @@ func Test_ngt_UpdateWithTime(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -5487,6 +5701,7 @@ func Test_ngt_UpdateWithTime(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -5552,6 +5767,7 @@ func Test_ngt_UpdateWithTime(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -5604,6 +5820,7 @@ func Test_ngt_update(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -5669,6 +5886,7 @@ func Test_ngt_update(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -5727,6 +5945,7 @@ func Test_ngt_update(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -5792,6 +6011,7 @@ func Test_ngt_update(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -5842,6 +6062,7 @@ func Test_ngt_UpdateMultiple(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -5905,6 +6126,7 @@ func Test_ngt_UpdateMultiple(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -5961,6 +6183,7 @@ func Test_ngt_UpdateMultiple(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -6026,6 +6249,7 @@ func Test_ngt_UpdateMultiple(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -6077,6 +6301,7 @@ func Test_ngt_UpdateMultipleWithTime(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -6141,6 +6366,7 @@ func Test_ngt_UpdateMultipleWithTime(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -6198,6 +6424,7 @@ func Test_ngt_UpdateMultipleWithTime(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -6263,6 +6490,7 @@ func Test_ngt_UpdateMultipleWithTime(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -6314,6 +6542,7 @@ func Test_ngt_updateMultiple(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -6378,6 +6607,7 @@ func Test_ngt_updateMultiple(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -6435,6 +6665,7 @@ func Test_ngt_updateMultiple(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -6500,6 +6731,7 @@ func Test_ngt_updateMultiple(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -6550,6 +6782,7 @@ func Test_ngt_Delete(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -6613,6 +6846,7 @@ func Test_ngt_Delete(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -6669,6 +6903,7 @@ func Test_ngt_Delete(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -6734,6 +6969,7 @@ func Test_ngt_Delete(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -6785,6 +7021,7 @@ func Test_ngt_DeleteWithTime(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -6849,6 +7086,7 @@ func Test_ngt_DeleteWithTime(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -6906,6 +7144,7 @@ func Test_ngt_DeleteWithTime(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -6971,6 +7210,7 @@ func Test_ngt_DeleteWithTime(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -7023,6 +7263,7 @@ func Test_ngt_delete(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -7088,6 +7329,7 @@ func Test_ngt_delete(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -7146,6 +7388,7 @@ func Test_ngt_delete(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -7211,6 +7454,7 @@ func Test_ngt_delete(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -7261,6 +7505,7 @@ func Test_ngt_DeleteMultiple(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -7324,6 +7569,7 @@ func Test_ngt_DeleteMultiple(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -7380,6 +7626,7 @@ func Test_ngt_DeleteMultiple(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -7445,6 +7692,7 @@ func Test_ngt_DeleteMultiple(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -7496,6 +7744,7 @@ func Test_ngt_DeleteMultipleWithTime(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -7560,6 +7809,7 @@ func Test_ngt_DeleteMultipleWithTime(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -7617,6 +7867,7 @@ func Test_ngt_DeleteMultipleWithTime(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -7682,6 +7933,7 @@ func Test_ngt_DeleteMultipleWithTime(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -7734,6 +7986,7 @@ func Test_ngt_deleteMultiple(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -7799,6 +8052,7 @@ func Test_ngt_deleteMultiple(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -7857,6 +8111,7 @@ func Test_ngt_deleteMultiple(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -7922,6 +8177,7 @@ func Test_ngt_deleteMultiple(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -7973,6 +8229,7 @@ func Test_ngt_CreateIndex(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -8037,6 +8294,7 @@ func Test_ngt_CreateIndex(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -8094,6 +8352,7 @@ func Test_ngt_CreateIndex(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -8159,6 +8418,7 @@ func Test_ngt_CreateIndex(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -8209,6 +8469,7 @@ func Test_ngt_removeInvalidIndex(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -8267,6 +8528,7 @@ func Test_ngt_removeInvalidIndex(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -8323,6 +8585,7 @@ func Test_ngt_removeInvalidIndex(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -8388,6 +8651,7 @@ func Test_ngt_removeInvalidIndex(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -8438,6 +8702,7 @@ func Test_ngt_SaveIndex(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -8501,6 +8766,7 @@ func Test_ngt_SaveIndex(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -8557,6 +8823,7 @@ func Test_ngt_SaveIndex(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -8622,6 +8889,7 @@ func Test_ngt_SaveIndex(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -8672,6 +8940,7 @@ func Test_ngt_saveIndex(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -8735,6 +9004,7 @@ func Test_ngt_saveIndex(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -8791,6 +9061,7 @@ func Test_ngt_saveIndex(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -8856,6 +9127,7 @@ func Test_ngt_saveIndex(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -8907,6 +9179,7 @@ func Test_ngt_CreateAndSaveIndex(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -8971,6 +9244,7 @@ func Test_ngt_CreateAndSaveIndex(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -9028,6 +9302,7 @@ func Test_ngt_CreateAndSaveIndex(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -9093,6 +9368,7 @@ func Test_ngt_CreateAndSaveIndex(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -9143,6 +9419,7 @@ func Test_ngt_moveAndSwitchSavedData(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -9206,6 +9483,7 @@ func Test_ngt_moveAndSwitchSavedData(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -9262,6 +9540,7 @@ func Test_ngt_moveAndSwitchSavedData(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -9327,6 +9606,7 @@ func Test_ngt_moveAndSwitchSavedData(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -9374,6 +9654,7 @@ func Test_ngt_mktmp(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -9433,6 +9714,7 @@ func Test_ngt_mktmp(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -9486,6 +9768,7 @@ func Test_ngt_mktmp(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -9551,6 +9834,7 @@ func Test_ngt_mktmp(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -9601,6 +9885,7 @@ func Test_ngt_Exists(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -9668,6 +9953,7 @@ func Test_ngt_Exists(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -9724,6 +10010,7 @@ func Test_ngt_Exists(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -9789,6 +10076,7 @@ func Test_ngt_Exists(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -9839,6 +10127,7 @@ func Test_ngt_GetObject(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -9906,6 +10195,7 @@ func Test_ngt_GetObject(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -9962,6 +10252,7 @@ func Test_ngt_GetObject(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -10027,6 +10318,7 @@ func Test_ngt_GetObject(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -10078,6 +10370,7 @@ func Test_ngt_readyForUpdate(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -10142,6 +10435,7 @@ func Test_ngt_readyForUpdate(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -10199,6 +10493,7 @@ func Test_ngt_readyForUpdate(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -10264,6 +10559,7 @@ func Test_ngt_readyForUpdate(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -10311,6 +10607,7 @@ func Test_ngt_IsSaving(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -10370,6 +10667,7 @@ func Test_ngt_IsSaving(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -10423,6 +10721,7 @@ func Test_ngt_IsSaving(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -10488,6 +10787,7 @@ func Test_ngt_IsSaving(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -10535,6 +10835,7 @@ func Test_ngt_IsIndexing(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -10594,6 +10895,7 @@ func Test_ngt_IsIndexing(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -10647,6 +10949,7 @@ func Test_ngt_IsIndexing(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -10712,6 +11015,7 @@ func Test_ngt_IsIndexing(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -10762,6 +11066,7 @@ func Test_ngt_UUIDs(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -10825,6 +11130,7 @@ func Test_ngt_UUIDs(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -10881,6 +11187,7 @@ func Test_ngt_UUIDs(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -10946,6 +11253,7 @@ func Test_ngt_UUIDs(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -10993,6 +11301,7 @@ func Test_ngt_NumberOfCreateIndexExecution(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -11052,6 +11361,7 @@ func Test_ngt_NumberOfCreateIndexExecution(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -11105,6 +11415,7 @@ func Test_ngt_NumberOfCreateIndexExecution(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -11170,6 +11481,7 @@ func Test_ngt_NumberOfCreateIndexExecution(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -11217,6 +11529,7 @@ func Test_ngt_NumberOfProactiveGCExecution(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -11276,6 +11589,7 @@ func Test_ngt_NumberOfProactiveGCExecution(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -11329,6 +11643,7 @@ func Test_ngt_NumberOfProactiveGCExecution(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -11394,6 +11709,7 @@ func Test_ngt_NumberOfProactiveGCExecution(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -11441,6 +11757,7 @@ func Test_ngt_gc(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -11495,6 +11812,7 @@ func Test_ngt_gc(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -11548,6 +11866,7 @@ func Test_ngt_gc(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -11613,6 +11932,7 @@ func Test_ngt_gc(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -11660,6 +11980,7 @@ func Test_ngt_Len(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -11719,6 +12040,7 @@ func Test_ngt_Len(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -11772,6 +12094,7 @@ func Test_ngt_Len(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -11837,6 +12160,7 @@ func Test_ngt_Len(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -11884,6 +12208,7 @@ func Test_ngt_InsertVQueueBufferLen(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -11943,6 +12268,7 @@ func Test_ngt_InsertVQueueBufferLen(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -11996,6 +12322,7 @@ func Test_ngt_InsertVQueueBufferLen(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -12061,6 +12388,7 @@ func Test_ngt_InsertVQueueBufferLen(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -12108,6 +12436,7 @@ func Test_ngt_DeleteVQueueBufferLen(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -12167,6 +12496,7 @@ func Test_ngt_DeleteVQueueBufferLen(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -12220,6 +12550,7 @@ func Test_ngt_DeleteVQueueBufferLen(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -12285,6 +12616,7 @@ func Test_ngt_DeleteVQueueBufferLen(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -12332,6 +12664,7 @@ func Test_ngt_GetDimensionSize(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -12391,6 +12724,7 @@ func Test_ngt_GetDimensionSize(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -12444,6 +12778,7 @@ func Test_ngt_GetDimensionSize(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -12509,6 +12844,7 @@ func Test_ngt_GetDimensionSize(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -12559,6 +12895,7 @@ func Test_ngt_Close(t *testing.T) {
 		nocie             uint64
 		nogce             uint64
 		wfci              uint64
+		nobic             uint64
 		inMem             bool
 		dim               int
 		alen              int
@@ -12622,6 +12959,7 @@ func Test_ngt_Close(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -12678,6 +13016,7 @@ func Test_ngt_Close(t *testing.T) {
 		           nocie:0,
 		           nogce:0,
 		           wfci:0,
+		           nobic:0,
 		           inMem:false,
 		           dim:0,
 		           alen:0,
@@ -12743,6 +13082,7 @@ func Test_ngt_Close(t *testing.T) {
 				nocie:             test.fields.nocie,
 				nogce:             test.fields.nogce,
 				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
 				inMem:             test.fields.inMem,
 				dim:               test.fields.dim,
 				alen:              test.fields.alen,
@@ -12771,6 +13111,234 @@ func Test_ngt_Close(t *testing.T) {
 
 			err := n.Close(test.args.ctx)
 			if err := checkFunc(test.want, err); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
+func Test_ngt_BrokenIndexCount(t *testing.T) {
+	type fields struct {
+		core              core.NGT
+		eg                errgroup.Group
+		kvs               kvs.BidiMap
+		fmap              map[string]int64
+		vq                vqueue.Queue
+		indexing          atomic.Value
+		saving            atomic.Value
+		lastNocie         uint64
+		nocie             uint64
+		nogce             uint64
+		wfci              uint64
+		nobic             uint64
+		inMem             bool
+		dim               int
+		alen              int
+		lim               time.Duration
+		dur               time.Duration
+		sdur              time.Duration
+		minLit            time.Duration
+		maxLit            time.Duration
+		litFactor         time.Duration
+		enableProactiveGC bool
+		enableCopyOnWrite bool
+		path              string
+		tmpPath           atomic.Value
+		oldPath           string
+		basePath          string
+		brokenPath        string
+		backupGen         uint64
+		poolSize          uint32
+		radius            float32
+		epsilon           float32
+		idelay            time.Duration
+		dcd               bool
+		kvsdbConcurrency  int
+		historyLimit      int
+	}
+	type want struct {
+		want uint64
+	}
+	type test struct {
+		name       string
+		fields     fields
+		want       want
+		checkFunc  func(want, uint64) error
+		beforeFunc func(*testing.T)
+		afterFunc  func(*testing.T)
+	}
+	defaultCheckFunc := func(w want, got uint64) error {
+		if !reflect.DeepEqual(got, w.want) {
+			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
+		}
+		return nil
+	}
+	tests := []test{
+		// TODO test cases
+		/*
+		   {
+		       name: "test_case_1",
+		       fields: fields {
+		           core:nil,
+		           eg:nil,
+		           kvs:nil,
+		           fmap:nil,
+		           vq:nil,
+		           indexing:nil,
+		           saving:nil,
+		           lastNocie:0,
+		           nocie:0,
+		           nogce:0,
+		           wfci:0,
+		           nobic:0,
+		           inMem:false,
+		           dim:0,
+		           alen:0,
+		           lim:nil,
+		           dur:nil,
+		           sdur:nil,
+		           minLit:nil,
+		           maxLit:nil,
+		           litFactor:nil,
+		           enableProactiveGC:false,
+		           enableCopyOnWrite:false,
+		           path:"",
+		           tmpPath:nil,
+		           oldPath:"",
+		           basePath:"",
+		           brokenPath:"",
+		           backupGen:0,
+		           poolSize:0,
+		           radius:0,
+		           epsilon:0,
+		           idelay:nil,
+		           dcd:false,
+		           kvsdbConcurrency:0,
+		           historyLimit:0,
+		       },
+		       want: want{},
+		       checkFunc: defaultCheckFunc,
+		       beforeFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		       afterFunc: func(t *testing.T,) {
+		           t.Helper()
+		       },
+		   },
+		*/
+
+		// TODO test cases
+		/*
+		   func() test {
+		       return test {
+		           name: "test_case_2",
+		           fields: fields {
+		           core:nil,
+		           eg:nil,
+		           kvs:nil,
+		           fmap:nil,
+		           vq:nil,
+		           indexing:nil,
+		           saving:nil,
+		           lastNocie:0,
+		           nocie:0,
+		           nogce:0,
+		           wfci:0,
+		           nobic:0,
+		           inMem:false,
+		           dim:0,
+		           alen:0,
+		           lim:nil,
+		           dur:nil,
+		           sdur:nil,
+		           minLit:nil,
+		           maxLit:nil,
+		           litFactor:nil,
+		           enableProactiveGC:false,
+		           enableCopyOnWrite:false,
+		           path:"",
+		           tmpPath:nil,
+		           oldPath:"",
+		           basePath:"",
+		           brokenPath:"",
+		           backupGen:0,
+		           poolSize:0,
+		           radius:0,
+		           epsilon:0,
+		           idelay:nil,
+		           dcd:false,
+		           kvsdbConcurrency:0,
+		           historyLimit:0,
+		           },
+		           want: want{},
+		           checkFunc: defaultCheckFunc,
+		           beforeFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		           afterFunc: func(t *testing.T,) {
+		               t.Helper()
+		           },
+		       }
+		   }(),
+		*/
+	}
+
+	for _, tc := range tests {
+		test := tc
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
+			if test.beforeFunc != nil {
+				test.beforeFunc(tt)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(tt)
+			}
+			checkFunc := test.checkFunc
+			if test.checkFunc == nil {
+				checkFunc = defaultCheckFunc
+			}
+			n := &ngt{
+				core:              test.fields.core,
+				eg:                test.fields.eg,
+				kvs:               test.fields.kvs,
+				fmap:              test.fields.fmap,
+				vq:                test.fields.vq,
+				indexing:          test.fields.indexing,
+				saving:            test.fields.saving,
+				lastNocie:         test.fields.lastNocie,
+				nocie:             test.fields.nocie,
+				nogce:             test.fields.nogce,
+				wfci:              test.fields.wfci,
+				nobic:             test.fields.nobic,
+				inMem:             test.fields.inMem,
+				dim:               test.fields.dim,
+				alen:              test.fields.alen,
+				lim:               test.fields.lim,
+				dur:               test.fields.dur,
+				sdur:              test.fields.sdur,
+				minLit:            test.fields.minLit,
+				maxLit:            test.fields.maxLit,
+				litFactor:         test.fields.litFactor,
+				enableProactiveGC: test.fields.enableProactiveGC,
+				enableCopyOnWrite: test.fields.enableCopyOnWrite,
+				path:              test.fields.path,
+				tmpPath:           test.fields.tmpPath,
+				oldPath:           test.fields.oldPath,
+				basePath:          test.fields.basePath,
+				brokenPath:        test.fields.brokenPath,
+				backupGen:         test.fields.backupGen,
+				poolSize:          test.fields.poolSize,
+				radius:            test.fields.radius,
+				epsilon:           test.fields.epsilon,
+				idelay:            test.fields.idelay,
+				dcd:               test.fields.dcd,
+				kvsdbConcurrency:  test.fields.kvsdbConcurrency,
+				historyLimit:      test.fields.historyLimit,
+			}
+
+			got := n.BrokenIndexCount()
+			if err := checkFunc(test.want, got); err != nil {
 				tt.Errorf("error = %v", err)
 			}
 		})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

This PR makes it possible to get the number of broken indexes as a metric. 
To check it's working, deployed vald to the local k3d with the settings of `dev-broken-index-backup.yaml`, and confirmed that the corresponding metric is correctly displayed on Grafana with the settings of `01-vald-agent.yaml`.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.3
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.11

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
