### PR TITLE
[CI]: Improve Chaos E2E test

### DIFF
--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -18,6 +18,10 @@ inputs:
     description: "If k3d is not required, set this to false"
     required: false
     default: "true"
+  ingress_port:
+    description: 'if it is not "0", ingress will be exposed to the specified port'
+    required: false
+    default: '0'
   target_images:
     description: "image names"
     required: false
@@ -73,6 +77,7 @@ runs:
       if: ${{ inputs.require_k3d == 'true' }}
       with:
         agents: 3
+        ingress_port: ${{ inputs.ingress_port }}
         options: "--image docker.io/rancher/k3s:latest"
 
     - name: Check Kubernetes cluster

--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -1,5 +1,5 @@
 name: "Setup E2E environment"
-description: 'Setup the environment to run E2E test'
+description: "Setup the environment to run E2E test"
 
 inputs:
   require_libhdf5:
@@ -21,7 +21,7 @@ inputs:
   ingress_port:
     description: 'if it is not "0", ingress will be exposed to the specified port'
     required: false
-    default: '0'
+    default: "0"
   target_images:
     description: "image names"
     required: false

--- a/.github/actions/setup-k3d/action.yaml
+++ b/.github/actions/setup-k3d/action.yaml
@@ -10,6 +10,10 @@ inputs:
     description: 'cluster name'
     required: false
     default: 'vald'
+  ingress_port:
+    description: 'if it is not "0", ingress will be exposed to the specified port'
+    required: false
+    default: '0'
   agents:
     description: 'number of agents'
     required: false
@@ -52,9 +56,13 @@ runs:
         if [ "${AGENTS}" != 0 ]; then
           OPTIONS="${OPTIONS} --agents ${AGENTS}"
         fi
+        if [ "${INGRESS_PORT}" != 0 ]; then
+          OPTIONS="${OPTIONS} -p ${INGRESS_PORT}:80@loadbalancer"
+        fi
         echo "options=${OPTIONS}" >> $GITHUB_OUTPUT
       env:
         AGENTS: ${{ inputs.agents }}
+        INGRESS_PORT: ${{ inputs.ingress_port }}
         OPTIONS: ${{ inputs.options }}
 
     - name: Create k8s cluster

--- a/.github/actions/setup-k3d/action.yaml
+++ b/.github/actions/setup-k3d/action.yaml
@@ -3,25 +3,25 @@ description: "GitHub Action for setting up k3d (k3s in Docker). It's lighter tha
 
 inputs:
   version:
-    description: 'k3d version'
+    description: "k3d version"
     required: false
-    default: 'latest'
+    default: "latest"
   name:
-    description: 'cluster name'
+    description: "cluster name"
     required: false
-    default: 'vald'
+    default: "vald"
   ingress_port:
     description: 'if it is not "0", ingress will be exposed to the specified port'
     required: false
-    default: '0'
+    default: "0"
   agents:
-    description: 'number of agents'
+    description: "number of agents"
     required: false
-    default: '3'
+    default: "3"
   options:
-    description: 'options for k3d cluster create command'
+    description: "options for k3d cluster create command"
     required: false
-    default: ''
+    default: ""
 
 runs:
   using: "composite"

--- a/.github/helm/values/values-chaos.yaml
+++ b/.github/helm/values/values-chaos.yaml
@@ -17,6 +17,7 @@
 defaults:
   grpc:
     client:
+      health_check_duration: 50ms
       dial_option:
         enable_backoff: true
   server_config:

--- a/.github/helm/values/values-chaos.yaml
+++ b/.github/helm/values/values-chaos.yaml
@@ -59,6 +59,7 @@ agent:
   persistentVolume:
     enabled: true
     storageClass: local-path
+    accessMode: ReadWriteOnce
     size: 200Mi
   hpa:
     enabled: false

--- a/.github/helm/values/values-chaos.yaml
+++ b/.github/helm/values/values-chaos.yaml
@@ -33,6 +33,13 @@ defaults:
 gateway:
   lb:
     enabled: true
+    ingress:
+      enabled: true
+      host: "localhost"
+    service:
+      # NOTE: https://doc.traefik.io/traefik/routing/providers/kubernetes-ingress/#on-service
+      annotations:
+        traefik.ingress.kubernetes.io/service.serversscheme: h2c
     minReplicas: 2
     hpa:
       enabled: false

