### PR TITLE
Fix ngt index path of test case

### DIFF
--- a/internal/core/algorithm/ngt/ngt_test.go
+++ b/internal/core/algorithm/ngt/ngt_test.go
@@ -1829,7 +1829,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-813",
+				idxPath:             "/tmp/ngt-814",
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Float,

--- a/internal/core/algorithm/ngt/ngt_test.go
+++ b/internal/core/algorithm/ngt/ngt_test.go
@@ -1397,7 +1397,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-81",
+				idxPath:             t.TempDir(),
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Uint8,
@@ -1425,7 +1425,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-82",
+				idxPath:             t.TempDir(),
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Uint8,
@@ -1453,7 +1453,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-83",
+				idxPath:             t.TempDir(),
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Uint8,
@@ -1487,7 +1487,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-84",
+				idxPath:             t.TempDir(),
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Uint8,
@@ -1528,7 +1528,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-85",
+				idxPath:             t.TempDir(),
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Uint8,
@@ -1574,7 +1574,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-86",
+				idxPath:             t.TempDir(),
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Float,
@@ -1602,7 +1602,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-87",
+				idxPath:             t.TempDir(),
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Float,
@@ -1630,7 +1630,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-88",
+				idxPath:             t.TempDir(),
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Float,
@@ -1663,7 +1663,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-89",
+				idxPath:             t.TempDir(),
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Float,
@@ -1704,7 +1704,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-810",
+				idxPath:             t.TempDir(),
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Float,
@@ -1750,7 +1750,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-811",
+				idxPath:             t.TempDir(),
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Uint8,
@@ -1778,7 +1778,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-812",
+				idxPath:             t.TempDir(),
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Uint8,
@@ -1804,7 +1804,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-813",
+				idxPath:             t.TempDir(),
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Float,
@@ -1829,7 +1829,7 @@ func Test_ngt_Search(t *testing.T) {
 			},
 			fields: fields{
 				inMemory:            false,
-				idxPath:             "/tmp/ngt-814",
+				idxPath:             t.TempDir(),
 				bulkInsertChunkSize: 100,
 				dimension:           9,
 				objectType:          Float,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

#### WHAT

I fixed index path of test case

#### WHY

The test failed because it was the same index path as the other test cases.

https://github.com/vdaas/vald/blob/main/internal/core/algorithm/ngt/ngt_test.go#L1807-L1832


<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.6
- Docker Version: 20.10.8
- Kubernetes Version: v1.27.3
- NGT Version: 2.0.16

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
