### PR TITLE
Fix invalid networkPolicy schema

### DIFF
--- a/charts/vald-helm-operator/crds/valdrelease.yaml
+++ b/charts/vald-helm-operator/crds/valdrelease.yaml
@@ -2032,11 +2032,15 @@ spec:
                           type: object
                           properties:
                             egress:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                              items:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                             ingress:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                              items:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                         enabled:
                           type: boolean
                     observability:

--- a/charts/vald/values.schema.json
+++ b/charts/vald/values.schema.json
@@ -3288,12 +3288,14 @@
               "description": "custom network policies that a user can add",
               "properties": {
                 "egress": {
-                  "type": "object",
-                  "description": "custom egress network policies that a user can add"
+                  "type": "array",
+                  "description": "custom egress network policies that a user can add",
+                  "items": { "type": "object" }
                 },
                 "ingress": {
-                  "type": "object",
-                  "description": "custom ingress network policies that a user can add"
+                  "type": "array",
+                  "description": "custom ingress network policies that a user can add",
+                  "items": { "type": "object" }
                 }
               }
             },

--- a/charts/vald/values.yaml
+++ b/charts/vald/values.yaml
@@ -838,12 +838,12 @@ defaults:
     # @schema {"name": "defaults.networkPolicy.custom", "type": "object"}
     # defaults.networkPolicy.custom -- custom network policies that a user can add
     custom:
-      # @schema {"name": "defaults.networkPolicy.custom.ingress", "type": "object"}
+      # @schema {"name": "defaults.networkPolicy.custom.ingress", "type": "array", "items": {"type": "object"}}
       # defaults.networkPolicy.custom.ingress -- custom ingress network policies that a user can add
-      ingress: {}
-      # @schema {"name": "defaults.networkPolicy.custom.egress", "type": "object"}
+      ingress: []
+      # @schema {"name": "defaults.networkPolicy.custom.egress", "type": "array", "items": {"type": "object"}}
       # defaults.networkPolicy.custom.egress -- custom egress network policies that a user can add
-      egress: {}
+      egress: []
 # @schema {"name": "gateway", "type": "object"}
 gateway:
   # @schema {"name": "gateway.lb", "type": "object"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

The following error occurred when deploying using [dev-observability.yaml](https://github.com/vdaas/vald/blob/main/charts/vald/values/dev-observability.yaml).
```
coalesce.go:220: warning: cannot overwrite table with non table for vald.defaults.networkPolicy.custom.egress (map[])
coalesce.go:220: warning: cannot overwrite table with non table for vald.defaults.networkPolicy.custom.ingress (map[])
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
vald:
- defaults.networkPolicy.custom.egress: Invalid type. Expected: object, given: array
- defaults.networkPolicy.custom.ingress: Invalid type. Expected: object, given: array
```

This is due to a wrong schema in `networkPolicy`. ([schema reference](https://github.com/vdaas/vald/blob/main/charts/vald/values.yaml#L841-L846) , [custom values reference](https://github.com/vdaas/vald/blob/main/charts/vald/values/dev-observability.yaml#L47-L55) )
The schema accepts object types but is actually passed as an array type.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.3
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.2
- NGT Version: 2.1.3

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
