### PR TITLE
Fix jaeger operator wait logic

### DIFF
--- a/Makefile.d/k8s.mk
+++ b/Makefile.d/k8s.mk
@@ -230,6 +230,7 @@ k8s/metrics/jaeger/deploy:
 	helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
 	helm install jaeger jaegertracing/jaeger-operator --version $(JAEGER_OPERATOR_VERSION)
 	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=jaeger-operator --timeout=60s
+	kubectl wait --for=condition=available deployment/jaeger-jaeger-operator --timeout=60s
 	sleep $(JAEGER_OPERATOR_WAIT_DURATION)
 	kubectl apply -f k8s/metrics/jaeger/jaeger.yaml
 

--- a/Makefile.d/k8s.mk
+++ b/Makefile.d/k8s.mk
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+JAEGER_OPERATOR_WAIT_DURATION := 0
+
 .PHONY: k8s/manifest/clean
 ## clean k8s manifests
 k8s/manifest/clean:
@@ -227,7 +230,7 @@ k8s/metrics/jaeger/deploy:
 	helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
 	helm install jaeger jaegertracing/jaeger-operator --version $(JAEGER_OPERATOR_VERSION)
 	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=jaeger-operator --timeout=60s
-	kubectl wait --for=condition=available deployment/jaeger-jaeger-operator --timeout=60s 
+	sleep $(JAEGER_OPERATOR_WAIT_DURATION)
 	kubectl apply -f k8s/metrics/jaeger/jaeger.yaml
 
 .PHONY: k8s/metrics/jaeger/delete

--- a/Makefile.d/k8s.mk
+++ b/Makefile.d/k8s.mk
@@ -227,7 +227,7 @@ k8s/metrics/jaeger/deploy:
 	helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
 	helm install jaeger jaegertracing/jaeger-operator --version $(JAEGER_OPERATOR_VERSION)
 	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=jaeger-operator --timeout=60s
-	until kubectl run busybox --restart=Never --image=busybox --rm -it -- wget -q -S --spider "https://jaeger-operator-webhook-service.default.svc:443/mutate-jaegertracing-io-v1-jaeger"; do sleep 1; done
+	kubectl wait --for=condition=available deployment/jaeger-jaeger-operator --timeout=60s 
 	kubectl apply -f k8s/metrics/jaeger/jaeger.yaml
 
 .PHONY: k8s/metrics/jaeger/delete


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

#### WHY

when I deployed the Jaeger component using `make k8s/external/cert-manager/deploy k8s/monitoring/deploy`, the deploy error occurred. 

```
until kubectl run busybox --restart=Never --image=busybox --rm -it -- wget -q -S --spider "https://jaeger-operator-webhook-service.default.svc:443/mutate-jaegertracing-io-v1-jaeger"; do sleep 1; done
If you don't see a command prompt, try pressing enter.
pod "busybox" deleted
pod default/busybox terminated (Error)
wget: note: TLS certificate validation not implemented
wget: TLS error from peer (alert code 40): handshake failure
wget: error getting response: Connection reset by peer
pod "busybox" deleted
pod default/busybox terminated (Error)
If you don't see a command prompt, try pressing enter.
warning: couldn't attach to pod/busybox, falling back to streaming logs: unable to upgrade connection: container busybox not found in pod busybox_default
wget: note: TLS certificate validation not implemented
wget: TLS error from peer (alert code 40): handshake failure
wget: error getting response: Connection reset by peer
pod "busybox" deleted
pod default/busybox terminated (Error)
```

#### WHAT

I tried to wait for operator deployment instead of accessing the endpoint.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.5
- Docker Version: 20.10.8
- Kubernetes Version: v1.27.3
- NGT Version: 2.0.13

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
