### PR TITLE
[DO NOT MERGE]: Disable VTPool handling

### DIFF
--- a/internal/net/grpc/codec.go
+++ b/internal/net/grpc/codec.go
@@ -43,9 +43,6 @@ type vtprotoPoolMessage interface {
 // Marshal returns byte slice representing the proto message marshalling result.
 func (Codec) Marshal(obj interface{}) (data []byte, err error) {
 	switch v := obj.(type) {
-	case vtprotoPoolMessage:
-		data, err = v.MarshalVT()
-		v.ReturnToVTPool()
 	case vtprotoMessage:
 		data, err = v.MarshalVT()
 	case proto.Message:

--- a/pkg/agent/core/ngt/handler/grpc/object.go
+++ b/pkg/agent/core/ngt/handler/grpc/object.go
@@ -122,11 +122,11 @@ func (s *server) GetObject(ctx context.Context, id *payload.Object_VectorRequest
 		}
 		return nil, err
 	}
-	res = payload.Object_VectorFromVTPool()
-	res.Id = uuid
-	res.Vector = vec
-	res.Timestamp = ts
-	return res, nil
+	return &payload.Object_Vector{
+		Id:        uuid,
+		Vector:    vec,
+		Timestamp: ts,
+	}, nil
 }
 
 func (s *server) StreamGetObject(stream vald.Object_StreamGetObjectServer) (err error) {
@@ -204,13 +204,13 @@ func (s *server) StreamListObject(_ *payload.Object_List_Request, stream vald.Ob
 				},
 			}
 		} else {
-			ovec := payload.Object_VectorFromVTPool()
-			ovec.Id = uuid
-			ovec.Vector = vec
-			ovec.Timestamp = ts
 			res = &payload.Object_List_Response{
 				Payload: &payload.Object_List_Response_Vector{
-					Vector: ovec,
+					Vector: &payload.Object_Vector{
+						Id:        uuid,
+						Vector:    vec,
+						Timestamp: ts,
+					},
 				},
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

This PR was created for verification purposes.
The main difference is that vtpool handling has been changed to those of v1.7.6.
https://github.com/vdaas/vald/compare/v1.7.6...v1.7.7

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.3
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.2
- NGT Version: 2.1.3

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
