### PR TITLE
Returns all connection information in the registration rpc

### DIFF
--- a/charts/vald/templates/gateway/mirror/configmap.yaml
+++ b/charts/vald/templates/gateway/mirror/configmap.yaml
@@ -43,7 +43,7 @@ data:
       {{- include "vald.observability" $observability | nindent 6 }}
     gateway:
       pod_name: {{ $gateway.gateway_config.pod_name }}
-      advertise_interval: {{ $gateway.gateway_config.advertise_interval }}
+      register_duration: {{ $gateway.gateway_config.register_duration }}
       namespace: {{ $gateway.gateway_config.namespace }}
       discovery_duration: {{ $gateway.gateway_config.discovery_duration }}
       colocation: {{ $gateway.gateway_config.colocation }}

--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -1716,9 +1716,9 @@ gateway:
       # @schema {"name": "gateway.mirror.gateway_config.pod_name", "type": "string"}
       # gateway.mirror.gateway_config.pod_name -- self mirror gateway pod name
       pod_name: _MY_POD_NAME_
-      # @schema {"name": "gateway.mirror.gateway_config.advertise_interval", "type": "string"}
-      # gateway.mirror.gateway_config.advertise_interval -- interval to advertise mirror-gateway information to other mirror-gateway.
-      advertise_interval: "1s"
+      # @schema {"name": "gateway.mirror.gateway_config.register_duration", "type": "string"}
+      # gateway.mirror.gateway_config.register_duration -- duration to register mirror-gateway.
+      register_duration: "1s"
       # @schema {"name": "gateway.mirror.gateway_config.namespace", "type": "string"}
       # gateway.mirror.gateway_config.namespace -- namespace to discovery
       namespace: _MY_POD_NAMESPACE_

--- a/internal/config/mirror.go
+++ b/internal/config/mirror.go
@@ -25,8 +25,8 @@ type Mirror struct {
 	GatewayAddr string `json:"gateway_addr"       yaml:"gateway_addr"`
 	// PodName represents the mirror gateway pod name.
 	PodName string `json:"pod_name"           yaml:"pod_name"`
-	// AdvertiseInterval represents the interval to advertise addresses of Mirror Gateway to other Mirror Gateway.
-	AdvertiseInterval string `json:"advertise_interval" yaml:"advertise_interval"`
+	// RegisterDuration represents the duration to register Mirror Gateway.
+	RegisterDuration string `json:"register_duration" yaml:"register_duration"`
 	// Namespace represents the target namespace to discover ValdMirrorTarget resource.
 	Namespace string `json:"namespace"          yaml:"namespace"`
 	// DiscoveryDuration represents the duration to discover.
@@ -43,7 +43,7 @@ func (m *Mirror) Bind() *Mirror {
 	m.SelfMirrorAddr = GetActualValue(m.SelfMirrorAddr)
 	m.GatewayAddr = GetActualValue(m.GatewayAddr)
 	m.PodName = GetActualValue(m.PodName)
-	m.AdvertiseInterval = GetActualValue(m.AdvertiseInterval)
+	m.RegisterDuration = GetActualValue(m.RegisterDuration)
 	m.Namespace = GetActualValue(m.Namespace)
 	m.DiscoveryDuration = GetActualValue(m.DiscoveryDuration)
 	m.Colocation = GetActualValue(m.Colocation)

--- a/pkg/gateway/mirror/handler/grpc/handler.go
+++ b/pkg/gateway/mirror/handler/grpc/handler.go
@@ -119,19 +119,11 @@ func (s *server) Register(ctx context.Context, req *payload.Mirror_Targets) (*pa
 		}
 		return nil, err
 	}
-	return req, nil
-}
 
