### PR TITLE
Add job error to report index correction error status

### DIFF
--- a/internal/errors/corrector.go
+++ b/internal/errors/corrector.go
@@ -28,3 +28,16 @@ var ErrNoAvailableAgentToInsert = New("no available agent to insert replica")
 
 // ErrFailedToCorrectReplicaNum represents an error that failed to correct replica number after correction process.
 var ErrFailedToCorrectReplicaNum = New("failed to correct replica number after correction process")
+
+// ErrFailedToReceiveVectorFromStream represents an error that failed to receive vector from stream while index correction process.
+var ErrFailedToReceiveVectorFromStream = New("failed to receive vector from stream")
+
+// ErrFailedToCheckConsistency represents an error that failed to check consistency process while index correction process.
+var ErrFailedToCheckConsistency = func(err error) error {
+	return Wrap(err, "failed to check consistency while index correctioin process")
+}
+
+// ErrStreamListObjectStreamFinishedUnexpectedly represents an error that StreamListObject finished not because of io.EOF.
+var ErrStreamListObjectStreamFinishedUnexpectedly = func(err error) error {
+	return Wrap(err, "stream list object stream finished unexpectedly")
+}

--- a/internal/errors/corrector.go
+++ b/internal/errors/corrector.go
@@ -20,6 +20,9 @@ package errors
 // ErrIndexReplicaOne represents an error that nothing to correct when index replica is 1.
 var ErrIndexReplicaOne = New("nothing to correct when index replica is 1")
 
+// ErrAgentReplicaOne represents an error that nothing to correct when agent replica is 1.
+var ErrAgentReplicaOne = New("nothing to correct when agent replica is 1")
+
 // ErrNoAvailableAgentToInsert represents an error that no available agent to insert replica.
 var ErrNoAvailableAgentToInsert = New("no available agent to insert replica")
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -288,9 +288,7 @@ func RemoveDuplicates(errs []error) []error {
 	slices.SortStableFunc(errs, func(l error, r error) int {
 		return cmp.Compare(l.Error(), r.Error())
 	})
-	return slices.CompactFunc(errs, func(l error, r error) bool {
-		return Is(l, r)
-	})
+	return slices.CompactFunc(errs, Is)
 }
 
 type joinError struct {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -18,10 +18,12 @@
 package errors
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/vdaas/vald/internal/sync"
@@ -277,6 +279,18 @@ func Join(errs ...error) error {
 		}
 	}
 	return e
+}
+
+func RemoveDuplicates(errs []error) []error {
+	if len(errs) < 2 {
+		return errs
+	}
+	slices.SortStableFunc(errs, func(l error, r error) int {
+		return cmp.Compare(l.Error(), r.Error())
+	})
+	return slices.CompactFunc(errs, func(l error, r error) bool {
+		return Is(l, r)
+	})
 }
 
 type joinError struct {

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1581,6 +1581,74 @@ func TestAs(t *testing.T) {
 	}
 }
 