--- a/.github/helm/values/values-chaos.yaml
+++ b/.github/helm/values/values-chaos.yaml
@@ -48,7 +48,7 @@ gateway:
         cpu: 100m
         memory: 50Mi
     gateway_config:
-      index_replica: 2
+      index_replica: 3
       discoverer:
         duration: 50ms
 

--- a/.github/helm/values/values-chaos.yaml
+++ b/.github/helm/values/values-chaos.yaml
@@ -56,6 +56,10 @@ agent:
   minReplicas: 5
   maxReplicas: 10
   podManagementPolicy: Parallel
+  persistentVolume:
+    enabled: true
+    storageClass: local-path
+    size: 200Mi
   hpa:
     enabled: false
   resources:
@@ -63,6 +67,8 @@ agent:
       cpu: 100m
       memory: 50Mi
   ngt:
+    index_path: "/var/ngt/index"
+    enable_in_memory_mode: false
     auto_index_duration_limit: 3m
     auto_index_check_duration: 1m
     auto_index_length: 1000

--- a/.github/helm/values/values-chaos.yaml
+++ b/.github/helm/values/values-chaos.yaml
@@ -49,6 +49,8 @@ gateway:
         memory: 50Mi
     gateway_config:
       index_replica: 2
+      discoverer:
+        duration: 50ms
 
 agent:
   minReplicas: 5
@@ -75,7 +77,7 @@ discoverer:
       cpu: 100m
       memory: 50Mi
   discoverer:
-    discovery_duration: 300ms
+    discovery_duration: 50ms
 
 manager:
   index:

--- a/.github/workflows/e2e-chaos.yaml
+++ b/.github/workflows/e2e-chaos.yaml
@@ -68,8 +68,8 @@ jobs:
           make E2E_BIND_PORT=8081 \
             E2E_DATASET_NAME=${DATASET} \
             E2E_TIMEOUT=15m \
-            E2E_INSERT_COUNT=10000 \
-            E2E_SEARCH_COUNT=10000 \
+            E2E_INSERT_COUNT=5000 \
+            E2E_SEARCH_COUNT=5000 \
             E2E_WAIT_FOR_CREATE_INDEX_DURATION=5m \
             E2E_TARGET_POD_NAME=${POD_NAME} \
             E2E_TARGET_NAMESPACE=default \
@@ -113,8 +113,8 @@ jobs:
           make E2E_BIND_PORT=8081 \
             E2E_DATASET_NAME=${DATASET} \
             E2E_TIMEOUT=15m \
-            E2E_INSERT_COUNT=10000 \
-            E2E_SEARCH_COUNT=10000 \
+            E2E_INSERT_COUNT=5000 \
+            E2E_SEARCH_COUNT=5000 \
             E2E_WAIT_FOR_CREATE_INDEX_DURATION=5m \
             E2E_TARGET_POD_NAME=${POD_NAME} \
             E2E_TARGET_NAMESPACE=default \
@@ -203,7 +203,7 @@ jobs:
           make E2E_BIND_PORT=8081 \
             E2E_DATASET_NAME=${DATASET} \
             E2E_TIMEOUT=15m \
-            E2E_INSERT_COUNT=10000 \
+            E2E_INSERT_COUNT=5000 \
             E2E_WAIT_FOR_CREATE_INDEX_DURATION=2m \
             E2E_TARGET_POD_NAME=${POD_NAME} \
             E2E_TARGET_NAMESPACE=default \
@@ -218,7 +218,7 @@ jobs:
           make E2E_BIND_PORT=8081 \
             E2E_DATASET_NAME=${DATASET} \
             E2E_TIMEOUT=15m \
-            E2E_SEARCH_COUNT=10000 \
+            E2E_SEARCH_COUNT=5000 \
             E2E_WAIT_FOR_CREATE_INDEX_DURATION=2m \
             E2E_TARGET_POD_NAME=${POD_NAME} \
             E2E_TARGET_NAMESPACE=default \

