### PR TITLE
Add backup origin when CoW enabled and failed to load primary

### DIFF
--- a/internal/errors/agent.go
+++ b/internal/errors/agent.go
@@ -109,4 +109,7 @@ var (
 	ErrAgentMigrationFailed = func(err error) error {
 		return Wrap(err, "index_path migration failed")
 	}
+
+	// ErrAgentIndexDirectoryRecreationFailed represents an error that the index directory recreation failed during the process of broken index backup.
+	ErrIndexDirectoryRecreationFailed = New("failed to recreate the index directory")
 )

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -655,7 +655,7 @@ func (n *ngt) initNGT(opts ...core.Option) (err error) {
 		} else {
 			log.Warnf("failed to load vald primary index from %s\t error: %v\ttrying to load from old copied index data from %s", n.path, err, n.oldPath)
 			if needsBackup(n.path) {
-				log.Infof("starting to backup broken index at %v", n.path)
+				log.Infof("starting to backup broken index at %s", n.path)
 				if err := n.backupBroken(ctx); err != nil {
 					log.Warnf("failed to backup broken index. will try to restart from old index anyway: %v", err)
 				}

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -527,6 +527,11 @@ func (n *ngt) backupBroken(ctx context.Context) error {
 	atomic.SwapUint64(&n.nobic, uint64(len(files)))
 	log.Debugf("broken index count updated: %v", n.nobic)
 
+	// remake the path since it has been moved to broken directory
+	if err := file.MkdirAll(n.path, fs.ModePerm); err != nil {
+		return fmt.Errorf("failed to recreate the index directory: %w", err)
+	}
+
 	return nil
 }
 
@@ -586,12 +591,6 @@ func (n *ngt) rebuild(ctx context.Context, path string, opts ...core.Option) (er
 		err = n.backupBroken(ctx)
 		if err != nil {
 			log.Warnf("failed to backup broken index. will remove it and restart: %v", err)
-		} else {
-			// remake the path since it has been moved to broken directory
-			err = file.MkdirAll(n.path, fs.ModePerm)
-			if err != nil {
-				return fmt.Errorf("failed to recreate the index directory: %w", err)
-			}
 		}
 	}
 
@@ -655,6 +654,12 @@ func (n *ngt) initNGT(opts ...core.Option) (err error) {
 			)
 		} else {
 			log.Warnf("failed to load vald primary index from %s\t error: %v\ttrying to load from old copied index data from %s", n.path, err, n.oldPath)
+			if needsBackup(n.path) {
+				log.Infof("starting to backup broken index at %v", n.path)
+				if err := n.backupBroken(ctx); err != nil {
+					log.Warnf("failed to backup broken index. will try to restart from old index anyway: %v", err)
+				}
+			}
 		}
 	} else {
 		return nil

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -529,7 +529,7 @@ func (n *ngt) backupBroken(ctx context.Context) error {
 
 	// remake the path since it has been moved to broken directory
 	if err := file.MkdirAll(n.path, fs.ModePerm); err != nil {
-		return fmt.Errorf("failed to recreate the index directory: %w", err)
+		return errors.Join(errors.ErrIndexDirectoryRecreationFailed, err)
 	}
 
 	return nil

--- a/pkg/agent/core/ngt/service/ngt.go
+++ b/pkg/agent/core/ngt/service/ngt.go
@@ -529,7 +529,7 @@ func (n *ngt) backupBroken(ctx context.Context) error {
 
 	// remake the path since it has been moved to broken directory
 	if err := file.MkdirAll(n.path, fs.ModePerm); err != nil {
-		return errors.Join(errors.ErrIndexDirectoryRecreationFailed, err)
+		return errors.Join(err, errors.ErrIndexDirectoryRecreationFailed)
 	}
 
 	return nil

--- a/pkg/agent/core/ngt/service/ngt_test.go
+++ b/pkg/agent/core/ngt/service/ngt_test.go
@@ -522,7 +522,6 @@ func TestNew(t *testing.T) {
 				},
 			}
 		}(),
-		// TODO:
 		func() test {
 			tmpDir := t.TempDir()
 			originDir := filepath.Join(tmpDir, originIndexDirName)

--- a/pkg/agent/core/ngt/service/ngt_test.go
+++ b/pkg/agent/core/ngt/service/ngt_test.go
@@ -522,6 +522,79 @@ func TestNew(t *testing.T) {
 				},
 			}
 		}(),
+		// TODO:
+		func() test {
+			tmpDir := t.TempDir()
+			originDir := filepath.Join(tmpDir, originIndexDirName)
+			backupDir := filepath.Join(tmpDir, oldIndexDirName)
+			brokenDir := filepath.Join(tmpDir, brokenIndexDirName)
+			testIndexDir := testdata.GetTestdataPath(testdata.ValidIndex)
+			config := defaultConfig
+			config.BrokenIndexHistoryLimit = 1
+			config.EnableCopyOnWrite = true
+			return test{
+				name: "New backup broken index when CoW is enabled and failed to load primary index",
+				args: args{
+					cfg: &config,
+					opts: []Option{
+						WithIndexPath(tmpDir),
+					},
+				},
+				want: want{
+					err: nil,
+				},
+				beforeFunc: func(t *testing.T, args args) {
+					t.Helper()
+					if err := file.MkdirAll(originDir, fs.ModePerm); err != nil {
+						t.Errorf("failed to create origin dir: %v", err)
+					}
+					if err := file.CopyDir(context.Background(), testIndexDir, originDir); err != nil {
+						t.Errorf("failed to copy test index: %v", err)
+					}
+					// remove metadata.json to make it broken
+					if err := os.Remove(filepath.Join(originDir, "metadata.json")); err != nil {
+						t.Errorf("failed to remove index file: %v", err)
+					}
+
+					if err := file.MkdirAll(backupDir, fs.ModePerm); err != nil {
+						t.Errorf("failed to create backup dir: %v", err)
+					}
+					if err := file.CopyDir(context.Background(), testIndexDir, backupDir); err != nil {
+						t.Errorf("failed to copy test index: %v", err)
+					}
+				},
+				checkFunc: func(w want, err error) error {
+					if !errors.Is(err, w.err) {
+						return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+					}
+					files, err := file.ListInDir(brokenDir)
+					if err != nil {
+						return err
+					}
+					if len(files) != 1 {
+						return fmt.Errorf("only one generation should be in broken dir but there's %v", len(files))
+					}
+
+					broken, err := file.ListInDir(files[0])
+					if err != nil {
+						return err
+					}
+					if len(broken) == 0 {
+						return fmt.Errorf("failed to move broken index files")
+					}
+
+					files, err = file.ListInDir(originDir)
+					if err != nil {
+						return err
+					}
+					if len(files) != 0 {
+						return fmt.Errorf("failed to move origin index files to broken directory")
+					}
+
+					return nil
+				},
+			}
+		}(),
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

With this PR, the primary index will be backed up immediately when the agent fails to load it with CoW enabled. Before, it was backed up only when it fails to load both primary and old index.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.3
- Docker Version: 20.10.8
- Kubernetes Version: 1.22.0
- NGT Version: 2.0.11

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
