### PR TITLE
[DO NOT MERGE]: Add interceptor to dump metadata

### DIFF
--- a/internal/net/grpc/interceptor/server/metadata/metadata.go
+++ b/internal/net/grpc/interceptor/server/metadata/metadata.go
@@ -1,0 +1,50 @@
+//
+// Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package recover provides gRPC interceptors for recovery
+package metadata
+
+import (
+	"context"
+	"unsafe"
+
+	"github.com/vdaas/vald/internal/log"
+	"github.com/vdaas/vald/internal/net/grpc"
+)
+
+func MetadataInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (resp interface{}, err error) {
+		res, err := handler(ctx, req)
+		log.Infof("Metadata object size: %d byte", unsafe.Sizeof(res))
+		return res, err
+	}
+}
+
+func MetadataStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		return handler(srv, ss)
+	}
+}

--- a/internal/servers/server/option.go
+++ b/internal/servers/server/option.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vdaas/vald/internal/net/control"
 	"github.com/vdaas/vald/internal/net/grpc"
 	"github.com/vdaas/vald/internal/net/grpc/interceptor/server/logging"
+	"github.com/vdaas/vald/internal/net/grpc/interceptor/server/metadata"
 	"github.com/vdaas/vald/internal/net/grpc/interceptor/server/metric"
 	"github.com/vdaas/vald/internal/net/grpc/interceptor/server/recover"
 	"github.com/vdaas/vald/internal/net/grpc/interceptor/server/trace"
@@ -559,6 +560,10 @@ func WithGRPCInterceptors(names ...string) Option {
 			default:
 			}
 		}
+		s.grpc.opts = append(s.grpc.opts,
+			grpc.ChainUnaryInterceptor(metadata.MetadataInterceptor()),
+			grpc.ChainStreamInterceptor(metadata.MetadataStreamInterceptor()),
+		)
 		return nil
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

We get `RESOURCE_EXHAUSTED` error when we send an upsert request.
I want to output a log to check if the size of the object really exceeds 4MB.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.3
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.2
- NGT Version: 2.1.3

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