--- a/.github/workflows/e2e-chaos.yaml
+++ b/.github/workflows/e2e-chaos.yaml
@@ -48,6 +48,8 @@ jobs:
       - name: Setup E2E environment
         id: setup_e2e
         uses: ./.github/actions/setup-e2e
+        with:
+          ingress_port: 8081
 
       - name: Deploy Vald
         id: deploy_vald
@@ -65,7 +67,9 @@ jobs:
       - name: Run Insert and Search operations
         run: |
           make hack/benchmark/assets/dataset/${DATASET}
-          make E2E_BIND_PORT=8081 \
+          make E2E_BIND_HOST=localhost \
+            E2E_BIND_PORT=8081 \
+            E2E_PORTFORWARD_ENABLED=false \
             E2E_DATASET_NAME=${DATASET} \
             E2E_TIMEOUT=15m \
             E2E_INSERT_COUNT=5000 \
@@ -93,6 +97,8 @@ jobs:
       - name: Setup E2E environment
         id: setup_e2e
         uses: ./.github/actions/setup-e2e
+        with:
+          ingress_port: 8081
 
       - name: Deploy Vald
         id: deploy_vald
@@ -110,7 +116,9 @@ jobs:
       - name: Run Insert and Search operations
         run: |
           make hack/benchmark/assets/dataset/${DATASET}
-          make E2E_BIND_PORT=8081 \
+          make E2E_BIND_HOST=localhost \
+            E2E_BIND_PORT=8081 \
+            E2E_PORTFORWARD_ENABLED=false \
             E2E_DATASET_NAME=${DATASET} \
             E2E_TIMEOUT=15m \
             E2E_INSERT_COUNT=5000 \
@@ -138,6 +146,8 @@ jobs:
       - name: Setup E2E environment
         id: setup_e2e
         uses: ./.github/actions/setup-e2e
+        with:
+          ingress_port: 8081
 
       - name: Deploy Vald
         id: deploy_vald
@@ -155,7 +165,9 @@ jobs:
       - name: Run Insert and Search operations
         run: |
           make hack/benchmark/assets/dataset/${DATASET}
-          make E2E_BIND_PORT=8081 \
+          make E2E_BIND_HOST=localhost \
+            E2E_BIND_PORT=8081 \
+            E2E_PORTFORWARD_ENABLED=false \
             E2E_DATASET_NAME=${DATASET} \
             E2E_TIMEOUT=15m \
             E2E_INSERT_COUNT=10000 \
@@ -183,6 +195,8 @@ jobs:
       - name: Setup E2E environment
         id: setup_e2e
         uses: ./.github/actions/setup-e2e
+        with:
+          ingress_port: 8081
 
       - name: Deploy Vald
         id: deploy_vald
@@ -200,7 +214,9 @@ jobs:
       - name: Run Insert operations
         run: |
           make hack/benchmark/assets/dataset/${DATASET}
-          make E2E_BIND_PORT=8081 \
+          make E2E_BIND_HOST=localhost \
+            E2E_BIND_PORT=8081 \
+            E2E_PORTFORWARD_ENABLED=false \
             E2E_DATASET_NAME=${DATASET} \
             E2E_TIMEOUT=15m \
             E2E_INSERT_COUNT=5000 \
@@ -215,7 +231,9 @@ jobs:
       - name: Run Search operations
         run: |
           make hack/benchmark/assets/dataset/${DATASET}
-          make E2E_BIND_PORT=8081 \
+          make E2E_BIND_HOST=localhost \
+            E2E_BIND_PORT=8081 \
+            E2E_PORTFORWARD_ENABLED=false \
             E2E_DATASET_NAME=${DATASET} \
             E2E_TIMEOUT=15m \
             E2E_SEARCH_COUNT=5000 \

--- a/.github/workflows/e2e-chaos.yaml
+++ b/.github/workflows/e2e-chaos.yaml
@@ -211,7 +211,7 @@ jobs:
         with:
           helm_extra_options: "--set networkChaos.bandwidth.enabled=true"
 
-      - name: Run Insert operations
+      - name: Run Insert and Search operations
         run: |
           make hack/benchmark/assets/dataset/${DATASET}
           make E2E_BIND_HOST=localhost \
@@ -220,27 +220,10 @@ jobs:
             E2E_DATASET_NAME=${DATASET} \
             E2E_TIMEOUT=15m \
             E2E_INSERT_COUNT=5000 \
