### PR TITLE
Disable format PR creation

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -71,22 +71,6 @@ jobs:
           if git diff --quiet --exit-code; then
             echo "Nothing updated"
           else
-            git add .
-            git commit -S --signoff -m ":robot: Update license headers / Format Go codes and YAML files"
-
-            git remote set-url origin "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-            git push -u origin ${BRANCH_NAME}
-
-            curl --include --verbose --fail \
-            -H "Accept: application/json" \
-            -H "Content-Type:application/json" \
-            -H "Authorization: token ${GITHUB_TOKEN}" \
-            --request POST \
-            --data "{\"title\": \"Update license headers / Format codes\", \"head\": \"${BRANCH_NAME}\", \"base\": \"main\", \"body\": \"Update license headers / Format Go codes and YAML files.\", \"maintainer_can_modify\": true}" \
-            $API_URL
+            echo "Please execute \`make format\` locally."
+            exit 1
           fi
-        env:
-          GITHUB_USER: ${{ secrets.DISPATCH_USER }}
-          GITHUB_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
-          API_URL: https://api.github.com/repos/vdaas/vald/pulls
-          BRANCH_NAME: ${{ steps.switch_to_new_branch.outputs.BRANCH_NAME }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,9 +15,7 @@
 #
 name: Run formatter
 on:
-  push:
-    branches:
-      - main
+  pull_request:
 
 jobs:
   dump-contexts-to-log:
@@ -65,8 +63,7 @@ jobs:
           make format
           git checkout go.mod go.sum
 
-      - name: Check and Push to main branch
-        continue-on-error: true
+      - name: Check git difference
         run: |
           if git diff --quiet --exit-code; then
             echo "Nothing updated"

--- a/Makefile.d/helm.mk
+++ b/Makefile.d/helm.mk
@@ -29,8 +29,8 @@ helm-docs/install: $(BINDIR)/helm-docs
 $(BINDIR)/helm-docs:
 	mkdir -p $(BINDIR)
 	cd $(TEMP_DIR) \
-	    && curl -LO https://github.com/norwoodj/helm-docs/releases/download/v$(HELM_DOCS_VERSION)/helm-docs_$(UNAME)_$(ARCH).tar.gz \
-	    && tar xzvf helm-docs_$(UNAME)_$(ARCH).tar.gz \
+	    && curl -LO https://github.com/norwoodj/helm-docs/releases/download/v$(HELM_DOCS_VERSION)/helm-docs_$(HELM_DOCS_VERSION)_$(UNAME)_$(ARCH).tar.gz \
+	    && tar xzvf helm-docs_$(HELM_DOCS_VERSION)_$(UNAME)_$(ARCH).tar.gz \
 	    && mv helm-docs $(BINDIR)/helm-docs
 
 .PHONY: helm/package/vald


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

### WHAT
This PR contains the following changes
- Disable format PR creation
- helm-docs installation URL

### WHY

When currently unformatted PR is merged, a format PR is automatically created. 
In the future, the format should always be done before PR is merged (using Require status checks), so automatic creation should be disabled.

Also, the ci-container build was failing in the main branch, so I fixed it in this PR.
- https://github.com/vdaas/vald/actions/runs/6542102319/job/17764603236


### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.3
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.2
- NGT Version: 2.1.3

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
