### PR TITLE
 Propagate context to Search operation.

### DIFF
--- a/internal/core/algorithm/ngt/ngt.go
+++ b/internal/core/algorithm/ngt/ngt.go
@@ -25,6 +25,7 @@ package ngt
 import "C"
 
 import (
+	"context"
 	"reflect"
 	"sync"
 	"unsafe"
@@ -40,7 +41,7 @@ type (
 	// NGT is core interface.
 	NGT interface {
 		// Search returns search result as []SearchResult
-		Search(vec []float32, size int, epsilon, radius float32) ([]SearchResult, error)
+		Search(ctx context.Context, vec []float32, size int, epsilon, radius float32) ([]SearchResult, error)
 
 		// Linear Search returns linear search result as []SearchResult
 		LinearSearch(vec []float32, size int) ([]SearchResult, error)
@@ -366,7 +367,7 @@ func (n *ngt) loadObjectSpace() error {
 }
 
 // Search returns search result as []SearchResult.
-func (n *ngt) Search(vec []float32, size int, epsilon, radius float32) (result []SearchResult, err error) {
+func (n *ngt) Search(ctx context.Context, vec []float32, size int, epsilon, radius float32) (result []SearchResult, err error) {
 	if len(vec) != int(n.dimension) {
 		return nil, errors.ErrIncompatibleDimensionSize(len(vec), int(n.dimension))
 	}
@@ -415,6 +416,12 @@ func (n *ngt) Search(vec []float32, size int, epsilon, radius float32) (result [
 	result = make([]SearchResult, rsize)
 
 	for i := range result {
+		select {
+		case <-ctx.Done():
+			n.PutErrorBuffer(ebuf)
+			return result[:i], nil
+		default:
+		}
 		d := C.ngt_get_result(results, C.uint32_t(i), ebuf)
 		if d.id == 0 && d.distance == 0 {
 			result[i] = SearchResult{0, 0, n.newGoError(ebuf)}

--- a/pkg/agent/core/ngt/handler/grpc/search.go
+++ b/pkg/agent/core/ngt/handler/grpc/search.go
@@ -69,7 +69,7 @@ func (s *server) Search(ctx context.Context, req *payload.Search_Request) (res *
 		return nil, err
 	}
 	res, err = toSearchResponse(
-		s.ngt.Search(
+		s.ngt.Search(ctx,
 			req.GetVector(),
 			req.GetConfig().GetNum(),
 			req.GetConfig().GetEpsilon(),
@@ -195,7 +195,7 @@ func (s *server) SearchByID(ctx context.Context, req *payload.Search_IDRequest) 
 		}
 		return nil, err
 	}
-	vec, dst, err := s.ngt.SearchByID(
+	vec, dst, err := s.ngt.SearchByID(ctx,
 		uuid,
 		req.GetConfig().GetNum(),
 		req.GetConfig().GetEpsilon(),

--- a/pkg/agent/core/ngt/service/ngt_stateful_test.go
+++ b/pkg/agent/core/ngt/service/ngt_stateful_test.go
@@ -511,9 +511,10 @@ var (
 		RunFunc: func(
 			systemUnderTest commands.SystemUnderTest,
 		) commands.Result {
-			ngt := systemUnderTest.(*ngtSystem).ngt
+			ngtSys := systemUnderTest.(*ngtSystem)
+			ngt := ngtSys.ngt
 
-			res, err := ngt.Search([]float32{0.1, 0.1, 0.1}, 3, 0.1, -1.0)
+			res, err := ngt.Search(ngtSys.ctx, []float32{0.1, 0.1, 0.1}, 3, 0.1, -1.0)
 			return &resultContainer{
 				err:     err,
 				results: res,
@@ -583,9 +584,10 @@ var (
 		RunFunc: func(
 			systemUnderTest commands.SystemUnderTest,
 		) commands.Result {
-			ngt := systemUnderTest.(*ngtSystem).ngt
+			ngtSys := systemUnderTest.(*ngtSystem)
+			ngt := ngtSys.ngt
 
-			_, res, err := ngt.SearchByID(idA, 3, 0.1, -1.0)
+			_, res, err := ngt.SearchByID(ngtSys.ctx, idA, 3, 0.1, -1.0)
 			return &resultContainer{
 				err:     err,
 				results: res,
@@ -662,9 +664,10 @@ var (
 		RunFunc: func(
 			systemUnderTest commands.SystemUnderTest,
 		) commands.Result {
-			ngt := systemUnderTest.(*ngtSystem).ngt
+			ngtSys := systemUnderTest.(*ngtSystem)
+			ngt := ngtSys.ngt
 
-			_, res, err := ngt.SearchByID(idB, 3, 0.1, -1.0)
+			_, res, err := ngt.SearchByID(ngtSys.ctx, idB, 3, 0.1, -1.0)
 			return &resultContainer{
 				err:     err,
 				results: res,
@@ -741,9 +744,10 @@ var (
 		RunFunc: func(
 			systemUnderTest commands.SystemUnderTest,
 		) commands.Result {
-			ngt := systemUnderTest.(*ngtSystem).ngt
+			ngtSys := systemUnderTest.(*ngtSystem)
+			ngt := ngtSys.ngt
 
-			_, res, err := ngt.SearchByID(idC, 3, 0.1, -1.0)
+			_, res, err := ngt.SearchByID(ngtSys.ctx, idC, 3, 0.1, -1.0)
 			return &resultContainer{
 				err:     err,
 				results: res,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

#### WHY

When Search operation is taking a long time, it cannot be interrupted because the Context is not propagated,

#### WHAT

I fixed to propagate context to Search operation.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.5
- Docker Version: 20.10.8
- Kubernetes Version: v1.27.3
- NGT Version: 2.0.13

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