-            E2E_WAIT_FOR_CREATE_INDEX_DURATION=2m \
+            E2E_WAIT_FOR_CREATE_INDEX_DURATION=5m \
             E2E_TARGET_POD_NAME=${POD_NAME} \
             E2E_TARGET_NAMESPACE=default \
-            e2e/insert
-        env:
-          DATASET: fashion-mnist-784-euclidean.hdf5
-          POD_NAME: ${{ steps.deploy_vald.outputs.POD_NAME }}
-
-      - name: Run Search operations
-        run: |
-          make hack/benchmark/assets/dataset/${DATASET}
-          make E2E_BIND_HOST=localhost \
-            E2E_BIND_PORT=8081 \
-            E2E_PORTFORWARD_ENABLED=false \
-            E2E_DATASET_NAME=${DATASET} \
-            E2E_TIMEOUT=15m \
-            E2E_SEARCH_COUNT=5000 \
-            E2E_WAIT_FOR_CREATE_INDEX_DURATION=2m \
-            E2E_TARGET_POD_NAME=${POD_NAME} \
-            E2E_TARGET_NAMESPACE=default \
-            e2e/search
+            e2e/insert/search
         env:
           DATASET: fashion-mnist-784-euclidean.hdf5
           POD_NAME: ${{ steps.deploy_vald.outputs.POD_NAME }}

--- a/.github/workflows/e2e-chaos.yaml
+++ b/.github/workflows/e2e-chaos.yaml
@@ -25,6 +25,10 @@ on:
     types:
       - "labeled"
 
+env:
+  VALUES: .github/helm/values/values-chaos.yaml
+  DATASET: fashion-mnist-784-euclidean.hdf5
+
 jobs:
   dump-contexts-to-log:
     if: startsWith( github.ref, 'refs/tags/') || github.event.action == 'labeled' && github.event.label.name == 'actions/e2e-chaos'
@@ -56,7 +60,7 @@ jobs:
         uses: ./.github/actions/e2e-deploy-vald
         with:
           helm_extra_options: ${{ steps.setup_e2e.outputs.HELM_EXTRA_OPTIONS }}
-          values: .github/helm/values/values-chaos.yaml
+          values: ${{ env.VALUES }}
           wait_for_selector: app=vald-lb-gateway
 
       - name: Deploy Chaos Mesh
@@ -66,21 +70,16 @@ jobs:
 
       - name: Run Insert and Search operations
         run: |
-          make hack/benchmark/assets/dataset/${DATASET}
+          make hack/benchmark/assets/dataset/${{ env.DATASET }}
           make E2E_BIND_HOST=localhost \
             E2E_BIND_PORT=8081 \
             E2E_PORTFORWARD_ENABLED=false \
-            E2E_DATASET_NAME=${DATASET} \
+            E2E_DATASET_NAME=${{ env.DATASET }} \
             E2E_TIMEOUT=15m \
             E2E_INSERT_COUNT=5000 \
             E2E_SEARCH_COUNT=5000 \
             E2E_WAIT_FOR_CREATE_INDEX_DURATION=5m \
-            E2E_TARGET_POD_NAME=${POD_NAME} \
-            E2E_TARGET_NAMESPACE=default \
             e2e/insert/search
-        env:
-          DATASET: fashion-mnist-784-euclidean.hdf5
-          POD_NAME: ${{ steps.deploy_vald.outputs.POD_NAME }}
 
   random-pod-failure:
     name: "E2E chaos test (random Pod failure: to test redundancy)"
@@ -105,7 +104,7 @@ jobs:
         uses: ./.github/actions/e2e-deploy-vald
         with:
           helm_extra_options: ${{ steps.setup_e2e.outputs.HELM_EXTRA_OPTIONS }}
-          values: .github/helm/values/values-chaos.yaml
+          values: ${{ env.VALUES }}
           wait_for_selector: app=vald-lb-gateway
 
       - name: Deploy Chaos Mesh
@@ -115,21 +114,16 @@ jobs:
 
       - name: Run Insert and Search operations
         run: |
