### PR TITLE
Fix coverage CI error

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -81,3 +81,10 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage.out
+      - name: Upload coverage report to deepsource
+        run: |
+          mv ./coverage.out ./cover.out
+          curl https://deepsource.io/cli | sh
+          ./bin/deepsource report --analyzer test-coverage --key go --value-file ./cover.out
+        env:
+          DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -81,10 +81,3 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage.out
-      - name: Upload coverage report to deepsource
-        run: |
-          mv ./coverage.out ./cover.out
-          curl https://deepsource.io/cli | sh
-          ./bin/deepsource report --analyzer test-coverage --key go --value-file ./cover.out
-        env:
-          DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -88,6 +88,3 @@ jobs:
           ./bin/deepsource report --analyzer test-coverage --key go --value-file ./cover.out
         env:
           DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
-
-
-          

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -88,3 +88,6 @@ jobs:
           ./bin/deepsource report --analyzer test-coverage --key go --value-file ./cover.out
         env:
           DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
+
+
+          

--- a/tests/performance/max_vector_dim_test.go
+++ b/tests/performance/max_vector_dim_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vdaas/vald/internal/core/algorithm/ngt"
 	"github.com/vdaas/vald/internal/errgroup"
 	"github.com/vdaas/vald/internal/errors"
+	"github.com/vdaas/vald/internal/log"
 	"github.com/vdaas/vald/internal/safety"
 	"github.com/vdaas/vald/internal/strings"
 	"github.com/vdaas/vald/internal/test/data/vector"
@@ -79,12 +80,16 @@ func parse(raw string) (key string, value int) {
 	return keyValue[0], val
 }
 
+func TestMain(m *testing.M) {
+	if testing.Short() {
+		log.Info("skipping this pkg test when -short because it takes a long time")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
 // Test for investigation of max dimension size for agent handler
 func TestMaxDimInsert(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-
 	t.Helper()
 	eg, ctx := errgroup.New(context.Background())
 	mu := sync.Mutex{}
@@ -187,10 +192,6 @@ func TestMaxDimInsert(t *testing.T) {
 
 // Test for investigation of max dimension size for agent handler with gRPC
 func TestMaxDimInsertGRPC(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-
 	// MaxUint64 cannot be used due to overflows
 	t.Helper()
 	eg, ctx := errgroup.New(context.Background())

--- a/tests/performance/max_vector_dim_test.go
+++ b/tests/performance/max_vector_dim_test.go
@@ -81,6 +81,11 @@ func parse(raw string) (key string, value int) {
 
 // Test for investigation of max dimension size for agent handler
 func TestMaxDimInsert(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+		return
+	}
+
 	t.Helper()
 	eg, ctx := errgroup.New(context.Background())
 	mu := sync.Mutex{}
@@ -183,6 +188,11 @@ func TestMaxDimInsert(t *testing.T) {
 
 // Test for investigation of max dimension size for agent handler with gRPC
 func TestMaxDimInsertGRPC(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+		return
+	}
+
 	// MaxUint64 cannot be used due to overflows
 	t.Helper()
 	eg, ctx := errgroup.New(context.Background())

--- a/tests/performance/max_vector_dim_test.go
+++ b/tests/performance/max_vector_dim_test.go
@@ -82,8 +82,7 @@ func parse(raw string) (key string, value int) {
 // Test for investigation of max dimension size for agent handler
 func TestMaxDimInsert(t *testing.T) {
 	if testing.Short() {
-		t.Skip()
-		return
+		t.SkipNow()
 	}
 
 	t.Helper()
@@ -189,8 +188,7 @@ func TestMaxDimInsert(t *testing.T) {
 // Test for investigation of max dimension size for agent handler with gRPC
 func TestMaxDimInsertGRPC(t *testing.T) {
 	if testing.Short() {
-		t.Skip()
-		return
+		t.SkipNow()
 	}
 
 	// MaxUint64 cannot be used due to overflows

--- a/tests/performance/max_vector_dim_test.go
+++ b/tests/performance/max_vector_dim_test.go
@@ -16,6 +16,7 @@ package performance
 import (
 	"bufio"
 	"context"
+	"flag"
 	"os"
 	"strconv"
 	"sync"
@@ -81,6 +82,7 @@ func parse(raw string) (key string, value int) {
 }
 
 func TestMain(m *testing.M) {
+	flag.Parse()
 	if testing.Short() {
 		log.Info("skipping this pkg test when -short because it takes a long time")
 		os.Exit(0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

This PR fixes coverage CI test error.

- Add short flag skip for performance test
- Stop sending coverage to deepsource since we're not using it right now

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.6
- Docker Version: 20.10.8
- Kubernetes Version: v1.27.3
- NGT Version: 2.0.16

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
