### PR TITLE
Fix duplicate make command

### DIFF
--- a/Makefile.d/e2e.mk
+++ b/Makefile.d/e2e.mk
@@ -61,7 +61,7 @@ e2e/remove:
 
 .PHONY: e2e/remove/timestamp
 ## run removeByTimestamp e2e
-e2e/remove:
+e2e/remove/timestamp:
 	$(call run-e2e-crud-test,-run TestE2ERemoveByTimestampOnly)
 
 .PHONY: e2e/insert/search


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

I fixed a duplicate make command declaration.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.0
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.1
- NGT Version: 2.1.3

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