-          make hack/benchmark/assets/dataset/${DATASET}
+          make hack/benchmark/assets/dataset/${{ env.DATASET }}
           make E2E_BIND_HOST=localhost \
             E2E_BIND_PORT=8081 \
             E2E_PORTFORWARD_ENABLED=false \
-            E2E_DATASET_NAME=${DATASET} \
+            E2E_DATASET_NAME=${{ env.DATASET }} \
             E2E_TIMEOUT=15m \
             E2E_INSERT_COUNT=5000 \
             E2E_SEARCH_COUNT=5000 \
             E2E_WAIT_FOR_CREATE_INDEX_DURATION=5m \
-            E2E_TARGET_POD_NAME=${POD_NAME} \
-            E2E_TARGET_NAMESPACE=default \
             e2e/insert/search
-        env:
-          DATASET: fashion-mnist-784-euclidean.hdf5
-          POD_NAME: ${{ steps.deploy_vald.outputs.POD_NAME }}
 
   agent-network-partition:
     name: "E2E chaos test (agent network partition: to test retries)"
@@ -154,7 +148,7 @@ jobs:
         uses: ./.github/actions/e2e-deploy-vald
         with:
           helm_extra_options: ${{ steps.setup_e2e.outputs.HELM_EXTRA_OPTIONS }}
-          values: .github/helm/values/values-chaos.yaml
+          values: ${{ env.VALUES }}
           wait_for_selector: app=vald-lb-gateway
 
       - name: Deploy Chaos Mesh
@@ -164,21 +158,16 @@ jobs:
 
       - name: Run Insert and Search operations
         run: |
-          make hack/benchmark/assets/dataset/${DATASET}
+          make hack/benchmark/assets/dataset/${{ env.DATASET }}
           make E2E_BIND_HOST=localhost \
             E2E_BIND_PORT=8081 \
             E2E_PORTFORWARD_ENABLED=false \
-            E2E_DATASET_NAME=${DATASET} \
+            E2E_DATASET_NAME=${{ env.DATASET }} \
             E2E_TIMEOUT=15m \
             E2E_INSERT_COUNT=10000 \
             E2E_SEARCH_COUNT=10000 \
             E2E_WAIT_FOR_CREATE_INDEX_DURATION=2m \
-            E2E_TARGET_POD_NAME=${POD_NAME} \
-            E2E_TARGET_NAMESPACE=default \
             e2e/insert/search
-        env:
-          DATASET: fashion-mnist-784-euclidean.hdf5
-          POD_NAME: ${{ steps.deploy_vald.outputs.POD_NAME }}
 
   clusterwide-network-bandwidth:
     name: "E2E chaos test (network bandwidth: to test it works properly under bandwidth limitation)"
@@ -203,7 +192,7 @@ jobs:
         uses: ./.github/actions/e2e-deploy-vald
         with:
           helm_extra_options: ${{ steps.setup_e2e.outputs.HELM_EXTRA_OPTIONS }}
-          values: .github/helm/values/values-chaos.yaml
+          values: ${{ env.VALUES }}
           wait_for_selector: app=vald-lb-gateway
 
       - name: Deploy Chaos Mesh
@@ -213,20 +202,15 @@ jobs:
 
       - name: Run Insert and Search operations
         run: |
-          make hack/benchmark/assets/dataset/${DATASET}
+          make hack/benchmark/assets/dataset/${{ env.DATASET }}
           make E2E_BIND_HOST=localhost \
             E2E_BIND_PORT=8081 \
             E2E_PORTFORWARD_ENABLED=false \
-            E2E_DATASET_NAME=${DATASET} \
+            E2E_DATASET_NAME=${{ env.DATASET }} \
             E2E_TIMEOUT=15m \
             E2E_INSERT_COUNT=5000 \
             E2E_WAIT_FOR_CREATE_INDEX_DURATION=5m \
-            E2E_TARGET_POD_NAME=${POD_NAME} \
-            E2E_TARGET_NAMESPACE=default \
             e2e/insert/search
-        env:
-          DATASET: fashion-mnist-784-euclidean.hdf5
-          POD_NAME: ${{ steps.deploy_vald.outputs.POD_NAME }}
 
   slack-notification:
     name: "Slack notification"

