### PR TITLE
Add minikube to create volume snapshot development environment locally

### DIFF
--- a/.github/workflows/dockers-dev-container-image.yml
+++ b/.github/workflows/dockers-dev-container-image.yml
@@ -22,22 +22,31 @@ on:
       - ".github/actions/docker-build/actions.yaml"
       - ".github/workflows/_docker-image.yaml"
       - ".github/workflows/dockers-dev-container-image.yml"
-      - "dockers/ci/**"
       - "dockers/dev/**"
+      - "Makefile"
+      - "Makefile.d/**"
+      - "versions/GO_VERSION"
+      - "versions/NGT_VERSION"
   pull_request:
     paths:
       - ".github/actions/docker-build/actions.yaml"
       - ".github/workflows/_docker-image.yaml"
       - ".github/workflows/dockers-dev-container-image.yml"
-      - "dockers/ci/**"
       - "dockers/dev/**"
+      - "Makefile"
+      - "Makefile.d/**"
+      - "versions/GO_VERSION"
+      - "versions/NGT_VERSION"
   pull_request_target:
     paths:
       - ".github/actions/docker-build/actions.yaml"
       - ".github/workflows/_docker-image.yaml"
       - ".github/workflows/dockers-dev-container-image.yml"
-      - "dockers/ci/**"
       - "dockers/dev/**"
+      - "Makefile"
+      - "Makefile.d/**"
+      - "versions/GO_VERSION"
+      - "versions/NGT_VERSION"
   schedule:
     - cron: "0 1 * * *"
 

--- a/Makefile
+++ b/Makefile
@@ -578,3 +578,4 @@ include Makefile.d/kind.mk
 include Makefile.d/proto.mk
 include Makefile.d/test.mk
 include Makefile.d/tools.mk
+include Makefile.d/minikube.mk

--- a/Makefile.d/minikube.mk
+++ b/Makefile.d/minikube.mk
@@ -1,3 +1,18 @@
+#
+# Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 .PHONY: minikube/install
 minikube/install: $(BINDIR)/minikube
 

--- a/Makefile.d/minikube.mk
+++ b/Makefile.d/minikube.mk
@@ -1,0 +1,27 @@
+.PHONY: minikube/install
+minikube/install: $(BINDIR)/minikube
+
+$(BINDIR)/minikube:
+	mkdir -p $(BINDIR)
+	curl -L https://storage.googleapis.com/minikube/releases/latest/minikube-$(shell echo $(UNAME) | tr '[:upper:]' '[:lower:]')-$(subst x86_64,amd64,$(shell echo $(ARCH) | tr '[:upper:]' '[:lower:]')) -o $(BINDIR)/minikube
+	chmod a+x $(BINDIR)/minikube
+
+# Start minikube with CSI Driver and Volume Snapshots support
+# Only use this for development related to Volume Snapshots. Usually k3d is faster.
+.PHONY: minikube/start
+minikube/start:
+	minikube start --force
+	minikube addons enable volumesnapshots
+	minikube addons enable csi-hostpath-driver
+	minikube addons disable storage-provisioner
+	minikube addons disable default-storageclass
+	kubectl patch storageclass csi-hostpath-sc -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
+.PHONY: minikube/delete
+minikube/delete:
+	minikube delete
+
+.PHONY: minikube/restart
+minikube/restart:
+	@make minikube/delete
+	@make minikube/start

--- a/Makefile.d/proto.mk
+++ b/Makefile.d/proto.mk
@@ -58,8 +58,7 @@ proto/deps: \
 	$(GOPATH)/src/github.com/planetscale/vtprotobuf \
 	$(GOPATH)/src/github.com/protocolbuffers/protobuf \
 	$(GOPATH)/src/google.golang.org/genproto \
-	$(GOPATH)/src/google.golang.org/protobuf \
-	$(ROOTDIR)/apis/proto/v1/rpc/error_details.proto
+	$(GOPATH)/src/google.golang.org/protobuf
 
 .PHONY: proto/clean/deps
 ## uninstall all protobuf dependencies

--- a/Makefile.d/proto.mk
+++ b/Makefile.d/proto.mk
@@ -79,8 +79,7 @@ proto/clean/deps:
 	$(GOPATH)/src/github.com/planetscale/vtprotobuf \
 	$(GOPATH)/src/github.com/protocolbuffers/protobuf \
 	$(GOPATH)/src/google.golang.org/genproto \
-	$(GOPATH)/src/google.golang.org/protobuf \
-	$(ROOTDIR)/apis/proto/v1/rpc/error_details.proto
+	$(GOPATH)/src/google.golang.org/protobuf
 
 
 $(GOPATH)/src/github.com/protocolbuffers/protobuf:

--- a/dockers/dev/Dockerfile
+++ b/dockers/dev/Dockerfile
@@ -64,4 +64,5 @@ RUN make deps \
 # additional deps
 RUN make k3d/install \
     && make buf/install \
-    && make k9s/install
+    && make k9s/install \
+    && make minikube/install


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

To develop features related to volume cloning and snapshot, we need a local support of it. Unfortunately k3d does not support it but minikube does. So this PR adds minikube environment in makefile and devcontainer.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.3
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.2
- NGT Version: 2.1.3

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
