### PR TITLE
remove some linters to make ci faster

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -66,7 +66,6 @@ jobs:
           go build -mod=readonly ./...
       - name: Run golangci-lint
         run: |
-          # golangci-lint run --config .golangci.yml --issues-exit-code 0
           golangci-lint run --config .golangci.yml \
               | reviewdog -f=golangci-lint -name=golangci -reporter=${REPORTER} -level=${LEVEL}
         env:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -163,15 +163,19 @@ linters-settings:
         json: snake
         yaml: snake
   depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages-with-error-message:
-      - errors: "errors is allowed only by internal/errors"
-      - k8s.io/apimachinery/pkg/api/errors: "errors is allowed only by internal/errors"
-      - github.com/cockroachdb/errors: "errors is allowed only by internal/errors"
-      - github.com/pkg/errors: "errors is allowed only by internal/errors"
-      - github.com/go-errors/errors: "errors is allowed only by internal/errors"
-      - golang.org/x/sync/errgroup: "errgroup is allowed only by internal/errgroup"
+    rules:
+      main:
+        deny:
+          - pkg: "errors"
+            desc: "errors is allowed only by internal/errors"
+          - pkg: "k8s.io/apimachinery/pkg/api/errors"
+            desc: "errors is allowed only by internal/errors"
+          - pkg: "github.com/cockroachdb/errors"
+            desc: "errors is allowed only by internal/errors"
+          - pkg: "github.com/pkg/errors"
+            desc: "errors is allowed only by internal/errors"
+          - pkg: github.com/go-errors/errors
+            desc: "errors is allowed only by internal/errors"
   govet:
     check-shadowing: true
     enable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,7 +50,6 @@ linters:
     - gochecknoglobals
     - gochecknoinits
     - goconst
-    - gocritic
     - godot
     - godox
     - gofumpt
@@ -91,7 +90,6 @@ linters:
     - unparam
     - unused #(megacheck)
     - usestdlibvars
-    - zerologlint
     # Disabled by your configuration linters
     # - cyclop
     # - errcheck
@@ -99,6 +97,7 @@ linters:
     # - funlen
     # - gci
     # - gocognit
+    # - gocritic
     # - gocyclo
     # - goerr113
     # - gofmt
@@ -123,6 +122,7 @@ linters:
     # - whitespace
     # - wrapcheck
     # - wslissues:
+    # - zerologlint
   exclude-use-default: false
   exclude-rules:
     - path: _test\.go


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

- Removed `gocritic` from golangci-lint because it was taking more than 30mins. Now it's just a few mins.
- Fix `depgurd` settings

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.5
- Docker Version: 20.10.8
- Kubernetes Version: v1.27.3
- NGT Version: 2.0.13

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