--- a/.github/workflows/e2e-chaos.yaml
+++ b/.github/workflows/e2e-chaos.yaml
@@ -28,6 +28,7 @@ on:
 env:
   VALUES: .github/helm/values/values-chaos.yaml
   DATASET: fashion-mnist-784-euclidean.hdf5
+  INGRESS_PORT: 8081
 
 jobs:
   dump-contexts-to-log:
@@ -53,7 +54,7 @@ jobs:
         id: setup_e2e
         uses: ./.github/actions/setup-e2e
         with:
-          ingress_port: 8081
+          ingress_port: ${{ env.INGRESS_PORT }}
 
       - name: Deploy Vald
         id: deploy_vald
@@ -97,7 +98,7 @@ jobs:
         id: setup_e2e
         uses: ./.github/actions/setup-e2e
         with:
-          ingress_port: 8081
+          ingress_port: ${{ env.INGRESS_PORT }}
 
       - name: Deploy Vald
         id: deploy_vald
@@ -141,7 +142,7 @@ jobs:
         id: setup_e2e
         uses: ./.github/actions/setup-e2e
         with:
-          ingress_port: 8081
+          ingress_port: ${{ env.INGRESS_PORT }}
 
       - name: Deploy Vald
         id: deploy_vald
@@ -185,7 +186,7 @@ jobs:
         id: setup_e2e
         uses: ./.github/actions/setup-e2e
         with:
-          ingress_port: 8081
+          ingress_port: ${{ env.INGRESS_PORT }}
 
       - name: Deploy Vald
         id: deploy_vald

--- a/.github/workflows/e2e-chaos.yaml
+++ b/.github/workflows/e2e-chaos.yaml
@@ -203,7 +203,7 @@ jobs:
         uses: ./.github/actions/e2e-deploy-vald
         with:
           helm_extra_options: ${{ steps.setup_e2e.outputs.HELM_EXTRA_OPTIONS }}
-          values: .github/helm/values/values-lb.yaml
+          values: .github/helm/values/values-chaos.yaml
           wait_for_selector: app=vald-lb-gateway
 
       - name: Deploy Chaos Mesh

--- a/.github/workflows/e2e-code-bench-agent.yaml
+++ b/.github/workflows/e2e-code-bench-agent.yaml
@@ -42,6 +42,10 @@ on:
       - "versions/GO_VERSION"
       - "versions/NGT_VERSION"
 
+env:
+  DATASET: fashion-mnist-784-euclidean.hdf5
+  DATASET_ARGS: fashion-mnist
+
 jobs:
   dump-contexts-to-log:
     runs-on: ubuntu-latest
@@ -65,11 +69,8 @@ jobs:
 
       - name: Run grpc-sequential
         run: |
-          make hack/benchmark/assets/dataset/${DATASET}
-          DATASET_ARGS=${DATASET_ARGS} make bench/agent/sequential/grpc
-        env:
-          DATASET: fashion-mnist-784-euclidean.hdf5
-          DATASET_ARGS: fashion-mnist
+          make hack/benchmark/assets/dataset/${{ env.DATASET }}
+          DATASET_ARGS=${{ env.DATASET_ARGS }} make bench/agent/sequential/grpc
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -99,11 +100,8 @@ jobs:
 
       - name: Run grpc-stream
         run: |
-          make hack/benchmark/assets/dataset/${DATASET}
-          DATASET_ARGS=${DATASET_ARGS} make bench/agent/stream
-        env:
-          DATASET: fashion-mnist-784-euclidean.hdf5
-          DATASET_ARGS: fashion-mnist
+          make hack/benchmark/assets/dataset/${{ env.DATASET }}
+          DATASET_ARGS=${{ env.DATASET_ARGS }} make bench/agent/stream
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -63,7 +63,7 @@ jobs:
             E2E_DATASET_NAME=${DATASET} \
             E2E_INSERT_COUNT=5000 \
             E2E_SEARCH_COUNT=10000 \
-            E2E_SEARCH_BY_ID_COUNT=10000 \
+            E2E_SEARCH_BY_ID_COUNT=5000 \
             E2E_GET_OBJECT_COUNT=100 \
             E2E_UPDATE_COUNT=100 \
             E2E_UPSERT_COUNT=100 \