+func TestRemoveDuplicates(t *testing.T) {
+	type args struct {
+		errs []error
+	}
+	tests := []struct {
+		name string
+		args args
+		want []error
+	}{
+		{
+			name: "succeeds to remove duplicated errors",
+			args: args{
+				errs: []error{
+					New("same error1"),
+					New("same error1"),
+					New("same error2"),
+					New("same error2"),
+					New("same error2"),
+					New("same error3"),
+				},
+			},
+			want: []error{
+				New("same error1"),
+				New("same error2"),
+				New("same error3"),
+			},
+		},
+		{
+			name: "single error remains the same",
+			args: args{
+				errs: []error{
+					New("same error"),
+				},
+			},
+			want: []error{
+				New("same error"),
+			},
+		},
+		{
+			name: "empty errs remains the same",
+			args: args{
+				errs: []error{},
+			},
+			want: []error{},
+		},
+	}
+
+	equalErrs := func(errs1, errs2 []error) bool {
+		if len(errs1) != len(errs2) {
+			return false
+		}
+		for i := range errs1 {
+			if !Is(errs1[i], errs2[i]) {
+				return false
+			}
+		}
+		return true
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RemoveDuplicates(tt.args.errs); !equalErrs(got, tt.want) {
+				t.Errorf("removeDuplicatedErrs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // NOT IMPLEMENTED BELOW
 //
 // func TestUnwrap(t *testing.T) {

--- a/internal/net/grpc/stream.go
+++ b/internal/net/grpc/stream.go
@@ -18,11 +18,9 @@
 package grpc
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"runtime"
-	"slices"
 	"sync/atomic"
 
 	"github.com/vdaas/vald/internal/errors"
@@ -75,9 +73,7 @@ func BidirectionalStream[Q any, R any](ctx context.Context, stream ServerStream,
 			errs = append(errs, err)
 			emu.Unlock()
 		}
-		removeDuplicates(errs, func(left, right error) int {
-			return cmp.Compare(left.Error(), right.Error())
-		})
+		errs := errors.RemoveDuplicates(errs)
 		emu.Lock()
 		err = errors.Join(errs...)
 		emu.Unlock()
@@ -228,12 +224,4 @@ func BidirectionalStreamClient(stream ClientStream,
 			}
 		}
 	}()
-}
-
-func removeDuplicates[S ~[]E, E comparable](x S, less func(left, right E) int) S {
-	if len(x) < 2 {
-		return x
-	}
-	slices.SortStableFunc(x, less)
-	return slices.Compact(x)
 }

--- a/pkg/index/job/correction/service/corrector.go
+++ b/pkg/index/job/correction/service/corrector.go
@@ -51,7 +51,7 @@ const (
 
 type Corrector interface {
 	Start(ctx context.Context) error
-	StartMonitoring(ctx context.Context) (<-chan error, error)
+	StartClient(ctx context.Context) (<-chan error, error)
 	PreStop(ctx context.Context) error
 	// For metrics
 	NumberOfCheckedIndex() uint64
@@ -90,7 +90,7 @@ func New(cfg *config.Data, discoverer discoverer.Client) (Corrector, error) {
 	}, nil
 }
 
-func (c *correct) StartMonitoring(ctx context.Context) (<-chan error, error) {
+func (c *correct) StartClient(ctx context.Context) (<-chan error, error) {
 	return c.discoverer.Start(ctx)
 }
 

--- a/pkg/index/job/correction/service/corrector.go
+++ b/pkg/index/job/correction/service/corrector.go
@@ -51,7 +51,7 @@ const (
 
 type Corrector interface {
 	Start(ctx context.Context) error
-	PreStart(ctx context.Context) (<-chan error, error)
+	StartMonitoring(ctx context.Context) (<-chan error, error)
 	PreStop(ctx context.Context) error
 	// For metrics
 	NumberOfCheckedIndex() uint64
@@ -90,7 +90,7 @@ func New(cfg *config.Data, discoverer discoverer.Client) (Corrector, error) {
 	}, nil
 }
 
-func (c *correct) PreStart(ctx context.Context) (<-chan error, error) {
+func (c *correct) StartMonitoring(ctx context.Context) (<-chan error, error) {
 	dech, err := c.discoverer.Start(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/index/job/correction/service/corrector.go
+++ b/pkg/index/job/correction/service/corrector.go
@@ -91,11 +91,7 @@ func New(cfg *config.Data, discoverer discoverer.Client) (Corrector, error) {
 }
 
 func (c *correct) StartMonitoring(ctx context.Context) (<-chan error, error) {
-	dech, err := c.discoverer.Start(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return dech, nil
+	return c.discoverer.Start(ctx)
 }
 
 func (c *correct) Start(ctx context.Context) error {

--- a/pkg/index/job/correction/usecase/corrector.go
+++ b/pkg/index/job/correction/usecase/corrector.go
@@ -150,7 +150,7 @@ func (r *run) Start(ctx context.Context) (<-chan error, error) {
 		oech = r.observability.Start(ctx)
 	}
 	sech := r.server.ListenAndServe(ctx)
-	nech, err := r.corrector.StartMonitoring(ctx)
+	nech, err := r.corrector.StartClient(ctx)
 	if err != nil {
 		close(ech)
 		return nil, err

--- a/pkg/index/job/correction/usecase/corrector.go
+++ b/pkg/index/job/correction/usecase/corrector.go
@@ -150,7 +150,7 @@ func (r *run) Start(ctx context.Context) (<-chan error, error) {
 		oech = r.observability.Start(ctx)
 	}
 	sech := r.server.ListenAndServe(ctx)
-	nech, err := r.corrector.PreStart(ctx)
+	nech, err := r.corrector.StartMonitoring(ctx)
 	if err != nil {
 		close(ech)
 		return nil, err


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
This PR updates `index correction` in two ways,
1. To report error to the usecase layer from service.Start, update error handling in the `correct` function. Also made changes in some cases not to continue processing but just stop processing and report errors.
2. Changed to call discoverer.Start outside of the correction goroutine to handle error chan.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.3
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.2
- NGT Version: 2.1.3

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
