### PR TITLE
Add handler logic to continue processing

### DIFF
--- a/pkg/gateway/mirror/handler/grpc/handler.go
+++ b/pkg/gateway/mirror/handler/grpc/handler.go
@@ -946,56 +946,31 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (loc *
 	// When this condition is matched, the request is proxied to another Mirror gateway.
 	// So this component sends requests only to the Vald gateway (LB gateway) of its own cluster.
 	if len(reqSrcPodName) != 0 {
-		_, err = s.gateway.Do(ctx, s.vAddr, func(ctx context.Context, vc vald.ClientWithMirror, copts ...grpc.CallOption) (interface{}, error) {
-			loc, err = vc.Insert(ctx, req, copts...)
-			return loc, err
-		})
+		loc, err = s.doInsert(ctx, req,
+			func(ctx context.Context) (*payload.Object_Location, error) {
+				s.gateway.Do(ctx, s.vAddr, func(ctx context.Context, vc vald.ClientWithMirror, copts ...grpc.CallOption) (interface{}, error) {
+					loc, err = vc.Insert(ctx, req, copts...)
+					return loc, err
+				})
+				return loc, err
+			},
+		)
 		if err != nil {
 			reqInfo := &errdetails.RequestInfo{
-				RequestId:   req.GetVector().GetId(),
-				ServingData: errdetails.Serialize(req),
+				RequestId: req.GetVector().GetId(),
 			}
 			resInfo := &errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertRPCName,
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, s.vAddr),
 			}
-			var attrs trace.Attributes
+			st, msg, err := status.ParseError(err, codes.Internal,
+				"failed to parse "+vald.InsertRPCName+" gRPC error response", reqInfo, resInfo,
+			)
 
-			switch {
-			case errors.Is(err, context.Canceled):
-				err = status.WrapWithCanceled(
-					vald.InsertRPCName+" API canceld", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeCancelled(err.Error())
-			case errors.Is(err, context.DeadlineExceeded):
-				err = status.WrapWithDeadlineExceeded(
-					vald.InsertRPCName+" API deadline exceeded", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeDeadlineExceeded(err.Error())
-			case errors.Is(err, errors.ErrTargetNotFound):
-				err = status.WrapWithInternal(
-					vald.InsertRPCName+" API target not found", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeInternal(err.Error())
-			case errors.Is(err, errors.ErrGRPCClientConnNotFound("*")):
-				err = status.WrapWithInternal(
-					vald.InsertRPCName+" API connection not found", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeInternal(err.Error())
-			default:
-				var (
-					st  *status.Status
-					msg string
-				)
-				st, msg, err = status.ParseError(err, codes.Internal,
-					"failed to parse "+vald.InsertRPCName+" gRPC error response", reqInfo, resInfo,
-				)
-				attrs = trace.FromGRPCStatus(st.Code(), msg)
-			}
 			log.Warn(err)
 			if span != nil {
 				span.RecordError(err)
-				span.SetAttributes(attrs...)
+				span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
 				span.SetStatus(trace.StatusError, err.Error())
 			}
 			return nil, err
@@ -1005,7 +980,7 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (loc *
 	}
 
 	var mu sync.Mutex
-	var result sync.Map[string, error]
+	var result sync.Map[string, *errorState] // map[target: errorState]
 	loc = &payload.Object_Location{
 		Uuid: req.GetVector().GetId(),
 		Ips:  make([]string, 0),
@@ -1018,23 +993,32 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (loc *
 			}
 		}()
 
-		ce, err := s.insert(ctx, vc, req, copts...)
+		code := codes.OK
+		ce, err := s.doInsert(ctx, req, func(ctx context.Context) (*payload.Object_Location, error) {
+			return vc.Insert(ctx, req, copts...)
+		})
 		if err != nil {
-			st, _, _ := status.ParseError(err, codes.Internal,
+			var (
+				st  *status.Status
+				msg string
+			)
+			st, msg, err = status.ParseError(err, codes.Internal,
 				"failed to parse "+vald.InsertRPCName+" gRPC error response",
 				&errdetails.RequestInfo{
-					RequestId:   req.GetVector().GetId(),
-					ServingData: errdetails.Serialize(req),
+					RequestId: req.GetVector().GetId(),
 				},
 				&errdetails.ResourceInfo{
 					ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertRPCName + ".BroadCast/" + target,
 					ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
 				},
 			)
-			if st.Code() == codes.AlreadyExists {
-				// NOTE: If it is strictly necessary to check, fix this logic.
-				return nil
+			log.Warn(err)
+			if span != nil {
+				span.RecordError(err)
+				span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+				span.SetStatus(trace.StatusError, err.Error())
 			}
+			code = st.Code()
 		}
 		if err == nil && ce != nil {
 			mu.Lock()
@@ -1042,13 +1026,12 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (loc *
 			loc.Ips = append(loc.Ips, ce.GetIps()...)
 			mu.Unlock()
 		}
-		result.Store(target, err)
+		result.Store(target, &errorState{err, code})
 		return err
 	})
 	if err != nil {
 		reqInfo := &errdetails.RequestInfo{
-			RequestId:   req.GetVector().GetId(),
-			ServingData: errdetails.Serialize(req),
+			RequestId: req.GetVector().GetId(),
 		}
 		resInfo := &errdetails.ResourceInfo{
 			ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertRPCName + ".BroadCast",
@@ -1080,33 +1063,47 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (loc *
 		return nil, err
 	}
 
-	var errs error
-	targets := make([]string, 0, 10)
-	result.Range(func(target string, err error) bool {
-		if err == nil {
-			targets = append(targets, target)
-		} else {
-			errs = errors.Join(errs, err)
+	alreadyExistsTgts := make([]string, 0, result.Len()/2)
+	successTgts := make([]string, 0, result.Len()/2)
+	result.Range(func(target string, es *errorState) bool {
+		switch {
+		case es.err == nil:
+			successTgts = append(successTgts, target)
+			err = errors.Join(err, es.err)
+		case es.code == codes.AlreadyExists:
+			alreadyExistsTgts = append(alreadyExistsTgts, target)
+			err = errors.Join(err, es.err)
+		default:
+			err = errors.Join(es.err, err)
 		}
 		return true
 	})
+
+	reqInfo := &errdetails.RequestInfo{
+		RequestId: req.GetVector().GetId(),
+	}
+	resInfo := &errdetails.ResourceInfo{
+		ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertRPCName,
+		ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
+	}
+
 	switch {
-	case errs == nil:
-		log.Debugf("Insert API mirror request succeeded to %#v", loc)
+	case err == nil:
+		log.Debugf(vald.InsertRPCName+" API request succeeded to %#v", loc)
 		return loc, nil
-	case len(targets) == 0 && errs != nil:
-		log.Error("failed to Insert API mirror request: %v and can not rollback because success target length is 0", errs)
-		st, msg, err := status.ParseError(errs, codes.Internal,
-			"failed to parse "+vald.InsertRPCName+" gRPC error response",
-			&errdetails.RequestInfo{
-				RequestId:   req.GetVector().GetId(),
-				ServingData: errdetails.Serialize(req),
-			},
-			&errdetails.ResourceInfo{
-				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertRPCName,
-				ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-			},
+	case result.Len() == len(alreadyExistsTgts):
+		err = status.WrapWithAlreadyExists(vald.InsertRPCName+" API target same vector already exists", err, reqInfo, resInfo)
+		if span != nil {
+			span.RecordError(err)
+			span.SetAttributes(trace.StatusCodeAlreadyExists(err.Error())...)
+			span.SetStatus(trace.StatusError, err.Error())
+		}
+		return nil, err
+	case result.Len() > len(successTgts)+len(alreadyExistsTgts): // Contains errors except for ALREADY_EXIST.
+		st, msg, err := status.ParseError(err, codes.Internal,
+			"failed to parse "+vald.InsertRPCName+" gRPC error response", reqInfo, resInfo,
 		)
+		log.Warn(err)
 		if span != nil {
 			span.RecordError(err)
 			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
@@ -1114,60 +1111,75 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (loc *
 		}
 		return nil, err
 	}
-	log.Error("failed to Insert API mirror request: %v, so starts the rollback request", errs)
 
-	var emu sync.Mutex
-	var rerrs error
-	rmReq := &payload.Remove_Request{
-		Id: &payload.Object_ID{
-			Id: req.GetVector().GetId(),
+	// In this case, the status code in the result object contains only OK or ALREADY_EXIST.
+	// And send Update API requst to ALREADY_EXIST cluster using query requested by the user.
+	log.Warnf("failed to Insert API: %#v", err)
+
+	updateReq := &payload.Update_Request{
+		Vector: req.GetVector(),
+		Config: &payload.Update_Config{
+			SkipStrictExistCheck: req.GetConfig().GetSkipStrictExistCheck(),
+			Timestamp:            req.GetConfig().GetTimestamp(),
 		},
 	}
-	err = s.gateway.DoMulti(ctx, targets,
+	err = s.gateway.DoMulti(ctx, alreadyExistsTgts,
 		func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error {
-			ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "rollback/BroadCast/"+target), apiName+"/"+vald.InsertRPCName+"/rollback/"+target)
+			ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "DoMulti/"+target), apiName+"/"+vald.UpdateRPCName+"/"+target)
 			defer func() {
 				if span != nil {
 					span.End()
 				}
 			}()
 
-			_, err := s.remove(ctx, vc, rmReq, copts...)
+			code := codes.OK
+			ce, err := s.doUpdate(ctx, updateReq, func(ctx context.Context) (*payload.Object_Location, error) {
+				return vc.Update(ctx, updateReq, copts...)
+			})
 			if err != nil {
-				st, _, err := status.ParseError(err, codes.Internal,
-					"failed to parse "+vald.RemoveRPCName+" for "+vald.InsertRPCName+" error response for "+target,
+				var (
+					st  *status.Status
+					msg string
+				)
+				st, msg, err = status.ParseError(err, codes.Internal,
+					"failed to parse "+vald.UpdateRPCName+" gRPC error response",
 					&errdetails.RequestInfo{
-						RequestId:   rmReq.GetId().GetId(),
-						ServingData: errdetails.Serialize(rmReq),
+						RequestId: req.GetVector().GetId(),
 					},
 					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertRPCName + "." + vald.RemoveRPCName + ".BroadCast/" + target,
+						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateRPCName + ".DoMulti/" + target,
 						ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
 					},
 				)
-				if st.Code() == codes.NotFound {
-					return nil
+				log.Warn(err)
+				if span != nil {
+					span.RecordError(err)
+					span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					span.SetStatus(trace.StatusError, err.Error())
 				}
-				emu.Lock()
-				rerrs = errors.Join(rerrs, err)
-				emu.Unlock()
-				return err
+				code = st.Code()
 			}
-			return nil
+			if err == nil && ce != nil {
+				mu.Lock()
+				loc.Name = ce.GetName()
+				loc.Ips = append(loc.Ips, ce.GetIps()...)
+				mu.Unlock()
+			}
+			result.Store(target, &errorState{err, code})
+			return err
 		},
 	)
 	if err != nil {
 		reqInfo := &errdetails.RequestInfo{
-			RequestId:   rmReq.GetId().GetId(),
-			ServingData: errdetails.Serialize(rmReq),
+			RequestId: updateReq.GetVector().GetId(),
 		}
 		resInfo := &errdetails.ResourceInfo{
-			ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertRPCName + "." + vald.RemoveRPCName + ".BroadCast",
+			ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateRPCName + ".DoMulti",
 			ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
 		}
 		if errors.Is(err, errors.ErrGRPCClientConnNotFound("*")) {
 			err = status.WrapWithInternal(
-				vald.RemoveRPCName+" for "+vald.InsertRPCName+" API connection not found", err, reqInfo, resInfo,
+				vald.UpdateRPCName+" API connection not found", err, reqInfo, resInfo,
 			)
 			log.Warn(err)
 			if span != nil {
@@ -1180,7 +1192,7 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (loc *
 
 		// There is no possibility to reach this part, but we add error handling just in case.
 		st, msg, err := status.ParseError(err, codes.Internal,
-			"failed to parse "+vald.RemoveRPCName+" for "+vald.InsertRPCName+" gRPC error response", reqInfo, resInfo,
+			"failed to parse "+vald.UpdateRPCName+" gRPC error response", reqInfo, resInfo,
 		)
 		log.Warn(err)
 		if span != nil {
@@ -1190,19 +1202,47 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (loc *
 		}
 		return nil, err
 	}
-	if rerrs == nil {
-		log.Debugf("rollback for Insert API mirror request succeeded to %v", targets)
-		st, msg, err := status.ParseError(errs, codes.Internal,
-			"failed to parse "+vald.InsertRPCName+" gRPC error response",
-			&errdetails.RequestInfo{
-				RequestId:   req.GetVector().GetId(),
-				ServingData: errdetails.Serialize(req),
-			},
-			&errdetails.ResourceInfo{
-				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertRPCName,
-				ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-			},
+
+	alreadyExistsTgts = alreadyExistsTgts[0:0]
+	successTgts = successTgts[0:0]
+	result.Range(func(target string, es *errorState) bool {
+		switch {
+		case es.err == nil:
+			successTgts = append(successTgts, target)
+		case es.code == codes.AlreadyExists:
+			alreadyExistsTgts = append(alreadyExistsTgts, target)
+			err = errors.Join(err, es.err)
+		default:
+			err = errors.Join(err, es.err)
+		}
+		return true
+	})
+
+	reqInfo = &errdetails.RequestInfo{
+		RequestId: req.GetVector().GetId(),
+	}
+	resInfo = &errdetails.ResourceInfo{
+		ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateRPCName,
+		ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
+	}
+
+	switch {
+	case err == nil:
+		log.Debugf(vald.UpdateRPCName+" API request succeeded to %#v", loc)
+		return loc, nil
+	case result.Len() == len(alreadyExistsTgts):
+		err = status.WrapWithAlreadyExists(vald.UpdateRPCName+" API target same vector already exists", err, reqInfo, resInfo)
+		if span != nil {
+			span.RecordError(err)
+			span.SetAttributes(trace.StatusCodeAlreadyExists(err.Error())...)
+			span.SetStatus(trace.StatusError, err.Error())
+		}
+		return nil, err
+	case result.Len() > len(successTgts)+len(alreadyExistsTgts):
+		st, msg, err := status.ParseError(err, codes.Internal,
+			"failed to parse "+vald.UpdateRPCName+" gRPC error response", reqInfo, resInfo,
 		)
+		log.Warn(err)
 		if span != nil {
 			span.RecordError(err)
 			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
@@ -1210,35 +1250,18 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (loc *
 		}
 		return nil, err
 	}
-	log.Debugf("failed to rollback for Insert API mirror request succeeded to %v: %v", targets, rerrs)
-	st, msg, err := status.ParseError(rerrs, codes.Internal,
-		"failed to parse "+vald.RemoveRPCName+" for "+vald.InsertRPCName+" gRPC error response",
-		&errdetails.RequestInfo{
-			RequestId:   rmReq.GetId().GetId(),
-			ServingData: errdetails.Serialize(rmReq),
-		},
-		&errdetails.ResourceInfo{
-			ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertRPCName + "." + vald.RemoveRPCName,
-			ResourceName: fmt.Sprintf("%s: %s(%s) %v", apiName, s.name, s.ip, targets),
-		},
-	)
-	if span != nil {
-		span.RecordError(err)
-		span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
-		span.SetStatus(trace.StatusError, err.Error())
-	}
-	return nil, err
+	return loc, nil
 }
 
-func (s *server) insert(ctx context.Context, client vald.InsertClient, req *payload.Insert_Request, opts ...grpc.CallOption) (loc *payload.Object_Location, err error) {
-	ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "insert"), apiName+"/insert")
+func (s *server) doInsert(ctx context.Context, req *payload.Insert_Request, f func(ctx context.Context) (*payload.Object_Location, error)) (loc *payload.Object_Location, err error) {
+	ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "doInsert"), apiName+"/doInsert")
 	defer func() {
 		if span != nil {
 			span.End()
 		}
 	}()
 
-	loc, err = client.Insert(ctx, req, opts...)
+	loc, err = f(ctx)
 	if err != nil {
 		reqInfo := &errdetails.RequestInfo{
 			RequestId:   req.GetVector().GetId(),
@@ -1416,59 +1439,31 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (loc *
 	// When this condition is matched, the request is proxied to another Mirror gateway.
 	// So this component sends requests only to the Vald gateway (LB gateway) of its own cluster.
 	if len(reqSrcPodName) != 0 {
-		_, err = s.gateway.Do(ctx, s.vAddr, func(ctx context.Context, vc vald.ClientWithMirror, copts ...grpc.CallOption) (interface{}, error) {
-			loc, err = vc.Update(ctx, req, copts...)
-			if err != nil {
-				return nil, err
-			}
-			return loc, nil
-		})
+		loc, err = s.doUpdate(ctx, req,
+			func(ctx context.Context) (*payload.Object_Location, error) {
+				s.gateway.Do(ctx, s.vAddr, func(ctx context.Context, vc vald.ClientWithMirror, copts ...grpc.CallOption) (interface{}, error) {
+					loc, err = vc.Update(ctx, req, copts...)
+					return loc, err
+				})
+				return loc, err
+			},
+		)
 		if err != nil {
 			reqInfo := &errdetails.RequestInfo{
-				RequestId:   req.GetVector().GetId(),
-				ServingData: errdetails.Serialize(req),
+				RequestId: req.GetVector().GetId(),
 			}
 			resInfo := &errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateRPCName,
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, s.vAddr),
 			}
-			var attrs trace.Attributes
+			st, msg, err := status.ParseError(err, codes.Internal,
+				"failed to parse "+vald.UpdateRPCName+" gRPC error response", reqInfo, resInfo,
+			)
 
-			switch {
-			case errors.Is(err, context.Canceled):
-				err = status.WrapWithCanceled(
-					vald.UpdateRPCName+" API canceld", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeCancelled(err.Error())
-			case errors.Is(err, context.DeadlineExceeded):
-				err = status.WrapWithDeadlineExceeded(
-					vald.UpdateRPCName+" API deadline exceeded", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeDeadlineExceeded(err.Error())
-			case errors.Is(err, errors.ErrTargetNotFound):
-				err = status.WrapWithInternal(
-					vald.UpdateRPCName+" API target not found", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeInternal(err.Error())
-			case errors.Is(err, errors.ErrGRPCClientConnNotFound("*")):
-				err = status.WrapWithInternal(
-					vald.UpdateRPCName+" API connection not found", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeInternal(err.Error())
-			default:
-				var (
-					st  *status.Status
-					msg string
-				)
-				st, msg, err = status.ParseError(err, codes.Internal,
-					"failed to parse "+vald.UpdateRPCName+" gRPC error response", reqInfo, resInfo,
-				)
-				attrs = trace.FromGRPCStatus(st.Code(), msg)
-			}
 			log.Warn(err)
 			if span != nil {
 				span.RecordError(err)
-				span.SetAttributes(attrs...)
+				span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
 				span.SetStatus(trace.StatusError, err.Error())
 			}
 			return nil, err
@@ -1477,18 +1472,8 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (loc *
 		return loc, nil
 	}
 
-	objReq := &payload.Object_VectorRequest{
-		Id: &payload.Object_ID{
-			Id: req.GetVector().GetId(),
-		},
-	}
-	oldVecs, err := s.getObjects(ctx, objReq)
-	if err != nil {
-		return nil, err
-	}
-
 	var mu sync.Mutex
-	var result sync.Map[string, error]
+	var result sync.Map[string, *errorState]
 	loc = &payload.Object_Location{
 		Uuid: req.GetVector().GetId(),
 		Ips:  make([]string, 0),
@@ -1503,10 +1488,17 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (loc *
 				}
 			}()
 
-			ce, err := s.update(ctx, vc, req, copts...)
+			code := codes.OK
+			ce, err := s.doUpdate(ctx, req, func(ctx context.Context) (*payload.Object_Location, error) {
+				return vc.Update(ctx, req, copts...)
+			})
 			if err != nil {
-				st, _, _ := status.ParseError(err, codes.Internal,
-					"failed to parse "+vald.UpdateRPCName+" API error response for "+target,
+				var (
+					st  *status.Status
+					msg string
+				)
+				st, msg, err = status.ParseError(err, codes.Internal,
+					"failed to parse "+vald.UpdateRPCName+" gRPC error response",
 					&errdetails.RequestInfo{
 						RequestId:   req.GetVector().GetId(),
 						ServingData: errdetails.Serialize(req),
@@ -1516,10 +1508,14 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (loc *
 						ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
 					},
 				)
-				if st.Code() == codes.AlreadyExists {
-					// NOTE: If it is strictly necessary to check, fix this logic.
-					return nil
+
+				log.Warn(err)
+				if span != nil {
+					span.RecordError(err)
+					span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					span.SetStatus(trace.StatusError, err.Error())
 				}
+				code = st.Code()
 			}
 			if err == nil && ce != nil {
 				mu.Lock()
@@ -1527,7 +1523,7 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (loc *
 				loc.Ips = append(loc.Ips, ce.GetIps()...)
 				mu.Unlock()
 			}
-			result.Store(target, err)
+			result.Store(target, &errorState{err, code})
 			return err
 		},
 	)
@@ -1543,6 +1539,160 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (loc *
 		if errors.Is(err, errors.ErrGRPCClientConnNotFound("*")) {
 			err = status.WrapWithInternal(
 				vald.UpdateRPCName+" API connection not found", err, reqInfo, resInfo,
+			)
+
+			log.Warn(err)
+			if span != nil {
+				span.RecordError(err)
+				span.SetAttributes(trace.StatusCodeInternal(err.Error())...)
+				span.SetStatus(trace.StatusError, err.Error())
+			}
+			return nil, err
+		}
+
+		// There is no possibility to reach this part, but we add error handling just in case.
+		st, msg, err := status.ParseError(err, codes.Internal,
+			"failed to parse "+vald.UpdateRPCName+" gRPC error response", reqInfo, resInfo,
+		)
+
+		log.Warn(err)
+		if span != nil {
+			span.RecordError(err)
+			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+			span.SetStatus(trace.StatusError, err.Error())
+		}
+		return nil, err
+	}
+
+	var alreadyExistsCnt int
+	notFoundTgts := make([]string, 0, result.Len()/2)
+	successTgts := make([]string, 0, result.Len()/2)
+	result.Range(func(target string, em *errorState) bool {
+		switch {
+		case em.err == nil:
+			successTgts = append(successTgts, target)
+		case em.code == codes.AlreadyExists:
+			alreadyExistsCnt++
+			err = errors.Join(err, em.err)
+		case em.code == codes.NotFound:
+			notFoundTgts = append(notFoundTgts, target)
+			err = errors.Join(err, em.err)
+		default:
+			err = errors.Join(em.err, err)
+		}
+		return true
+	})
+
+	reqInfo := &errdetails.RequestInfo{
+		RequestId: req.GetVector().GetId(),
+	}
+	resInfo := &errdetails.ResourceInfo{
+		ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateRPCName,
+		ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
+	}
+
+	switch {
+	case err == nil, result.Len() == len(successTgts)+alreadyExistsCnt:
+		return loc, nil
+	case result.Len() == len(notFoundTgts):
+		err = status.WrapWithNotFound(vald.UpdateRPCName+" API target not found", err, reqInfo, resInfo)
+		log.Warn(err)
+		if span != nil {
+			span.RecordError(err)
+			span.SetAttributes(trace.StatusCodeAlreadyExists(err.Error())...)
+			span.SetStatus(trace.StatusError, err.Error())
+		}
+		return nil, err
+	case result.Len() == alreadyExistsCnt:
+		err = status.WrapWithAlreadyExists(vald.UpdateRPCName+" API target same vector already exists", err, reqInfo, resInfo)
+		log.Warn(err)
+		if span != nil {
+			span.RecordError(err)
+			span.SetAttributes(trace.StatusCodeNotFound(err.Error())...)
+			span.SetStatus(trace.StatusError, err.Error())
+		}
+		return nil, err
+	case result.Len() > len(successTgts)+len(notFoundTgts)+alreadyExistsCnt: // Contains errors except for NOT_FOUND and ALREADY_EXIST.
+		st, msg, err := status.ParseError(err, codes.Internal,
+			"failed to parse "+vald.UpdateRPCName+" gRPC error response", reqInfo, resInfo)
+		log.Warn(err)
+		if span != nil {
+			span.RecordError(err)
+			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+			span.SetStatus(trace.StatusError, err.Error())
+		}
+		return nil, err
+	}
+
+	// In this case, the status code in the result object contains only OK or ALREADY_EXIST.
+	// And send Insert API requst to NOT_FOUND cluster using query requested by the user.
+
+	insReq := &payload.Insert_Request{
+		Vector: req.GetVector(),
+		Config: &payload.Insert_Config{
+			SkipStrictExistCheck: req.GetConfig().GetSkipStrictExistCheck(),
+			Timestamp:            req.GetConfig().GetTimestamp(),
+		},
+	}
+	err = s.gateway.DoMulti(ctx, notFoundTgts,
+		func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error {
+			ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "BroadCast/"+target), apiName+"/"+vald.InsertRPCName+"/"+target)
+			defer func() {
+				if span != nil {
+					span.End()
+				}
+			}()
+
+			code := codes.OK
+			ce, err := s.doInsert(ctx, insReq, func(ctx context.Context) (*payload.Object_Location, error) {
+				return vc.Insert(ctx, insReq, copts...)
+			})
+			if err != nil {
+				var (
+					st  *status.Status
+					msg string
+				)
+				st, msg, err = status.ParseError(err, codes.Internal,
+					"failed to parse "+vald.InsertRPCName+" gRPC error response",
+					&errdetails.RequestInfo{
+						RequestId:   req.GetVector().GetId(),
+						ServingData: errdetails.Serialize(req),
+					},
+					&errdetails.ResourceInfo{
+						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertRPCName + ".BroadCast/" + target,
+						ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
+					},
+				)
+				log.Warn(err)
+				if span != nil {
+					span.RecordError(err)
+					span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					span.SetStatus(trace.StatusError, err.Error())
+				}
+				code = st.Code()
+			}
+			if err == nil && ce != nil {
+				mu.Lock()
+				loc.Name = ce.GetName()
+				loc.Ips = append(loc.Ips, ce.GetIps()...)
+				mu.Unlock()
+			}
+			result.Store(target, &errorState{err, code})
+			return err
+		},
+	)
+	if err != nil {
+		reqInfo := &errdetails.RequestInfo{
+			RequestId:   req.GetVector().GetId(),
+			ServingData: errdetails.Serialize(req),
+		}
+		resInfo := &errdetails.ResourceInfo{
+			ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateRPCName + ".BroadCast",
+			ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
+		}
+		if errors.Is(err, errors.ErrGRPCClientConnNotFound("*")) {
+			err = status.WrapWithInternal(
+				vald.InsertRPCName+" API connection not found", err, reqInfo, resInfo,
 			)
 			log.Warn(err)
 			if span != nil {
@@ -1566,140 +1716,58 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (loc *
 		return nil, err
 	}
 
-	var errs error
-	targets := make([]string, 0, 10)
-	result.Range(func(target string, err error) bool {
-		if err == nil {
-			targets = append(targets, target)
-		} else {
-			errs = errors.Join(errs, err)
+	alreadyExistsCnt = 0
+	notFoundTgts = notFoundTgts[0:0]
+	successTgts = successTgts[0:0]
+	result.Range(func(target string, em *errorState) bool {
+		switch {
+		case em.err == nil:
+			successTgts = append(successTgts, target)
+		case em.code == codes.AlreadyExists:
+			alreadyExistsCnt++
+			err = errors.Join(err, em.err)
+		case em.code == codes.NotFound:
+			notFoundTgts = append(notFoundTgts, target)
+			err = errors.Join(err, em.err)
+		default:
+			err = errors.Join(em.err, err)
 		}
 		return true
 	})
+
+	reqInfo = &errdetails.RequestInfo{
+		RequestId:   req.GetVector().GetId(),
+		ServingData: errdetails.Serialize(req),
+	}
+	resInfo = &errdetails.ResourceInfo{
+		ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertRPCName,
+		ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
+	}
+
 	switch {
-	case errs == nil:
-		log.Debugf("Update API mirror request succeeded to %#v", loc)
+	case err == nil, result.Len() == len(successTgts)+alreadyExistsCnt:
 		return loc, nil
-	case len(targets) == 0 && errs != nil:
-		log.Error("failed to Update API mirror request: %v and can not rollback because success target length is 0", errs)
-		st, msg, err := status.ParseError(errs, codes.Internal,
-			"failed to parse "+vald.UpdateRPCName+" gRPC error response",
-			&errdetails.RequestInfo{
-				RequestId:   req.GetVector().GetId(),
-				ServingData: errdetails.Serialize(req),
-			},
-			&errdetails.ResourceInfo{
-				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateRPCName,
-				ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-			},
-		)
+	case result.Len() == len(notFoundTgts):
+		err = status.WrapWithNotFound(vald.InsertRPCName+" API target not found", err, reqInfo, resInfo)
+		log.Warn(err)
 		if span != nil {
 			span.RecordError(err)
-			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+			span.SetAttributes(trace.StatusCodeAlreadyExists(err.Error())...)
 			span.SetStatus(trace.StatusError, err.Error())
 		}
 		return nil, err
-	}
-	log.Error("failed to Update API mirror request: %v, so starts the rollback request", errs)
-
-	var emu sync.Mutex
-	var rerrs error
-	rmReq := &payload.Remove_Request{
-		Id: &payload.Object_ID{
-			Id: req.GetVector().GetId(),
-		},
-	}
-
-	err = s.gateway.DoMulti(ctx, targets,
-		func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error {
-			ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "rollback/BroadCast/"+target), apiName+"/"+vald.RemoveRPCName+"/rollback/"+target)
-			defer func() {
-				if span != nil {
-					span.End()
-				}
-			}()
-
-			oldVec, ok := oldVecs.Load(target)
-			if !ok || oldVec == nil {
-				_, err := s.remove(ctx, vc, rmReq, copts...)
-				if err != nil {
-					st, _, _ := status.ParseError(err, codes.Internal,
-						"failed to parse "+vald.RemoveRPCName+" for "+vald.UpdateRPCName+" gRPC error response",
-						&errdetails.RequestInfo{
-							RequestId:   rmReq.GetId().GetId(),
-							ServingData: errdetails.Serialize(rmReq),
-						},
-						&errdetails.ResourceInfo{
-							ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateRPCName + "." + vald.RemoveRPCName + ".BroadCast/" + target,
-							ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-						},
-					)
-					if st.Code() == codes.NotFound {
-						return nil
-					}
-					emu.Lock()
-					rerrs = errors.Join(rerrs, err)
-					emu.Unlock()
-					return err
-				}
-				return nil
-			}
-
-			req := &payload.Update_Request{
-				Vector: oldVec,
-				Config: &payload.Update_Config{
-					SkipStrictExistCheck: true,
-				},
-			}
-			_, err := s.update(ctx, vc, req, copts...)
-			if err != nil {
-				st, _, _ := status.ParseError(err, codes.Internal,
-					"failed to parse "+vald.UpdateRPCName+" for "+vald.UpdateRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetVector().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateRPCName + "." + vald.UpdateRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-					},
-				)
-				if st.Code() == codes.AlreadyExists {
-					return nil
-				}
-				emu.Lock()
-				rerrs = errors.Join(rerrs, err)
-				emu.Unlock()
-				return err
-			}
-			return nil
-		},
-	)
-	if err != nil {
-		reqInfo := &errdetails.RequestInfo{
-			RequestId: req.GetVector().GetId(),
+	case result.Len() == alreadyExistsCnt:
+		err = status.WrapWithAlreadyExists(vald.InsertRPCName+" API target same vector already exists", err, reqInfo, resInfo)
+		log.Warn(err)
+		if span != nil {
+			span.RecordError(err)
+			span.SetAttributes(trace.StatusCodeNotFound(err.Error())...)
+			span.SetStatus(trace.StatusError, err.Error())
 		}
-		resInfo := &errdetails.ResourceInfo{
-			ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateRPCName + ".Rollback.BroadCast",
-			ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-		}
-		if errors.Is(err, errors.ErrGRPCClientConnNotFound("*")) {
-			err = status.WrapWithInternal(
-				vald.UpdateRPCName+" for Rollback connection not found", err, reqInfo, resInfo,
-			)
-			log.Warn(err)
-			if span != nil {
-				span.RecordError(err)
-				span.SetAttributes(trace.StatusCodeInternal(err.Error())...)
-				span.SetStatus(trace.StatusError, err.Error())
-			}
-			return nil, err
-		}
-
-		// There is no possibility to reach this part, but we add error handling just in case.
+		return nil, err
+	case result.Len() > len(successTgts)+len(notFoundTgts)+alreadyExistsCnt: // Contains errors except for NOT_FOUND and ALREADY_EXIST.
 		st, msg, err := status.ParseError(err, codes.Internal,
-			"failed to parse "+vald.UpdateRPCName+" for Rollback gRPC error response", reqInfo, resInfo,
-		)
+			"failed to parse "+vald.InsertRPCName+" gRPC error response", reqInfo, resInfo)
 		log.Warn(err)
 		if span != nil {
 			span.RecordError(err)
@@ -1708,54 +1776,18 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (loc *
 		}
 		return nil, err
 	}
-	if rerrs == nil {
-		log.Debugf("rollback for Update API mirror request succeeded to %v", targets)
-		st, msg, err := status.ParseError(errs, codes.Internal,
-			"failed to parse "+vald.UpdateRPCName+" gRPC error response",
-			&errdetails.RequestInfo{
-				RequestId:   req.GetVector().GetId(),
-				ServingData: errdetails.Serialize(req),
-			},
-			&errdetails.ResourceInfo{
-				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateRPCName,
-				ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-			},
-		)
-		if span != nil {
-			span.RecordError(err)
-			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
-			span.SetStatus(trace.StatusError, err.Error())
-		}
-		return nil, err
-	}
-	log.Debugf("failed to rollback for Update API mirror request succeeded to %v: %v", targets, rerrs)
-	st, msg, err := status.ParseError(rerrs, codes.Internal,
-		"failed to parse "+vald.UpdateRPCName+" for Rollback gRPC error response",
-		&errdetails.RequestInfo{
-			RequestId: req.GetVector().GetId(),
-		},
-		&errdetails.ResourceInfo{
-			ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateRPCName + ".Rollback",
-			ResourceName: fmt.Sprintf("%s: %s(%s) %v", apiName, s.name, s.ip, targets),
-		},
-	)
-	if span != nil {
-		span.RecordError(err)
-		span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
-		span.SetStatus(trace.StatusError, err.Error())
-	}
 	return nil, err
 }
 
-func (s *server) update(ctx context.Context, client vald.UpdateClient, req *payload.Update_Request, opts ...grpc.CallOption) (loc *payload.Object_Location, err error) {
-	ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "update"), apiName+"/update")
+func (s *server) doUpdate(ctx context.Context, req *payload.Update_Request, f func(ctx context.Context) (*payload.Object_Location, error)) (loc *payload.Object_Location, err error) {
+	ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "doUpdate"), apiName+"/doUpdate")
 	defer func() {
 		if span != nil {
 			span.End()
 		}
 	}()
 
-	loc, err = client.Update(ctx, req, opts...)
+	loc, err = f(ctx)
 	if err != nil {
 		reqInfo := &errdetails.RequestInfo{
 			RequestId:   req.GetVector().GetId(),
@@ -1933,13 +1965,15 @@ func (s *server) Upsert(ctx context.Context, req *payload.Upsert_Request) (loc *
 	// When this condition is matched, the request is proxied to another Mirror gateway.
 	// So this component sends requests only to the Vald gateway (LB gateway) of its own cluster.
 	if len(reqSrcPodName) != 0 {
-		_, err = s.gateway.Do(ctx, s.vAddr, func(ctx context.Context, vc vald.ClientWithMirror, copts ...grpc.CallOption) (interface{}, error) {
-			loc, err = vc.Upsert(ctx, req, copts...)
-			if err != nil {
-				return nil, err
-			}
-			return loc, nil
-		})
+		loc, err = s.doUpsert(ctx, req,
+			func(ctx context.Context) (*payload.Object_Location, error) {
+				s.gateway.Do(ctx, s.vAddr, func(ctx context.Context, vc vald.ClientWithMirror, copts ...grpc.CallOption) (interface{}, error) {
+					loc, err = vc.Upsert(ctx, req, copts...)
+					return loc, err
+				})
+				return loc, err
+			},
+		)
 		if err != nil {
 			reqInfo := &errdetails.RequestInfo{
 				RequestId:   req.GetVector().GetId(),
@@ -1949,43 +1983,14 @@ func (s *server) Upsert(ctx context.Context, req *payload.Upsert_Request) (loc *
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpsertRPCName,
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, s.vAddr),
 			}
-			var attrs trace.Attributes
+			st, msg, err := status.ParseError(err, codes.Internal,
+				"failed to parse "+vald.UpsertRPCName+" gRPC error response", reqInfo, resInfo,
+			)
 
-			switch {
-			case errors.Is(err, context.Canceled):
-				err = status.WrapWithCanceled(
-					vald.UpsertRPCName+" API canceld", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeCancelled(err.Error())
-			case errors.Is(err, context.DeadlineExceeded):
-				err = status.WrapWithDeadlineExceeded(
-					vald.UpsertRPCName+" API deadline exceeded", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeDeadlineExceeded(err.Error())
-			case errors.Is(err, errors.ErrTargetNotFound):
-				err = status.WrapWithInternal(
-					vald.UpsertRPCName+" API target not found", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeInternal(err.Error())
-			case errors.Is(err, errors.ErrGRPCClientConnNotFound("*")):
-				err = status.WrapWithInternal(
-					vald.UpsertRPCName+" API connection not found", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeInternal(err.Error())
-			default:
-				var (
-					st  *status.Status
-					msg string
-				)
-				st, msg, err = status.ParseError(err, codes.Internal,
-					"failed to parse "+vald.UpsertRPCName+" gRPC error response", reqInfo, resInfo,
-				)
-				attrs = trace.FromGRPCStatus(st.Code(), msg)
-			}
 			log.Warn(err)
 			if span != nil {
 				span.RecordError(err)
-				span.SetAttributes(attrs...)
+				span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
 				span.SetStatus(trace.StatusError, err.Error())
 			}
 			return nil, err
@@ -1994,57 +1999,60 @@ func (s *server) Upsert(ctx context.Context, req *payload.Upsert_Request) (loc *
 		return loc, nil
 	}
 
-	objReq := &payload.Object_VectorRequest{
-		Id: &payload.Object_ID{
-			Id: req.GetVector().GetId(),
-		},
-	}
-	oldVecs, err := s.getObjects(ctx, objReq)
-	if err != nil {
-		return nil, err
-	}
-
 	var mu sync.Mutex
-	var result sync.Map[string, error]
+	var result sync.Map[string, *errorState]
 	loc = &payload.Object_Location{
 		Uuid: req.GetVector().GetId(),
 		Ips:  make([]string, 0),
 	}
-	err = s.gateway.BroadCast(ctx, func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error {
-		ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "BroadCast/"+target), apiName+"/"+vald.UpsertRPCName+"/"+target)
-		defer func() {
-			if span != nil {
-				span.End()
-			}
-		}()
+	err = s.gateway.BroadCast(ctx,
+		func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error {
+			ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "BroadCast/"+target), apiName+"/"+vald.UpsertRPCName+"/"+target)
+			defer func() {
+				if span != nil {
+					span.End()
+				}
+			}()
 
-		ce, err := s.upsert(ctx, vc, req, copts...)
-		if err != nil {
-			st, _, _ := status.ParseError(err, codes.Internal,
-				"failed to parse "+vald.UpsertRPCName+" gRPC error response",
-				&errdetails.RequestInfo{
-					RequestId:   req.GetVector().GetId(),
-					ServingData: errdetails.Serialize(req),
-				},
-				&errdetails.ResourceInfo{
-					ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpsertRPCName + ".BroadCast/" + target,
-					ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-				},
-			)
-			if st.Code() == codes.AlreadyExists {
-				// NOTE: If it is strictly necessary to check, fix this logic.
-				return nil
+			code := codes.OK
+			ce, err := s.doUpsert(ctx, req, func(ctx context.Context) (*payload.Object_Location, error) {
+				return vc.Upsert(ctx, req, copts...)
+			})
+			if err != nil {
+				var (
+					st  *status.Status
+					msg string
+				)
+				st, msg, err = status.ParseError(err, codes.Internal,
+					"failed to parse "+vald.UpsertRPCName+" gRPC error response",
+					&errdetails.RequestInfo{
+						RequestId:   req.GetVector().GetId(),
+						ServingData: errdetails.Serialize(req),
+					},
+					&errdetails.ResourceInfo{
+						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpsertRPCName + ".BroadCast/" + target,
+						ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
+					},
+				)
+
+				log.Warn(err)
+				if span != nil {
+					span.RecordError(err)
+					span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					span.SetStatus(trace.StatusError, err.Error())
+				}
+				code = st.Code()
 			}
-		}
-		if err == nil && ce != nil {
-			mu.Lock()
-			loc.Name = ce.GetName()
-			loc.Ips = append(loc.Ips, ce.GetIps()...)
-			mu.Unlock()
-		}
-		result.Store(target, err)
-		return err
-	})
+			if err == nil && ce != nil {
+				mu.Lock()
+				loc.Name = ce.GetName()
+				loc.Ips = append(loc.Ips, ce.GetIps()...)
+				mu.Unlock()
+			}
+			result.Store(target, &errorState{err, code})
+			return err
+		},
+	)
 	if err != nil {
 		reqInfo := &errdetails.RequestInfo{
 			RequestId:   req.GetVector().GetId(),
@@ -2058,6 +2066,7 @@ func (s *server) Upsert(ctx context.Context, req *payload.Upsert_Request) (loc *
 			err = status.WrapWithInternal(
 				vald.UpsertRPCName+" API connection not found", err, reqInfo, resInfo,
 			)
+
 			log.Warn(err)
 			if span != nil {
 				span.RecordError(err)
@@ -2071,6 +2080,7 @@ func (s *server) Upsert(ctx context.Context, req *payload.Upsert_Request) (loc *
 		st, msg, err := status.ParseError(err, codes.Internal,
 			"failed to parse "+vald.UpsertRPCName+" gRPC error response", reqInfo, resInfo,
 		)
+
 		log.Warn(err)
 		if span != nil {
 			span.RecordError(err)
@@ -2080,139 +2090,44 @@ func (s *server) Upsert(ctx context.Context, req *payload.Upsert_Request) (loc *
 		return nil, err
 	}
 
-	var errs error
-	targets := make([]string, 0, 10)
-	result.Range(func(target string, err error) bool {
-		if err == nil {
-			targets = append(targets, target)
+	var alreadyExistsCnt int
+	successTgts := make([]string, 0, result.Len()/2)
+	result.Range(func(target string, em *errorState) bool {
+		if em.err == nil {
+			successTgts = append(successTgts, target)
 		} else {
-			errs = errors.Join(errs, err)
+			if em.code == codes.AlreadyExists {
+				alreadyExistsCnt++
+			}
+			err = errors.Join(err, em.err)
 		}
 		return true
 	})
+
+	reqInfo := &errdetails.RequestInfo{
+		RequestId:   req.GetVector().GetId(),
+		ServingData: errdetails.Serialize(req),
+	}
+	resInfo := &errdetails.ResourceInfo{
+		ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpsertRPCName,
+		ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
+	}
+
 	switch {
-	case errs == nil:
-		log.Debugf("Upsert API mirror request succeeded to %#v", loc)
+	case err == nil, len(successTgts) > 0 && result.Len() == len(successTgts)+alreadyExistsCnt:
+		log.Debugf(vald.UpsertRPCName+" API request succeeded to %#v", loc)
 		return loc, nil
-	case len(targets) == 0 && errs != nil:
-		log.Error("failed to Upsert API mirror request: %v and can not rollback because success target length is 0", errs)
-		st, msg, err := status.ParseError(errs, codes.Internal,
-			"failed to parse "+vald.UpsertRPCName+" gRPC error response",
-			&errdetails.RequestInfo{
-				RequestId:   req.GetVector().GetId(),
-				ServingData: errdetails.Serialize(req),
-			},
-			&errdetails.ResourceInfo{
-				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpsertRPCName,
-				ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-			},
-		)
+	case result.Len() == alreadyExistsCnt:
+		err = status.WrapWithAlreadyExists(vald.UpsertRPCName+" API target same vector already exists", err, reqInfo, resInfo)
 		if span != nil {
 			span.RecordError(err)
-			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+			span.SetAttributes(trace.StatusCodeAlreadyExists(err.Error())...)
 			span.SetStatus(trace.StatusError, err.Error())
 		}
 		return nil, err
-	}
-	log.Error("failed to Upsert API mirror request: %v, so starts the rollback request", errs)
-
-	var emu sync.Mutex
-	var rerrs error
-	rmReq := &payload.Remove_Request{
-		Id: &payload.Object_ID{
-			Id: req.GetVector().GetId(),
-		},
-	}
-	err = s.gateway.DoMulti(ctx, targets,
-		func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error {
-			ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "rollback/BroadCast/"+target), apiName+"/"+vald.UpsertRPCName+"/rollback/"+target)
-			defer func() {
-				if span != nil {
-					span.End()
-				}
-			}()
-
-			oldVec, ok := oldVecs.Load(target)
-			if !ok || oldVec == nil {
-				_, err := s.remove(ctx, vc, rmReq, copts...)
-				if err != nil {
-					st, _, _ := status.ParseError(err, codes.Internal,
-						"failed to parse "+vald.RemoveRPCName+" for "+vald.UpsertRPCName+" gRPC error response",
-						&errdetails.RequestInfo{
-							RequestId:   rmReq.GetId().GetId(),
-							ServingData: errdetails.Serialize(rmReq),
-						},
-						&errdetails.ResourceInfo{
-							ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpsertRPCName + "." + vald.RemoveRPCName + ".BroadCast/" + target,
-							ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-						},
-					)
-					if st.Code() == codes.NotFound {
-						return nil
-					}
-					emu.Lock()
-					rerrs = errors.Join(rerrs, err)
-					emu.Unlock()
-					return err
-				}
-				return nil
-			}
-
-			req := &payload.Update_Request{
-				Vector: oldVec,
-				Config: &payload.Update_Config{
-					SkipStrictExistCheck: true,
-				},
-			}
-			_, err := s.update(ctx, vc, req, copts...)
-			if err != nil {
-				st, _, _ := status.ParseError(err, codes.Internal,
-					"failed to parse "+vald.UpdateRPCName+" for "+vald.UpsertRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetVector().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpsertRPCName + "." + vald.UpdateRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-					},
-				)
-				if st.Code() == codes.AlreadyExists {
-					return nil
-				}
-				emu.Lock()
-				rerrs = errors.Join(rerrs, err)
-				emu.Unlock()
-				return err
-			}
-			return nil
-		},
-	)
-	if err != nil {
-		reqInfo := &errdetails.RequestInfo{
-			RequestId: req.GetVector().GetId(),
-		}
-		resInfo := &errdetails.ResourceInfo{
-			ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpsertRPCName + ".Rollback.BroadCast",
-			ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-		}
-		if errors.Is(err, errors.ErrGRPCClientConnNotFound("*")) {
-			err = status.WrapWithInternal(
-				vald.UpsertRPCName+" for Rollback connection not found", err, reqInfo, resInfo,
-			)
-			log.Warn(err)
-			if span != nil {
-				span.RecordError(err)
-				span.SetAttributes(trace.StatusCodeInternal(err.Error())...)
-				span.SetStatus(trace.StatusError, err.Error())
-			}
-			return nil, err
-		}
-
-		// There is no possibility to reach this part, but we add error handling just in case.
+	default:
 		st, msg, err := status.ParseError(err, codes.Internal,
-			"failed to parse "+vald.UpsertRPCName+" for Rollback gRPC error response", reqInfo, resInfo,
-		)
+			"failed to parse "+vald.UpsertRPCName+" gRPC error response", reqInfo, resInfo)
 		log.Warn(err)
 		if span != nil {
 			span.RecordError(err)
@@ -2221,54 +2136,17 @@ func (s *server) Upsert(ctx context.Context, req *payload.Upsert_Request) (loc *
 		}
 		return nil, err
 	}
-	if rerrs == nil {
-		log.Debugf("rollback for Upsert API mirror request succeeded to %v", targets)
-		st, msg, err := status.ParseError(errs, codes.Internal,
-			"failed to parse "+vald.UpsertRPCName+" gRPC error response",
-			&errdetails.RequestInfo{
-				RequestId:   req.GetVector().GetId(),
-				ServingData: errdetails.Serialize(req),
-			},
-			&errdetails.ResourceInfo{
-				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpsertRPCName,
-				ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-			},
-		)
-		if span != nil {
-			span.RecordError(err)
-			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
-			span.SetStatus(trace.StatusError, err.Error())
-		}
-		return nil, err
-	}
-	log.Debugf("failed to rollback for Upsert API mirror request succeeded to %v: %v", targets, rerrs)
-	st, msg, err := status.ParseError(rerrs, codes.Internal,
-		"failed to parse "+vald.UpsertRPCName+" for Rollback gRPC error response",
-		&errdetails.RequestInfo{
-			RequestId: req.GetVector().GetId(),
-		},
-		&errdetails.ResourceInfo{
-			ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpsertRPCName + ".Rollback",
-			ResourceName: fmt.Sprintf("%s: %s(%s) %v", apiName, s.name, s.ip, targets),
-		},
-	)
-	if span != nil {
-		span.RecordError(err)
-		span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
-		span.SetStatus(trace.StatusError, err.Error())
-	}
-	return nil, err
 }
 
-func (s *server) upsert(ctx context.Context, client vald.UpsertClient, req *payload.Upsert_Request, opts ...grpc.CallOption) (loc *payload.Object_Location, err error) {
-	ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "upsert"), apiName+"/upsert")
+func (s *server) doUpsert(ctx context.Context, req *payload.Upsert_Request, f func(ctx context.Context) (*payload.Object_Location, error)) (loc *payload.Object_Location, err error) {
+	ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "doUpsert"), apiName+"/doUpsert")
 	defer func() {
 		if span != nil {
 			span.End()
 		}
 	}()
 
-	loc, err = client.Upsert(ctx, req, opts...)
+	loc, err = f(ctx)
 	if err != nil {
 		reqInfo := &errdetails.RequestInfo{
 			RequestId:   req.GetVector().GetId(),
@@ -2306,7 +2184,7 @@ func (s *server) upsert(ctx context.Context, client vald.UpsertClient, req *payl
 			)
 			attrs = trace.FromGRPCStatus(st.Code(), msg)
 		}
-		log.Warn("failed to process Upsert request\terror: %s", err.Error())
+		log.Warn(err)
 		if span != nil {
 			span.RecordError(err)
 			span.SetAttributes(attrs...)
@@ -2446,59 +2324,31 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (loc *
 	// When this condition is matched, the request is proxied to another Mirror gateway.
 	// So this component sends the request only to the Vald gateway (LB gateway) of own cluster.
 	if len(reqSrcPodName) != 0 {
-		_, err = s.gateway.Do(ctx, s.vAddr, func(ctx context.Context, vc vald.ClientWithMirror, copts ...grpc.CallOption) (interface{}, error) {
-			loc, err = vc.Remove(ctx, req, copts...)
-			if err != nil {
-				return nil, err
-			}
-			return loc, nil
-		})
+		loc, err = s.doRemove(ctx, req,
+			func(ctx context.Context) (*payload.Object_Location, error) {
+				s.gateway.Do(ctx, s.vAddr, func(ctx context.Context, vc vald.ClientWithMirror, copts ...grpc.CallOption) (interface{}, error) {
+					loc, err = vc.Remove(ctx, req, copts...)
+					return loc, err
+				})
+				return loc, err
+			},
+		)
 		if err != nil {
 			reqInfo := &errdetails.RequestInfo{
-				RequestId:   req.GetId().GetId(),
-				ServingData: errdetails.Serialize(req),
+				RequestId: req.GetId().GetId(),
 			}
 			resInfo := &errdetails.ResourceInfo{
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveRPCName,
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, s.vAddr),
 			}
-			var attrs trace.Attributes
+			st, msg, err := status.ParseError(err, codes.Internal,
+				"failed to parse "+vald.RemoveRPCName+" gRPC error response", reqInfo, resInfo,
+			)
 
-			switch {
-			case errors.Is(err, context.Canceled):
-				err = status.WrapWithCanceled(
-					vald.RemoveRPCName+" API canceld", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeCancelled(err.Error())
-			case errors.Is(err, context.DeadlineExceeded):
-				err = status.WrapWithDeadlineExceeded(
-					vald.RemoveRPCName+" API deadline exceeded", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeDeadlineExceeded(err.Error())
-			case errors.Is(err, errors.ErrTargetNotFound):
-				err = status.WrapWithInternal(
-					vald.RemoveRPCName+" API target not found", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeInternal(err.Error())
-			case errors.Is(err, errors.ErrGRPCClientConnNotFound("*")):
-				err = status.WrapWithInternal(
-					vald.RemoveRPCName+" API connection not found", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeInternal(err.Error())
-			default:
-				var (
-					st  *status.Status
-					msg string
-				)
-				st, msg, err = status.ParseError(err, codes.Internal,
-					"failed to parse "+vald.RemoveRPCName+" gRPC error response", reqInfo, resInfo,
-				)
-				attrs = trace.FromGRPCStatus(st.Code(), msg)
-			}
 			log.Warn(err)
 			if span != nil {
 				span.RecordError(err)
-				span.SetAttributes(attrs...)
+				span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
 				span.SetStatus(trace.StatusError, err.Error())
 			}
 			return nil, err
@@ -2507,23 +2357,12 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (loc *
 		return loc, nil
 	}
 
-	objReq := &payload.Object_VectorRequest{
-		Id: &payload.Object_ID{
-			Id: req.GetId().GetId(),
-		},
-	}
-	oldVecs, err := s.getObjects(ctx, objReq)
-	if err != nil {
-		return nil, err
-	}
-
 	var mu sync.Mutex
-	var result sync.Map[string, error]
+	var result sync.Map[string, *errorState]
 	loc = &payload.Object_Location{
 		Uuid: req.GetId().GetId(),
 		Ips:  make([]string, 0),
 	}
-
 	err = s.gateway.BroadCast(ctx, func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error {
 		ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "BroadCast/"+target), apiName+"/"+vald.RemoveRPCName+"/"+target)
 		defer func() {
@@ -2532,23 +2371,32 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (loc *
 			}
 		}()
 
-		ce, err := s.remove(ctx, vc, req, copts...)
+		code := codes.OK
+		ce, err := s.doRemove(ctx, req, func(ctx context.Context) (*payload.Object_Location, error) {
+			return vc.Remove(ctx, req, copts...)
+		})
 		if err != nil {
-			st, _, _ := status.ParseError(err, codes.Internal,
-				"failed to parse "+vald.RemoveRPCName+" gRPC error response for "+target,
+			var (
+				st  *status.Status
+				msg string
+			)
+			st, msg, err = status.ParseError(err, codes.Internal,
+				"failed to parse "+vald.RemoveRPCName+" gRPC error response",
 				&errdetails.RequestInfo{
-					RequestId:   req.GetId().GetId(),
-					ServingData: errdetails.Serialize(req),
+					RequestId: req.GetId().GetId(),
 				},
 				&errdetails.ResourceInfo{
 					ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveRPCName + ".BroadCast/" + target,
 					ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
 				},
 			)
-			if st.Code() == codes.NotFound {
-				// NOTE: If it is strictly necessary to check, fix this logic.
-				return nil
+			log.Warn(err)
+			if span != nil {
+				span.RecordError(err)
+				span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+				span.SetStatus(trace.StatusError, err.Error())
 			}
+			code = st.Code()
 		}
 		if err == nil && ce != nil {
 			mu.Lock()
@@ -2556,13 +2404,12 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (loc *
 			loc.Ips = append(loc.Ips, ce.GetIps()...)
 			mu.Unlock()
 		}
-		result.Store(target, err)
+		result.Store(target, &errorState{err, code})
 		return err
 	})
 	if err != nil {
 		reqInfo := &errdetails.RequestInfo{
-			RequestId:   req.GetId().GetId(),
-			ServingData: errdetails.Serialize(req),
+			RequestId: req.GetId().GetId(),
 		}
 		resInfo := &errdetails.ResourceInfo{
 			ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveRPCName + ".BroadCast",
@@ -2594,113 +2441,43 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (loc *
 		return nil, err
 	}
 
-	var errs error
-	targets := make([]string, 0, 10)
-	result.Range(func(target string, err error) bool {
-		if err == nil {
-			targets = append(targets, target)
+	var notFoundCnt int
+	successTgts := make([]string, 0, result.Len()/2)
+	result.Range(func(target string, em *errorState) bool {
+		if em.err == nil {
+			successTgts = append(successTgts, target)
 		} else {
-			errs = errors.Join(errs, err)
+			if em.code == codes.NotFound {
+				notFoundCnt++
+			}
+			err = errors.Join(err, em.err)
 		}
 		return true
 	})
+
+	reqInfo := &errdetails.RequestInfo{
+		RequestId: req.GetId().GetId(),
+	}
+	resInfo := &errdetails.ResourceInfo{
+		ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveRPCName,
+		ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
+	}
+
 	switch {
-	case errs == nil:
-		log.Debugf("Remove API mirror request succeeded to %#v", loc)
+	case err == nil, len(successTgts) > 0 && result.Len() == len(successTgts)+notFoundCnt:
+		log.Debugf(vald.RemoveRPCName+" API request succeeded to %#v", loc)
 		return loc, nil
-	case len(targets) == 0 && errs != nil:
-		log.Error("failed to Remove API mirror request: %v and can not rollback because success target length is 0", errs)
-		st, msg, err := status.ParseError(errs, codes.Internal,
-			"failed to parse "+vald.RemoveRPCName+" gRPC error response",
-			&errdetails.RequestInfo{
-				RequestId:   req.GetId().GetId(),
-				ServingData: errdetails.Serialize(req),
-			},
-			&errdetails.ResourceInfo{
-				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveRPCName,
-				ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-			},
-		)
+	case result.Len() == notFoundCnt:
+		err = status.WrapWithNotFound(vald.RemoveRPCName+" API id "+req.GetId().GetId()+" not found", err, reqInfo, resInfo)
 		if span != nil {
 			span.RecordError(err)
-			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+			span.SetAttributes(trace.StatusCodeAlreadyExists(err.Error())...)
 			span.SetStatus(trace.StatusError, err.Error())
 		}
 		return nil, err
-	}
-	log.Error("failed to Remove API mirror request: %v, so starts the rollback request", errs)
-
-	var emu sync.Mutex
-	var rerrs error
-	err = s.gateway.DoMulti(ctx, targets,
-		func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error {
-			ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "rollback/BroadCast/"+target), apiName+"/"+vald.RemoveRPCName+"/rollback/"+target)
-			defer func() {
-				if span != nil {
-					span.End()
-				}
-			}()
-
-			objv, ok := oldVecs.Load(target)
-			if !ok || objv == nil {
-				log.Debug("failed to load old vector from  %s", target)
-				return nil
-			}
-			req := &payload.Upsert_Request{
-				Vector: objv,
-				Config: &payload.Upsert_Config{
-					SkipStrictExistCheck: true,
-				},
-			}
-			_, err := s.upsert(ctx, vc, req, copts...)
-			if err != nil {
-				st, _, _ := status.ParseError(err, codes.Internal,
-					"failed to parse "+vald.UpsertRPCName+" for "+vald.RemoveRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetVector().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveRPCName + "." + vald.UpsertRPCName + ".BroadCast/" + target,
-						ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-					},
-				)
-				if st.Code() == codes.AlreadyExists {
-					return nil
-				}
-				emu.Lock()
-				rerrs = errors.Join(rerrs, err)
-				emu.Unlock()
-				return err
-			}
-			return nil
-		},
-	)
-	if err != nil {
-		reqInfo := &errdetails.RequestInfo{
-			RequestId: req.GetId().GetId(),
-		}
-		resInfo := &errdetails.ResourceInfo{
-			ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveRPCName + "." + vald.UpsertRPCName + ".BroadCast",
-			ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-		}
-		if errors.Is(err, errors.ErrGRPCClientConnNotFound("*")) {
-			err = status.WrapWithInternal(
-				vald.UpsertRPCName+" for "+vald.RemoveRPCName+" API connection not found", err, reqInfo, resInfo,
-			)
-			log.Warn(err)
-			if span != nil {
-				span.RecordError(err)
-				span.SetAttributes(trace.StatusCodeInternal(err.Error())...)
-				span.SetStatus(trace.StatusError, err.Error())
-			}
-			return nil, err
-		}
-
-		// There is no possibility to reach this part, but we add error handling just in case.
+	default:
 		st, msg, err := status.ParseError(err, codes.Internal,
-			"failed to parse "+vald.UpsertRPCName+" for "+vald.RemoveRPCName+" gRPC error response", reqInfo, resInfo,
-		)
+			"failed to parse "+vald.RemoveRPCName+" gRPC error response", reqInfo, resInfo)
 		log.Warn(err)
 		if span != nil {
 			span.RecordError(err)
@@ -2709,58 +2486,20 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (loc *
 		}
 		return nil, err
 	}
-	if rerrs == nil {
-		log.Debugf("rollback for Remove API mirror request succeeded to %v", targets)
-		st, msg, err := status.ParseError(errs, codes.Internal,
-			"failed to parse "+vald.RemoveRPCName+" gRPC error response",
-			&errdetails.RequestInfo{
-				RequestId:   req.GetId().GetId(),
-				ServingData: errdetails.Serialize(req),
-			},
-			&errdetails.ResourceInfo{
-				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveRPCName,
-				ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-			},
-		)
-		if span != nil {
-			span.RecordError(err)
-			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
-			span.SetStatus(trace.StatusError, err.Error())
-		}
-		return nil, err
-	}
-	log.Debugf("failed to rollback for Remove API mirror request succeeded to %v: %v", targets, rerrs)
-	st, msg, err := status.ParseError(rerrs, codes.Internal,
-		"failed to parse "+vald.UpsertRPCName+" for "+vald.RemoveRPCName+" gRPC error response",
-		&errdetails.RequestInfo{
-			RequestId: req.GetId().GetId(),
-		},
-		&errdetails.ResourceInfo{
-			ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveRPCName + "." + vald.UpsertRPCName,
-			ResourceName: fmt.Sprintf("%s: %s(%s) %v", apiName, s.name, s.ip, targets),
-		},
-	)
-	if span != nil {
-		span.RecordError(err)
-		span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
-		span.SetStatus(trace.StatusError, err.Error())
-	}
-	return nil, err
 }
 
-func (s *server) remove(ctx context.Context, client vald.RemoveClient, req *payload.Remove_Request, opts ...grpc.CallOption) (*payload.Object_Location, error) {
-	ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "remove"), apiName+"/remove")
+func (s *server) doRemove(ctx context.Context, req *payload.Remove_Request, f func(ctx context.Context) (*payload.Object_Location, error)) (loc *payload.Object_Location, err error) {
+	ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "doRemove"), apiName+"/doRemove")
 	defer func() {
 		if span != nil {
 			span.End()
 		}
 	}()
 
-	loc, err := client.Remove(ctx, req, opts...)
+	loc, err = f(ctx)
 	if err != nil {
 		reqInfo := &errdetails.RequestInfo{
-			RequestId:   req.GetId().GetId(),
-			ServingData: errdetails.Serialize(req),
+			RequestId: req.GetId().GetId(),
 		}
 		resInfo := &errdetails.ResourceInfo{
 			ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveRPCName,
@@ -2934,10 +2673,15 @@ func (s *server) RemoveByTimestamp(ctx context.Context, req *payload.Remove_Time
 	// When this condition is matched, the request is proxied to another Mirror gateway.
 	// So this component sends requests only to the Vald gateway (LB gateway) of its own cluster.
 	if len(reqSrcPodName) != 0 {
-		_, err = s.gateway.Do(ctx, s.vAddr, func(ctx context.Context, vc vald.ClientWithMirror, opts ...grpc.CallOption) (interface{}, error) {
-			locs, err = vc.RemoveByTimestamp(ctx, req, opts...)
-			return locs, err
-		})
+		locs, err = s.doRemoveByTimestamp(ctx, req,
+			func(ctx context.Context) (*payload.Object_Locations, error) {
+				s.gateway.Do(ctx, s.vAddr, func(ctx context.Context, vc vald.ClientWithMirror, copts ...grpc.CallOption) (interface{}, error) {
+					locs, err = vc.RemoveByTimestamp(ctx, req, copts...)
+					return locs, err
+				})
+				return locs, err
+			},
+		)
 		if err != nil {
 			reqInfo := &errdetails.RequestInfo{
 				ServingData: errdetails.Serialize(req),
@@ -2946,55 +2690,27 @@ func (s *server) RemoveByTimestamp(ctx context.Context, req *payload.Remove_Time
 				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveByTimestampRPCName,
 				ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, s.vAddr),
 			}
-			var attrs trace.Attributes
+			st, msg, err := status.ParseError(err, codes.Internal,
+				"failed to parse "+vald.RemoveRPCName+" gRPC error response", reqInfo, resInfo,
+			)
 
-			switch {
-			case errors.Is(err, context.Canceled):
-				err = status.WrapWithCanceled(
-					vald.RemoveByTimestampRPCName+" API canceld", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeCancelled(err.Error())
-			case errors.Is(err, context.DeadlineExceeded):
-				err = status.WrapWithDeadlineExceeded(
-					vald.RemoveByTimestampRPCName+" API deadline exceeded", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeDeadlineExceeded(err.Error())
-			case errors.Is(err, errors.ErrTargetNotFound):
-				err = status.WrapWithInternal(
-					vald.RemoveByTimestampRPCName+" API target not found", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeInternal(err.Error())
-			case errors.Is(err, errors.ErrGRPCClientConnNotFound("*")):
-				err = status.WrapWithInternal(
-					vald.RemoveByTimestampRPCName+" API connection not found", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeInternal(err.Error())
-			default:
-				var (
-					st  *status.Status
-					msg string
-				)
-				st, msg, err = status.ParseError(err, codes.Internal,
-					"failed to parse "+vald.RemoveByTimestampRPCName+" gRPC error response", reqInfo, resInfo,
-				)
-				attrs = trace.FromGRPCStatus(st.Code(), msg)
-			}
 			log.Warn(err)
 			if span != nil {
 				span.RecordError(err)
-				span.SetAttributes(attrs...)
+				span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
 				span.SetStatus(trace.StatusError, err.Error())
 			}
 			return nil, err
 		}
+		log.Debugf("RemoveByTimestamp API remove succeeded to %#v", locs)
 		return locs, nil
 	}
 
 	var mu sync.Mutex
-	var result sync.Map[string, error]
+	var result sync.Map[string, *errorState]
 	locs = new(payload.Object_Locations)
 
-	err = s.gateway.BroadCast(ctx, func(ctx context.Context, target string, vc vald.ClientWithMirror, opts ...grpc.CallOption) error {
+	err = s.gateway.BroadCast(ctx, func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error {
 		ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "BroadCast/"+target), apiName+"/"+vald.RemoveByTimestampRPCName+"/"+target)
 		defer func() {
 			if span != nil {
@@ -3002,61 +2718,37 @@ func (s *server) RemoveByTimestamp(ctx context.Context, req *payload.Remove_Time
 			}
 		}()
 
-		res, err := vc.RemoveByTimestamp(ctx, req, opts...)
+		code := codes.OK
+		res, err := s.doRemoveByTimestamp(ctx, req, func(ctx context.Context) (*payload.Object_Locations, error) {
+			return vc.RemoveByTimestamp(ctx, req, copts...)
+		})
 		if err != nil {
-			reqInfo := &errdetails.RequestInfo{
-				ServingData: errdetails.Serialize(req),
-			}
-			resInfo := &errdetails.ResourceInfo{
-				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveByTimestampRPCName,
-				ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-			}
-			var attrs trace.Attributes
-			var code codes.Code
-
-			switch {
-			case errors.Is(err, context.Canceled):
-				err = status.WrapWithCanceled(
-					vald.RemoveByTimestampRPCName+" API canceld", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeCancelled(err.Error())
-			case errors.Is(err, context.DeadlineExceeded):
-				err = status.WrapWithDeadlineExceeded(
-					vald.RemoveByTimestampRPCName+" API deadline exceeded", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeDeadlineExceeded(err.Error())
-			case errors.Is(err, errors.ErrGRPCClientConnNotFound("*")):
-				err = status.WrapWithInternal(
-					vald.RemoveByTimestampRPCName+" API connection not found", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeInternal(err.Error())
-			default:
-				var (
-					st  *status.Status
-					msg string
-				)
-				st, msg, err = status.ParseError(err, codes.Internal,
-					"failed to parse "+vald.RemoveByTimestampRPCName+" gRPC error response", reqInfo, resInfo,
-				)
-				attrs = trace.FromGRPCStatus(st.Code(), msg)
-				code = st.Code()
-			}
+			var (
+				st  *status.Status
+				msg string
+			)
+			st, msg, err = status.ParseError(err, codes.Internal,
+				"failed to parse "+vald.RemoveByTimestampRPCName+" gRPC error response",
+				&errdetails.ResourceInfo{
+					ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveByTimestampRPCName + ".BroadCast/" + target,
+					ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
+				},
+			)
 			log.Warn(err)
 			if span != nil {
 				span.RecordError(err)
-				span.SetAttributes(attrs...)
+				span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
 				span.SetStatus(trace.StatusError, err.Error())
 			}
-			if code == codes.NotFound {
-				return nil
-			}
-			result.Store(target, err)
-			return err
+			code = st.Code()
 		}
-		mu.Lock()
-		locs.Locations = append(locs.Locations, res.GetLocations()...)
-		mu.Unlock()
-		return nil
+		if err == nil && res != nil {
+			mu.Lock()
+			locs.Locations = append(locs.Locations, res.GetLocations()...)
+			mu.Unlock()
+		}
+		result.Store(target, &errorState{err, code})
+		return err
 	})
 	if err != nil {
 		reqInfo := &errdetails.RequestInfo{
@@ -3084,28 +2776,110 @@ func (s *server) RemoveByTimestamp(ctx context.Context, req *payload.Remove_Time
 			"failed to parse "+vald.RemoveByTimestampRPCName+" gRPC error response", reqInfo, resInfo,
 		)
 		log.Warn(err)
-		if err != nil {
-			if span != nil {
-				span.RecordError(err)
-				span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
-				span.SetStatus(trace.StatusError, err.Error())
-			}
+		if span != nil {
+			span.RecordError(err)
+			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+			span.SetStatus(trace.StatusError, err.Error())
 		}
 		return nil, err
 	}
 
-	result.Range(func(_ string, rerr error) bool {
-		if rerr != nil {
-			err = errors.Join(err, rerr)
+	var notFoundCnt int
+	successTgts := make([]string, 0, result.Len()/2)
+	result.Range(func(target string, em *errorState) bool {
+		if em.err == nil {
+			successTgts = append(successTgts, target)
+		} else {
+			if em.code == codes.NotFound {
+				notFoundCnt++
+			}
+			err = errors.Join(err, em.err)
 		}
 		return true
 	})
-	if err != nil {
+
+	reqInfo := &errdetails.RequestInfo{
+		ServingData: errdetails.Serialize(req),
+	}
+	resInfo := &errdetails.ResourceInfo{
+		ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveByTimestampRPCName,
+		ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
+	}
+
+	switch {
+	case err == nil:
+		log.Debugf(vald.RemoveByTimestampRPCName+" API request succeeded to %#v", locs)
+		return locs, nil
+	case result.Len() == notFoundCnt:
+		err = status.WrapWithNotFound(vald.RemoveByTimestampRPCName+" API target same vector already exists", err, reqInfo, resInfo)
+		if span != nil {
+			span.RecordError(err)
+			span.SetAttributes(trace.StatusCodeAlreadyExists(err.Error())...)
+			span.SetStatus(trace.StatusError, err.Error())
+		}
+		return nil, err
+	default:
 		st, msg, err := status.ParseError(err, codes.Internal,
-			"failed to parse "+vald.RemoveByTimestampRPCName+" gRPC error response")
-		if err != nil {
+			"failed to parse "+vald.RemoveByTimestampRPCName+" gRPC error response", reqInfo, resInfo)
+		log.Warn(err)
+		if span != nil {
 			span.RecordError(err)
 			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+			span.SetStatus(trace.StatusError, err.Error())
+		}
+		return nil, err
+	}
+}
+
+func (s *server) doRemoveByTimestamp(ctx context.Context, req *payload.Remove_TimestampRequest, f func(ctx context.Context) (*payload.Object_Locations, error)) (locs *payload.Object_Locations, err error) {
+	ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "doRemoveByTimestamp"), apiName+"/doRemoveByTimestamp")
+	defer func() {
+		if span != nil {
+			span.End()
+		}
+	}()
+
+	locs, err = f(ctx)
+	if err != nil {
+		reqInfo := &errdetails.RequestInfo{
+			ServingData: errdetails.Serialize(req),
+		}
+		resInfo := &errdetails.ResourceInfo{
+			ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveByTimestampRPCName,
+			ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
+		}
+		var attrs trace.Attributes
+
+		switch {
+		case errors.Is(err, context.Canceled):
+			err = status.WrapWithCanceled(
+				vald.RemoveByTimestampRPCName+" API canceld", err, reqInfo, resInfo,
+			)
+			attrs = trace.StatusCodeCancelled(err.Error())
+		case errors.Is(err, context.DeadlineExceeded):
+			err = status.WrapWithDeadlineExceeded(
+				vald.RemoveByTimestampRPCName+" API deadline exceeded", err, reqInfo, resInfo,
+			)
+			attrs = trace.StatusCodeDeadlineExceeded(err.Error())
+		case errors.Is(err, errors.ErrGRPCClientConnNotFound("*")):
+			err = status.WrapWithInternal(
+				vald.RemoveByTimestampRPCName+" API connection not found", err, reqInfo, resInfo,
+			)
+			attrs = trace.StatusCodeInternal(err.Error())
+		default:
+			var (
+				st  *status.Status
+				msg string
+			)
+			st, msg, err = status.ParseError(err, codes.Internal,
+				"failed to parse "+vald.RemoveByTimestampRPCName+" gRPC error response", reqInfo, resInfo,
+			)
+			attrs = trace.FromGRPCStatus(st.Code(), msg)
+		}
+		log.Warn(err)
+		if span != nil {
+			span.RecordError(err)
+			span.SetAttributes(attrs...)
 			span.SetStatus(trace.StatusError, err.Error())
 		}
 		return nil, err
@@ -3181,137 +2955,6 @@ func (s *server) GetObject(ctx context.Context, req *payload.Object_VectorReques
 	return vec, nil
 }
 
-func (s *server) getObjects(ctx context.Context, req *payload.Object_VectorRequest) (vecs *sync.Map[string, *payload.Object_Vector], err error) {
-	ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "getObjects"), apiName+"/"+vald.GetObjectRPCName+"/getObjects")
-	defer func() {
-		if span != nil {
-			span.End()
-		}
-	}()
-
-	var errs error
-	var emu sync.Mutex
-	vecs = new(sync.Map[string, *payload.Object_Vector])
-	err = s.gateway.BroadCast(ctx, func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error {
-		ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "BroadCast/"+target), apiName+"/"+vald.GetObjectRPCName+"/getObjects/"+target)
-		defer func() {
-			if span != nil {
-				span.End()
-			}
-		}()
-
-		vec, err := vc.GetObject(ctx, req, copts...)
-		if err != nil {
-			reqInfo := &errdetails.RequestInfo{
-				RequestId:   req.GetId().GetId(),
-				ServingData: errdetails.Serialize(req),
-			}
-			resInfo := &errdetails.ResourceInfo{
-				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.GetObjectRPCName,
-				ResourceName: fmt.Sprintf("%s: %s(%s) to %s", apiName, s.name, s.ip, target),
-			}
-			var attrs trace.Attributes
-			var code codes.Code
-
-			switch {
-			case errors.Is(err, context.Canceled):
-				err = status.WrapWithCanceled(
-					vald.GetObjectRPCName+" API canceld", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeCancelled(err.Error())
-				code = codes.Canceled
-			case errors.Is(err, context.DeadlineExceeded):
-				err = status.WrapWithDeadlineExceeded(
-					vald.GetObjectRPCName+" API deadline exceeded", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeDeadlineExceeded(err.Error())
-				code = codes.DeadlineExceeded
-			case errors.Is(err, errors.ErrTargetNotFound):
-				err = status.WrapWithInternal(
-					vald.GetObjectRPCName+" API target not found", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeInternal(err.Error())
-				code = codes.Internal
-			case errors.Is(err, errors.ErrGRPCClientConnNotFound("*")):
-				err = status.WrapWithInternal(
-					vald.GetObjectRPCName+" API connection not found", err, reqInfo, resInfo,
-				)
-				attrs = trace.StatusCodeInternal(err.Error())
-				code = codes.Internal
-			default:
-				var (
-					st  *status.Status
-					msg string
-				)
-				st, msg, err = status.ParseError(err, codes.Internal,
-					"failed to parse "+vald.GetObjectRPCName+" gRPC error response", reqInfo, resInfo,
-				)
-				attrs = trace.FromGRPCStatus(st.Code(), msg)
-				code = st.Code()
-			}
-			log.Warn(err)
-			if span != nil {
-				span.RecordError(err)
-				span.SetAttributes(attrs...)
-				span.SetStatus(trace.StatusError, err.Error())
-			}
-			if code == codes.NotFound {
-				return nil
-			}
-			emu.Lock()
-			errs = errors.Join(errs, err)
-			emu.Unlock()
-			return err
-		}
-		vecs.Store(target, vec)
-		return nil
-	})
-	if err != nil {
-		if errors.Is(err, errors.ErrGRPCClientConnNotFound("*")) {
-			err = status.WrapWithInternal(
-				vald.GetObjectRPCName+" API connection not found", err,
-				&errdetails.RequestInfo{
-					RequestId:   req.GetId().GetId(),
-					ServingData: errdetails.Serialize(req),
-				},
-				&errdetails.ResourceInfo{
-					ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.GetObjectRPCName + ".BroadCast",
-					ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-				},
-			)
-			log.Warn(err)
-			if span != nil {
-				span.RecordError(err)
-				span.SetAttributes(trace.StatusCodeInternal(err.Error())...)
-				span.SetStatus(trace.StatusError, err.Error())
-			}
-			return nil, err
-		}
-		errs = errors.Join(errs, err)
-	}
-	if errs != nil {
-		st, msg, err := status.ParseError(errs, codes.Internal,
-			"failed to parse "+vald.GetObjectRPCName+" gRPC error response",
-			&errdetails.RequestInfo{
-				RequestId:   req.GetId().GetId(),
-				ServingData: errdetails.Serialize(req),
-			},
-			&errdetails.ResourceInfo{
-				ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.GetObjectRPCName + "." + "BroadCast",
-				ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-			},
-		)
-		log.Warn(err)
-		if span != nil {
-			span.RecordError(err)
-			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
-			span.SetStatus(trace.StatusError, err.Error())
-		}
-		return nil, err
-	}
-	return vecs, nil
-}
-
 func (s *server) StreamGetObject(stream vald.Object_StreamGetObjectServer) (err error) {
 	ctx, span := trace.StartSpan(grpc.WithGRPCMethod(stream.Context(), vald.PackageName+"."+vald.ObjectRPCServiceName+"/"+vald.StreamGetObjectRPCName), apiName+"/"+vald.StreamGetObjectRPCName)
 	defer func() {
@@ -3358,4 +3001,9 @@ func (s *server) StreamGetObject(stream vald.Object_StreamGetObjectServer) (err 
 		return err
 	}
 	return nil
+}
+
+type errorState struct {
+	err  error
+	code codes.Code
 }

--- a/pkg/gateway/mirror/handler/grpc/handler.go
+++ b/pkg/gateway/mirror/handler/grpc/handler.go
@@ -2817,7 +2817,7 @@ func (s *server) RemoveByTimestamp(ctx context.Context, req *payload.Remove_Time
 
 	switch {
 	case result.Len() == notFoundCnt:
-		err = status.WrapWithNotFound(vald.RemoveByTimestampRPCName+" API target same vector already exists", err, reqInfo, resInfo)
+		err = status.WrapWithNotFound(vald.RemoveByTimestampRPCName+" API target not found", err, reqInfo, resInfo)
 		log.Warn(err)
 		if span != nil {
 			span.RecordError(err)

--- a/pkg/gateway/mirror/handler/grpc/handler.go
+++ b/pkg/gateway/mirror/handler/grpc/handler.go
@@ -1162,8 +1162,7 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (loc *
 		}
 		result.Store(target, &errorState{err, code})
 		return err
-	},
-	)
+	})
 	if err != nil {
 		reqInfo := &errdetails.RequestInfo{
 			RequestId: updateReq.GetVector().GetId(),
@@ -1630,7 +1629,6 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (loc *
 			Timestamp: req.GetConfig().GetTimestamp(),
 		},
 	}
-
 	err = s.gateway.DoMulti(ctx, notFoundTgts, func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error {
 		ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "BroadCast/"+target), apiName+"/"+vald.InsertRPCName+"/"+target)
 		defer func() {
@@ -2049,8 +2047,7 @@ func (s *server) Upsert(ctx context.Context, req *payload.Upsert_Request) (loc *
 		}
 		result.Store(target, &errorState{err, code})
 		return err
-	},
-	)
+	})
 	if err != nil {
 		reqInfo := &errdetails.RequestInfo{
 			RequestId:   req.GetVector().GetId(),

--- a/pkg/gateway/mirror/handler/grpc/handler.go
+++ b/pkg/gateway/mirror/handler/grpc/handler.go
@@ -2835,7 +2835,11 @@ func (s *server) RemoveByTimestamp(ctx context.Context, req *payload.Remove_Time
 	}
 }
 
-func (s *server) doRemoveByTimestamp(ctx context.Context, req *payload.Remove_TimestampRequest, f func(ctx context.Context) (*payload.Object_Locations, error)) (locs *payload.Object_Locations, err error) {
+func (s *server) doRemoveByTimestamp(
+	ctx context.Context,
+	req *payload.Remove_TimestampRequest,
+	f func(ctx context.Context) (*payload.Object_Locations, error),
+) (locs *payload.Object_Locations, err error) {
 	ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, "doRemoveByTimestamp"), apiName+"/doRemoveByTimestamp")
 	defer func() {
 		if span != nil {

--- a/pkg/gateway/mirror/handler/grpc/handler.go
+++ b/pkg/gateway/mirror/handler/grpc/handler.go
@@ -976,6 +976,9 @@ func (s *server) Insert(ctx context.Context, req *payload.Insert_Request) (loc *
 		return loc, nil
 	}
 
+	// If this condition is matched, it means the request from user.
+	// So this component sends requests to other Mirror gateways and the Vald gateway (LB gateway) of its own cluster.
+
 	var mu sync.Mutex
 	var result sync.Map[string, *errorState] // map[target host: error state]
 	loc = &payload.Object_Location{
@@ -1470,6 +1473,9 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (loc *
 		log.Debugf("Update API succeeded to %#v", loc)
 		return loc, nil
 	}
+
+	// If this condition is matched, it means the request from user.
+	// So this component sends requests to other Mirror gateways and the Vald gateway (LB gateway) of its own cluster.
 
 	var mu sync.Mutex
 	var result sync.Map[string, *errorState] // map[target host: error state]
@@ -1997,6 +2003,9 @@ func (s *server) Upsert(ctx context.Context, req *payload.Upsert_Request) (loc *
 		return loc, nil
 	}
 
+	// If this condition is matched, it means the request from user.
+	// So this component sends requests to other Mirror gateways and the Vald gateway (LB gateway) of its own cluster.
+
 	var mu sync.Mutex
 	var result sync.Map[string, *errorState] // map[target host: error state]
 	loc = &payload.Object_Location{
@@ -2354,6 +2363,9 @@ func (s *server) Remove(ctx context.Context, req *payload.Remove_Request) (loc *
 		return loc, nil
 	}
 
+	// If this condition is matched, it means the request from user.
+	// So this component sends requests to other Mirror gateways and the Vald gateway (LB gateway) of its own cluster.
+
 	var mu sync.Mutex
 	var result sync.Map[string, *errorState] // map[target host: error state]
 	loc = &payload.Object_Location{
@@ -2706,6 +2718,9 @@ func (s *server) RemoveByTimestamp(ctx context.Context, req *payload.Remove_Time
 		log.Debugf("RemoveByTimestamp API remove succeeded to %#v", locs)
 		return locs, nil
 	}
+
+	// If this condition is matched, it means the request from user.
+	// So this component sends requests to other Mirror gateways and the Vald gateway (LB gateway) of its own cluster.
 
 	var mu sync.Mutex
 	var result sync.Map[string, *errorState] // map[target host: error state]

--- a/pkg/gateway/mirror/handler/grpc/handler.go
+++ b/pkg/gateway/mirror/handler/grpc/handler.go
@@ -1576,7 +1576,7 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (loc *
 		}
 		return true
 	})
-	if err == nil || result.Len() == len(successTgts)+alreadyExistsCnt {
+	if err == nil || (len(successTgts) > 0 && result.Len() == len(successTgts)+alreadyExistsCnt) {
 		log.Debugf(vald.UpdateRPCName+" API request succeeded to %#v", loc)
 		return loc, nil
 	}
@@ -1729,7 +1729,7 @@ func (s *server) Update(ctx context.Context, req *payload.Update_Request) (loc *
 		}
 		return true
 	})
-	if err == nil || result.Len() == len(successTgts)+alreadyExistsCnt {
+	if err == nil || (len(successTgts) > 0 && result.Len() == len(successTgts)+alreadyExistsCnt) {
 		log.Debugf(vald.InsertRPCName+" for "+vald.UpdateRPCName+" API request succeeded to %#v", loc)
 		return loc, nil
 	}

--- a/pkg/gateway/mirror/handler/grpc/handler_test.go
+++ b/pkg/gateway/mirror/handler/grpc/handler_test.go
@@ -15,7 +15,6 @@ package grpc
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -1086,7 +1085,6 @@ func Test_server_Update(t *testing.T) {
 			}
 
 			gotLoc, err := s.Update(test.args.ctx, test.args.req)
-			fmt.Println(err)
 			if err := checkFunc(test.want, gotLoc, err); err != nil {
 				tt.Errorf("error = %v", err)
 			}
@@ -1818,8 +1816,12 @@ func Test_server_RemoveByTimestamp(t *testing.T) {
 					"127.0.0.1",
 				},
 			}
+			targets := []string{
+				"vald-01",
+				"vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					RemoveByTimestampFunc: func(_ context.Context, _ *payload.Remove_TimestampRequest, _ ...grpc.CallOption) (*payload.Object_Locations, error) {
 						return &payload.Object_Locations{
 							Locations: []*payload.Object_Location{
@@ -1828,7 +1830,7 @@ func Test_server_RemoveByTimestamp(t *testing.T) {
 						}, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					RemoveByTimestampFunc: func(_ context.Context, _ *payload.Remove_TimestampRequest, _ ...grpc.CallOption) (*payload.Object_Locations, error) {
 						return &payload.Object_Locations{
 							Locations: []*payload.Object_Location{
@@ -1851,8 +1853,8 @@ func Test_server_RemoveByTimestamp(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},

--- a/pkg/gateway/mirror/handler/grpc/handler_test.go
+++ b/pkg/gateway/mirror/handler/grpc/handler_test.go
@@ -85,13 +85,16 @@ func Test_server_Insert(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					InsertFunc: func(_ context.Context, _ *payload.Insert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					InsertFunc: func(_ context.Context, _ *payload.Insert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
@@ -116,8 +119,8 @@ func Test_server_Insert(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -144,8 +147,11 @@ func Test_server_Insert(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					InsertFunc: func(_ context.Context, _ *payload.Insert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return &payload.Object_Location{
 							Uuid: uuid,
@@ -153,7 +159,7 @@ func Test_server_Insert(t *testing.T) {
 						}, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					InsertFunc: func(_ context.Context, _ *payload.Insert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.AlreadyExists, errors.ErrMetaDataAlreadyExists(uuid).Error())
 					},
@@ -181,15 +187,15 @@ func Test_server_Insert(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
 						DoMultiFunc: func(ctx context.Context, targets []string, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
 							for _, target := range targets {
 								if c, ok := cmap[target]; !ok {
-									return errors.New("target not found")
+									return errors.ErrTargetNotFound
 								} else {
 									f(ctx, target, c)
 								}
@@ -215,8 +221,11 @@ func Test_server_Insert(t *testing.T) {
 			eg, egctx := errgroup.New(ctx)
 
 			uuid := "test"
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					InsertFunc: func(_ context.Context, _ *payload.Insert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return &payload.Object_Location{
 							Uuid: uuid,
@@ -224,7 +233,7 @@ func Test_server_Insert(t *testing.T) {
 						}, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					InsertFunc: func(_ context.Context, _ *payload.Insert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.AlreadyExists, errors.ErrMetaDataAlreadyExists(uuid).Error())
 					},
@@ -252,8 +261,8 @@ func Test_server_Insert(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -286,13 +295,16 @@ func Test_server_Insert(t *testing.T) {
 			eg, egctx := errgroup.New(ctx)
 
 			uuid := "test"
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					InsertFunc: func(_ context.Context, _ *payload.Insert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.AlreadyExists, errors.ErrMetaDataAlreadyExists(uuid).Error())
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					InsertFunc: func(_ context.Context, _ *payload.Insert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.AlreadyExists, errors.ErrMetaDataAlreadyExists(uuid).Error())
 					},
@@ -317,8 +329,8 @@ func Test_server_Insert(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -342,13 +354,16 @@ func Test_server_Insert(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					InsertFunc: func(_ context.Context, _ *payload.Insert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					InsertFunc: func(_ context.Context, _ *payload.Insert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.Internal, errors.ErrCircuitBreakerHalfOpenFlowLimitation.Error())
 					},
@@ -373,8 +388,8 @@ func Test_server_Insert(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -394,13 +409,16 @@ func Test_server_Insert(t *testing.T) {
 			eg, egctx := errgroup.New(ctx)
 
 			uuid := "test"
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					InsertFunc: func(_ context.Context, _ *payload.Insert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.Internal, errors.ErrCircuitBreakerHalfOpenFlowLimitation.Error())
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					InsertFunc: func(_ context.Context, _ *payload.Insert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.Internal, errors.ErrCircuitBreakerOpenState.Error())
 					},
@@ -425,8 +443,8 @@ func Test_server_Insert(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -449,8 +467,11 @@ func Test_server_Insert(t *testing.T) {
 			eg, egctx := errgroup.New(ctx)
 
 			uuid := "test"
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					InsertFunc: func(_ context.Context, _ *payload.Insert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return &payload.Object_Location{
 							Uuid: uuid,
@@ -458,7 +479,7 @@ func Test_server_Insert(t *testing.T) {
 						}, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					InsertFunc: func(_ context.Context, _ *payload.Insert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.AlreadyExists, errors.ErrMetaDataAlreadyExists(uuid).Error())
 					},
@@ -486,8 +507,8 @@ func Test_server_Insert(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -603,13 +624,16 @@ func Test_server_Update(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
@@ -634,8 +658,8 @@ func Test_server_Update(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -662,13 +686,16 @@ func Test_server_Update(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.AlreadyExists, errors.ErrMetaDataAlreadyExists(uuid).Error())
 					},
@@ -693,8 +720,8 @@ func Test_server_Update(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -722,13 +749,16 @@ func Test_server_Update(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.Internal, errors.ErrCircuitBreakerHalfOpenFlowLimitation.Error())
 					},
@@ -753,8 +783,8 @@ func Test_server_Update(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -774,13 +804,16 @@ func Test_server_Update(t *testing.T) {
 			eg, egctx := errgroup.New(ctx)
 
 			uuid := "test"
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.Internal, errors.ErrCircuitBreakerHalfOpenFlowLimitation.Error())
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.AlreadyExists, errors.ErrMetaDataAlreadyExists(uuid).Error())
 					},
@@ -805,8 +838,8 @@ func Test_server_Update(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -833,13 +866,16 @@ func Test_server_Update(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02", "vald-03",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.NotFound, errors.ErrObjectIDNotFound(uuid).Error())
 					},
@@ -847,7 +883,7 @@ func Test_server_Update(t *testing.T) {
 						return loc, nil
 					},
 				},
-				"vald-03": &mockClient{
+				targets[2]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
@@ -872,15 +908,15 @@ func Test_server_Update(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
 						DoMultiFunc: func(ctx context.Context, targets []string, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
 							for _, target := range targets {
 								if c, ok := cmap[target]; !ok {
-									return errors.New("target not found")
+									return errors.ErrTargetNotFound
 								} else {
 									f(ctx, target, c)
 								}
@@ -912,13 +948,16 @@ func Test_server_Update(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02", "vald-03",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.NotFound, errors.ErrObjectIDNotFound(uuid).Error())
 					},
@@ -926,7 +965,7 @@ func Test_server_Update(t *testing.T) {
 						return loc, nil
 					},
 				},
-				"vald-03": &mockClient{
+				targets[2]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.AlreadyExists, errors.ErrMetaDataAlreadyExists(uuid).Error())
 					},
@@ -951,15 +990,15 @@ func Test_server_Update(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
 						DoMultiFunc: func(ctx context.Context, targets []string, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
 							for _, target := range targets {
 								if c, ok := cmap[target]; !ok {
-									return errors.New("target not found")
+									return errors.ErrTargetNotFound
 								} else {
 									f(ctx, target, c)
 								}
@@ -991,13 +1030,16 @@ func Test_server_Update(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02", "vald-03",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.NotFound, errors.ErrObjectIDNotFound(uuid).Error())
 					},
@@ -1005,7 +1047,7 @@ func Test_server_Update(t *testing.T) {
 						return nil, status.Error(codes.Internal, errors.ErrCircuitBreakerHalfOpenFlowLimitation.Error())
 					},
 				},
-				"vald-03": &mockClient{
+				targets[2]: &mockClient{
 					UpdateFunc: func(_ context.Context, _ *payload.Update_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
@@ -1030,8 +1072,8 @@ func Test_server_Update(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -1147,13 +1189,16 @@ func Test_server_Upsert(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					UpsertFunc: func(_ context.Context, _ *payload.Upsert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					UpsertFunc: func(_ context.Context, _ *payload.Upsert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
@@ -1178,8 +1223,8 @@ func Test_server_Upsert(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -1206,13 +1251,16 @@ func Test_server_Upsert(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					UpsertFunc: func(_ context.Context, _ *payload.Upsert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					UpsertFunc: func(ctx context.Context, in *payload.Upsert_Request, opts ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.AlreadyExists, errors.ErrMetaDataAlreadyExists(uuid).Error())
 					},
@@ -1237,8 +1285,8 @@ func Test_server_Upsert(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(_ context.Context, _ string, _ vald.ClientWithMirror, _ ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -1262,13 +1310,16 @@ func Test_server_Upsert(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					UpsertFunc: func(_ context.Context, _ *payload.Upsert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					UpsertFunc: func(_ context.Context, _ *payload.Upsert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.Internal, errors.ErrCircuitBreakerHalfOpenFlowLimitation.Error())
 					},
@@ -1293,8 +1344,8 @@ func Test_server_Upsert(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -1314,13 +1365,16 @@ func Test_server_Upsert(t *testing.T) {
 			eg, egctx := errgroup.New(ctx)
 
 			uuid := "test"
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					UpsertFunc: func(_ context.Context, _ *payload.Upsert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.Internal, errors.ErrCircuitBreakerHalfOpenFlowLimitation.Error())
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					UpsertFunc: func(_ context.Context, _ *payload.Upsert_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.Internal, errors.ErrCircuitBreakerOpenState.Error())
 					},
@@ -1345,8 +1399,8 @@ func Test_server_Upsert(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -1455,13 +1509,16 @@ func Test_server_Remove(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					RemoveFunc: func(_ context.Context, _ *payload.Remove_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					RemoveFunc: func(_ context.Context, _ *payload.Remove_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
@@ -1485,8 +1542,8 @@ func Test_server_Remove(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -1513,13 +1570,16 @@ func Test_server_Remove(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					RemoveFunc: func(_ context.Context, _ *payload.Remove_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					RemoveFunc: func(_ context.Context, _ *payload.Remove_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.NotFound, errors.ErrObjectIDNotFound(uuid).Error())
 					},
@@ -1543,8 +1603,8 @@ func Test_server_Remove(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -1568,13 +1628,16 @@ func Test_server_Remove(t *testing.T) {
 				Uuid: uuid,
 				Ips:  []string{"127.0.0.1"},
 			}
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					RemoveFunc: func(_ context.Context, _ *payload.Remove_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return loc, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					RemoveFunc: func(_ context.Context, _ *payload.Remove_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.Internal, errors.ErrCircuitBreakerHalfOpenFlowLimitation.Error())
 					},
@@ -1598,8 +1661,8 @@ func Test_server_Remove(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -1619,13 +1682,16 @@ func Test_server_Remove(t *testing.T) {
 			eg, egctx := errgroup.New(ctx)
 
 			uuid := "test"
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					RemoveFunc: func(_ context.Context, _ *payload.Remove_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.Internal, errors.ErrCircuitBreakerHalfOpenFlowLimitation.Error())
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					RemoveFunc: func(_ context.Context, _ *payload.Remove_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.Internal, errors.ErrCircuitBreakerOpenState.Error())
 					},
@@ -1649,8 +1715,8 @@ func Test_server_Remove(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -1673,13 +1739,16 @@ func Test_server_Remove(t *testing.T) {
 			eg, egctx := errgroup.New(ctx)
 
 			uuid := "test"
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					RemoveFunc: func(_ context.Context, _ *payload.Remove_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.NotFound, errors.ErrIndexNotFound.Error())
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					RemoveFunc: func(_ context.Context, _ *payload.Remove_Request, _ ...grpc.CallOption) (*payload.Object_Location, error) {
 						return nil, status.Error(codes.NotFound, errors.ErrIndexNotFound.Error())
 					},
@@ -1703,8 +1772,8 @@ func Test_server_Remove(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -1817,8 +1886,7 @@ func Test_server_RemoveByTimestamp(t *testing.T) {
 				},
 			}
 			targets := []string{
-				"vald-01",
-				"vald-02",
+				"vald-01", "vald-02",
 			}
 			cmap := map[string]vald.ClientWithMirror{
 				targets[0]: &mockClient{
@@ -1883,8 +1951,11 @@ func Test_server_RemoveByTimestamp(t *testing.T) {
 					"127.0.0.1",
 				},
 			}
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					RemoveByTimestampFunc: func(_ context.Context, _ *payload.Remove_TimestampRequest, _ ...grpc.CallOption) (*payload.Object_Locations, error) {
 						return &payload.Object_Locations{
 							Locations: []*payload.Object_Location{
@@ -1893,7 +1964,7 @@ func Test_server_RemoveByTimestamp(t *testing.T) {
 						}, nil
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					RemoveByTimestampFunc: func(_ context.Context, _ *payload.Remove_TimestampRequest, _ ...grpc.CallOption) (*payload.Object_Locations, error) {
 						return nil, status.Error(codes.NotFound, errors.ErrObjectIDNotFound("test02").Error())
 					},
@@ -1912,8 +1983,8 @@ func Test_server_RemoveByTimestamp(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -1936,13 +2007,16 @@ func Test_server_RemoveByTimestamp(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			eg, egctx := errgroup.New(ctx)
 
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					RemoveByTimestampFunc: func(_ context.Context, _ *payload.Remove_TimestampRequest, _ ...grpc.CallOption) (*payload.Object_Locations, error) {
 						return nil, status.Error(codes.Internal, errors.ErrCircuitBreakerHalfOpenFlowLimitation.Error())
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					RemoveByTimestampFunc: func(_ context.Context, _ *payload.Remove_TimestampRequest, _ ...grpc.CallOption) (*payload.Object_Locations, error) {
 						return nil, status.Error(codes.Internal, errors.ErrCircuitBreakerOpenState.Error())
 					},
@@ -1961,8 +2035,8 @@ func Test_server_RemoveByTimestamp(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},
@@ -1986,13 +2060,16 @@ func Test_server_RemoveByTimestamp(t *testing.T) {
 
 			uuid1 := "test01"
 			uuid2 := "test02"
+			targets := []string{
+				"vald-01", "vald-02",
+			}
 			cmap := map[string]vald.ClientWithMirror{
-				"vald-01": &mockClient{
+				targets[0]: &mockClient{
 					RemoveByTimestampFunc: func(_ context.Context, _ *payload.Remove_TimestampRequest, _ ...grpc.CallOption) (*payload.Object_Locations, error) {
 						return nil, status.Error(codes.NotFound, errors.ErrObjectIDNotFound(uuid1).Error())
 					},
 				},
-				"vald-02": &mockClient{
+				targets[1]: &mockClient{
 					RemoveByTimestampFunc: func(_ context.Context, _ *payload.Remove_TimestampRequest, _ ...grpc.CallOption) (*payload.Object_Locations, error) {
 						return nil, status.Error(codes.NotFound, errors.ErrObjectIDNotFound(uuid2).Error())
 					},
@@ -2011,8 +2088,8 @@ func Test_server_RemoveByTimestamp(t *testing.T) {
 							return ""
 						},
 						BroadCastFunc: func(ctx context.Context, f func(ctx context.Context, target string, vc vald.ClientWithMirror, copts ...grpc.CallOption) error) error {
-							for tgt, c := range cmap {
-								f(ctx, tgt, c)
+							for _, tgt := range targets {
+								f(ctx, tgt, cmap[tgt])
 							}
 							return nil
 						},

--- a/pkg/gateway/mirror/handler/grpc/mock_test.go
+++ b/pkg/gateway/mirror/handler/grpc/mock_test.go
@@ -151,7 +151,7 @@ func (m *mockClient) Remove(ctx context.Context, in *payload.Remove_Request, opt
 }
 
 func (m *mockClient) RemoveByTimestamp(ctx context.Context, in *payload.Remove_TimestampRequest, opts ...grpc.CallOption) (*payload.Object_Locations, error) {
-	return m.RemoveByTimestamp(ctx, in, opts...)
+	return m.RemoveByTimestampFunc(ctx, in, opts...)
 }
 
 func (m *mockClient) StreamRemove(ctx context.Context, opts ...grpc.CallOption) (vald.Remove_StreamRemoveClient, error) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

I have changed the rollback implementation for the following RPCs. 
- Insert
- Update
- Upsert
- Remove
- RemoveByTimestamp

The previous implementation was to return to the previous cluster state, but now processing continues with the user's query as positive.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.1
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.2
- NGT Version: 2.1.3

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