--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -61,7 +61,7 @@ jobs:
           make hack/benchmark/assets/dataset/${DATASET}
           make E2E_BIND_PORT=8081 \
             E2E_DATASET_NAME=${DATASET} \
-            E2E_INSERT_COUNT=10000 \
+            E2E_INSERT_COUNT=5000 \
             E2E_SEARCH_COUNT=10000 \
             E2E_SEARCH_BY_ID_COUNT=10000 \
             E2E_GET_OBJECT_COUNT=100 \
@@ -129,9 +129,9 @@ jobs:
           make hack/benchmark/assets/dataset/${DATASET}
           make E2E_BIND_PORT=8081 \
             E2E_DATASET_NAME=${DATASET} \
-            E2E_INSERT_COUNT=10000 \
-            E2E_SEARCH_COUNT=10000 \
-            E2E_SEARCH_BY_ID_COUNT=10000 \
+            E2E_INSERT_COUNT=5000 \
+            E2E_SEARCH_COUNT=5000 \
+            E2E_SEARCH_BY_ID_COUNT=5000 \
             E2E_GET_OBJECT_COUNT=100 \
             E2E_UPDATE_COUNT=100 \
             E2E_UPSERT_COUNT=100 \
@@ -261,7 +261,7 @@ jobs:
           make hack/benchmark/assets/dataset/${DATASET}
           make E2E_BIND_PORT=8081 \
             E2E_DATASET_NAME=${DATASET} \
-            E2E_INSERT_COUNT=10000 \
+            E2E_INSERT_COUNT=5000 \
             E2E_SEARCH_COUNT=4000 \
             E2E_WAIT_FOR_CREATE_INDEX_DURATION=8m \
             E2E_TARGET_POD_NAME=${POD_NAME} \

--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -24,6 +24,9 @@ on:
   pull_request:
     types:
       - "labeled"
+env:
+  DATASET: fashion-mnist-784-euclidean.hdf5
+
 jobs:
   dump-contexts-to-log:
     if: startsWith( github.ref, 'refs/tags/') || github.event.action == 'labeled' && github.event.label.name == 'actions/e2e-deploy'
@@ -58,9 +61,9 @@ jobs:
 
       - name: Run E2E CRUD
         run: |
-          make hack/benchmark/assets/dataset/${DATASET}
+          make hack/benchmark/assets/dataset/${{ env.DATASET }}
           make E2E_BIND_PORT=8081 \
-            E2E_DATASET_NAME=${DATASET} \
+            E2E_DATASET_NAME=${{ env.DATASET }} \
             E2E_INSERT_COUNT=5000 \
             E2E_SEARCH_COUNT=10000 \
             E2E_SEARCH_BY_ID_COUNT=5000 \
@@ -73,7 +76,6 @@ jobs:
             E2E_TARGET_NAMESPACE=default \
             e2e
         env:
-          DATASET: fashion-mnist-784-euclidean.hdf5
           POD_NAME: ${{ steps.deploy_vald.outputs.POD_NAME }}
 
   e2e-stream-crud-for-operator:
@@ -126,9 +128,9 @@ jobs:
 
       - name: Run E2E CRUD
         run: |
-          make hack/benchmark/assets/dataset/${DATASET}
+          make hack/benchmark/assets/dataset/${{ env.DATASET }}
           make E2E_BIND_PORT=8081 \
-            E2E_DATASET_NAME=${DATASET} \
+            E2E_DATASET_NAME=${{ env.DATASET }} \
             E2E_INSERT_COUNT=5000 \
             E2E_SEARCH_COUNT=5000 \
             E2E_SEARCH_BY_ID_COUNT=5000 \
@@ -141,7 +143,6 @@ jobs:
             E2E_TARGET_NAMESPACE=default \
             e2e
         env:
-          DATASET: fashion-mnist-784-euclidean.hdf5
           POD_NAME: ${{ steps.deploy_vald.outputs.POD_NAME }}
 
   e2e-stream-crud-skip-exist-check:
@@ -170,9 +171,9 @@ jobs:
 
       - name: Run E2E CRUD
         run: |
-          make hack/benchmark/assets/dataset/${DATASET}
+          make hack/benchmark/assets/dataset/${{ env.DATASET }}
           make E2E_BIND_PORT=8081 \