-func (s *server) Advertise(ctx context.Context, req *payload.Mirror_Targets) (res *payload.Mirror_Targets, err error) {
-	ctx, span := trace.StartSpan(grpc.WithGRPCMethod(ctx, vald.PackageName+"."+vald.MirrorRPCServiceName+"/"+vald.AdvertiseRPCName), apiName+"/"+vald.AdvertiseRPCName)
-	defer func() {
-		if span != nil {
-			span.End()
-		}
-	}()
+	// Get own address and the addresses of other mirror gateways to which this gateway is currently connected.
 	tgts, err := s.mirror.MirrorTargets()
 	if err != nil {
-		err = status.WrapWithInternal(vald.AdvertiseRPCName+" API failed to get connected vald gateway targets", err,
+		err = status.WrapWithInternal(vald.RegisterRPCName+" API failed to get connected vald gateway targets", err,
 			&errdetails.BadRequest{
 				FieldViolations: []*errdetails.BadRequestFieldViolation{
 					{
@@ -141,7 +133,7 @@ func (s *server) Advertise(ctx context.Context, req *payload.Mirror_Targets) (re
 				},
 			},
 			&errdetails.ResourceInfo{
-				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.AdvertiseRPCName,
+				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RegisterRPCName,
 				ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
 			},
 		)

--- a/pkg/gateway/mirror/service/mirror.go
+++ b/pkg/gateway/mirror/service/mirror.go
@@ -50,7 +50,7 @@ type mirr struct {
 	selfMirrAddrl sync.Map[string, any]    // List of self Mirror gateway addresses
 	gwAddrl       sync.Map[string, any]    // List of Vald Gateway addresses
 	eg            errgroup.Group
-	advertiseDur  time.Duration
+	registerDur   time.Duration
 	gateway       Gateway
 }
 
@@ -97,8 +97,7 @@ func (m *mirr) Start(ctx context.Context) <-chan error {
 	ech := make(chan error, 100)
 
 	m.eg.Go(func() error {
-		// TODO: change variable names.
-		tic := time.NewTicker(m.advertiseDur)
+		tic := time.NewTicker(m.registerDur)
 		defer close(ech)
 		defer tic.Stop()
 

--- a/pkg/gateway/mirror/service/mirror_option.go
+++ b/pkg/gateway/mirror/service/mirror_option.go
@@ -23,7 +23,7 @@ import (
 type MirrorOption func(m *mirr) error
 
 var defaultMirrOpts = []MirrorOption{
-	WithAdvertiseInterval("1s"),
+	WithRegisterDuration("1s"),
 }
 
 func WithErrorGroup(eg errgroup.Group) MirrorOption {
@@ -68,16 +68,16 @@ func WithGateway(g Gateway) MirrorOption {
 	}
 }
 
-func WithAdvertiseInterval(s string) MirrorOption {
+func WithRegisterDuration(s string) MirrorOption {
 	return func(m *mirr) error {
 		if len(s) == 0 {
-			return errors.NewErrInvalidOption("advertiseInterval", s)
+			return errors.NewErrInvalidOption("registerDuration", s)
 		}
 		dur, err := time.ParseDuration(s)
 		if err != nil {
-			return errors.NewErrInvalidOption("advertiseInterval", s, err)
+			return errors.NewErrInvalidOption("registerDuration", s, err)
 		}
-		m.advertiseDur = dur
+		m.registerDur = dur
 		return nil
 	}
 }

--- a/pkg/gateway/mirror/usecase/vald.go
+++ b/pkg/gateway/mirror/usecase/vald.go
@@ -83,7 +83,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	}
 	mirr, err := service.NewMirror(
 		service.WithErrorGroup(eg),
-		service.WithAdvertiseInterval(cfg.Mirror.AdvertiseInterval),
+		service.WithRegisterDuration(cfg.Mirror.RegisterDuration),
 		service.WithValdAddrs(cfg.Mirror.GatewayAddr),
 		service.WithSelfMirrorAddrs(cfg.Mirror.SelfMirrorAddr),
 		service.WithGateway(gw),

--- a/pkg/gateway/mirror/usecase/vald.go
+++ b/pkg/gateway/mirror/usecase/vald.go
@@ -198,11 +198,7 @@ func (r *run) Start(ctx context.Context) (<-chan error, error) {
 		}
 	}
 	if r.mirr != nil {
-		mech, err = r.mirr.Start(ctx)
-		if err != nil {
-			close(ech)
-			return nil, err
-		}
+		mech = r.mirr.Start(ctx)
 	}
 	if r.dsc != nil {
 		dech, err = r.dsc.Start(ctx)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

I have integrated the `Advertise` logic into the `RegisterAPI`. With that, I have removed unnecessary parameters.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.1
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.2
- NGT Version: 2.1.3

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