-            E2E_DATASET_NAME=${DATASET} \
+            E2E_DATASET_NAME=${{ env.DATASET }} \
             E2E_INSERT_COUNT=10 \
             E2E_SEARCH_COUNT=10 \
             E2E_SEARCH_BY_ID_COUNT=10 \
@@ -185,7 +186,6 @@ jobs:
             E2E_TARGET_NAMESPACE=default \
             e2e/skip
         env:
-          DATASET: fashion-mnist-784-euclidean.hdf5
           POD_NAME: ${{ steps.deploy_vald.outputs.POD_NAME }}
 
   e2e-multiapis-crud:
@@ -214,9 +214,9 @@ jobs:
 
       - name: Run E2E CRUD
         run: |
-          make hack/benchmark/assets/dataset/${DATASET}
+          make hack/benchmark/assets/dataset/${{ env.DATASET }}
           make E2E_BIND_PORT=8081 \
-            E2E_DATASET_NAME=${DATASET} \
+            E2E_DATASET_NAME=${{ env.DATASET }} \
             E2E_INSERT_COUNT=100 \
             E2E_SEARCH_COUNT=10 \
             E2E_SEARCH_BY_ID_COUNT=10 \
@@ -225,7 +225,6 @@ jobs:
             E2E_TARGET_NAMESPACE=default \
             e2e/multi
         env:
-          DATASET: fashion-mnist-784-euclidean.hdf5
           POD_NAME: ${{ steps.deploy_vald.outputs.POD_NAME }}
 
   e2e-agent-and-sidecar:
@@ -258,9 +257,9 @@ jobs:
 
       - name: Run E2E Agent & Sidecar
         run: |
-          make hack/benchmark/assets/dataset/${DATASET}
+          make hack/benchmark/assets/dataset/${{ env.DATASET }}
           make E2E_BIND_PORT=8081 \
-            E2E_DATASET_NAME=${DATASET} \
+            E2E_DATASET_NAME=${{ env.DATASET }} \
             E2E_INSERT_COUNT=5000 \
             E2E_SEARCH_COUNT=4000 \
             E2E_WAIT_FOR_CREATE_INDEX_DURATION=8m \
@@ -268,7 +267,6 @@ jobs:
             E2E_TARGET_NAMESPACE=default \
             e2e/sidecar
         env:
-          DATASET: fashion-mnist-784-euclidean.hdf5
           POD_NAME: ${{ steps.deploy_vald.outputs.POD_NAME }}
 
   slack-notification:

--- a/.github/workflows/e2e-profiling.yml
+++ b/.github/workflows/e2e-profiling.yml
@@ -25,6 +25,9 @@ on:
     types:
       - "labeled"
 
+env:
+  DATASET: fashion-mnist-784-euclidean.hdf5
+
 jobs:
   dump-contexts-to-log:
     if: startsWith( github.ref, 'refs/tags/') || github.event.action == 'labeled' && github.event.label.name == 'actions/e2e-profiling'
@@ -66,9 +69,9 @@ jobs:
       - name: Run E2E CRUD
         continue-on-error: true
         run: |
-          make hack/benchmark/assets/dataset/${DATASET}
+          make hack/benchmark/assets/dataset/${{ env.DATASET }}
           make E2E_BIND_PORT=8081 \
-            E2E_DATASET_NAME=${DATASET} \
+            E2E_DATASET_NAME=${{ env.DATASET }} \
             E2E_INSERT_COUNT=10000 \
             E2E_SEARCH_COUNT=100 \
             E2E_SEARCH_BY_ID_COUNT=100 \
@@ -81,7 +84,6 @@ jobs:
             E2E_TARGET_NAMESPACE=default \
             e2e
         env:
-          DATASET: fashion-mnist-784-euclidean.hdf5
           POD_NAME: ${{ steps.deploy_vald.outputs.POD_NAME }}
 
       - name: Get profiles


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR contains the following changes

- Execute chaos test via k8s ingress
- Enable Persistent volume to prevent index data loss
- Reduce the number of insert vector ( 10000 -> 5000)
- Improve gRPC client configurations for pod kill chaos scenario

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.20.6
- Docker Version: 20.10.8
- Kubernetes Version: v1.27.3
- NGT Version: 2.0.16

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
