### PR TITLE
 Add docker buildx cache

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -15,7 +15,6 @@
 #
 name: "Build Docker images"
 description: "A action to build Docker images and publish them"
-
 inputs:
   target:
     description: "Build target"
@@ -45,7 +44,6 @@ outputs:
   EXTRA_TAGS:
     description: "Extra tags"
     value: ${{ steps.add_extra_tags.outputs.EXTRA_TAGS }}
-
 runs:
   using: "composite"
   steps:
@@ -62,11 +60,9 @@ runs:
         echo "ALTER_IMAGE_NAME=${alter_image_name}" >> $GITHUB_OUTPUT
       env:
         TARGET: ${{ inputs.target }}
-
     - name: Determine tag name
       id: determine_tag_name
       uses: ./.github/actions/determine-docker-image-tag
-
     - name: Determine platforms
       shell: bash
       id: determine_platforms
@@ -86,7 +82,6 @@ runs:
         echo "PLATFORMS=${platforms}" >> $GITHUB_OUTPUT
       env:
         TARGET_PLATFORMS: ${{ inputs.platforms }}
-
     - name: Add extra tags
       shell: bash
       id: add_extra_tags
@@ -102,14 +97,15 @@ runs:
         IMAGE_NAME: ${{ steps.image_name.outputs.IMAGE_NAME }}
         ALTER_IMAGE_NAME: ${{ steps.image_name.outputs.ALTER_IMAGE_NAME }}
         PRIMARY_TAG: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
-
     - name: Build and Push
       shell: bash
       id: build_and_push
       run: |
         make \
-          DOCKER="docker buildx" \
-          DOCKER_OPTS="--platform ${PLATFORMS} --builder ${BUILDER} ${LABEL_OPTS} ${EXTRA_TAGS} --push" \
+          REMOTE="true" \
+          DOCKER="docker" \
+          DOCKER_OPTS="--platform ${PLATFORMS} --builder ${BUILDER} ${LABEL_OPTS}  --label org.opencontainers.image.version=${PRIMARY_TAG} --label org.opencontainers.image.title=${TARGET}" \
+          EXTRA_TAGS="${EXTRA_TAGS}" \
           TAG="${PRIMARY_TAG}" \
           docker/build/${TARGET}
       env:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ GOPKG                           = github.com/$(ORG)/$(NAME)
 DATETIME                        = $(eval DATETIME := $(shell date -u +%Y/%m/%d_%H:%M:%S%z))$(DATETIME)
 TAG                            ?= latest
 CRORG                          ?= $(ORG)
-# CRORG                           = ghcr.io/vdaas/vald
+GHCRORG                         = ghcr.io/$(ORG)/$(NAME)
 AGENT_IMAGE                     = $(NAME)-agent-ngt
 AGENT_SIDECAR_IMAGE             = $(NAME)-agent-sidecar
 CI_CONTAINER_IMAGE              = $(NAME)-ci-container

--- a/Makefile.d/docker.mk
+++ b/Makefile.d/docker.mk
@@ -30,11 +30,46 @@ docker/name/org:
 
 .PHONY: docker/name/org/alter
 docker/name/org/alter:
-	@echo "ghcr.io/vdaas/vald"
+	@echo "$(GHCRORG)"
 
 .PHONY: docker/platforms
 docker/platforms:
 	@echo "linux/amd64,linux/arm64"
+
+.PHONY: docker/build/image
+## Generalized docker build function
+docker/build/image:
+ifeq ($(REMOTE),true)
+	@echo "starting remote build for $(IMAGE):$(TAG)"
+	DOCKER_BUILDKIT=1 $(DOCKER) buildx build \
+		$(DOCKER_OPTS) \
+		--cache-to type=registry,ref=$(GHCRORG)/$(IMAGE):$(TAG)-buildcache,mode=max \
+		--cache-from type=registry,ref=$(GHCRORG)/$(IMAGE):$(TAG)-buildcache \
+		--build-arg BUILDKIT_INLINE_CACHE=1 \
+		--build-arg GO_VERSION=$(GO_VERSION) \
+		--build-arg DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) \
+		--build-arg DISTROLESS_IMAGE_TAG=$(DISTROLESS_IMAGE_TAG) \
+		--build-arg MAINTAINER=$(MAINTAINER) \
+		$(EXTRA_ARGS) \
+		--sbom=true \
+		--provenance=mode=max \
+		-t $(CRORG)/$(IMAGE):$(TAG) \
+		-t $(GHCRORG)/$(IMAGE):$(TAG) \
+		--output type=registry,oci-mediatypes=true,compression=zstd,compression-level=5,force-compression=true,push=true \
+		-f $(DOCKERFILE) .
+else
+	@echo "starting local build for $(IMAGE):$(TAG)"
+	DOCKER_BUILDKIT=1 $(DOCKER) build \
+		$(DOCKER_OPTS) \
+		--build-arg BUILDKIT_INLINE_CACHE=1 \
+		--build-arg GO_VERSION=$(GO_VERSION) \
+		--build-arg DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) \
+		--build-arg DISTROLESS_IMAGE_TAG=$(DISTROLESS_IMAGE_TAG) \
+		--build-arg MAINTAINER=$(MAINTAINER) \
+		$(EXTRA_ARGS) \
+		-t $(IMAGE):$(TAG) \
+		-f $(DOCKERFILE) .
+endif
 
 .PHONY: docker/name/agent-ngt
 docker/name/agent-ngt:
@@ -43,14 +78,9 @@ docker/name/agent-ngt:
 .PHONY: docker/build/agent-ngt
 ## build agent-ngt image
 docker/build/agent-ngt:
-	$(DOCKER) build \
-	    $(DOCKER_OPTS) \
-	    -f dockers/agent/core/ngt/Dockerfile \
-	    -t $(ORG)/$(AGENT_IMAGE):$(TAG) . \
-	    --build-arg GO_VERSION=$(GO_VERSION) \
-	    --build-arg DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) \
-	    --build-arg DISTROLESS_IMAGE_TAG=$(DISTROLESS_IMAGE_TAG) \
-	    --build-arg MAINTAINER=$(MAINTAINER)
+	@make DOCKERFILE="$(ROOTDIR)/dockers/agent/core/ngt/Dockerfile" \
+		IMAGE=$(AGENT_IMAGE) \
+		docker/build/image
 
 .PHONY: docker/name/agent-sidecar
 docker/name/agent-sidecar:
@@ -59,14 +89,9 @@ docker/name/agent-sidecar:
 .PHONY: docker/build/agent-sidecar
 ## build agent-sidecar image
 docker/build/agent-sidecar:
-	$(DOCKER) build \
-	    $(DOCKER_OPTS) \
-	    -f dockers/agent/sidecar/Dockerfile \
-	    -t $(ORG)/$(AGENT_SIDECAR_IMAGE):$(TAG) . \
-	    --build-arg GO_VERSION=$(GO_VERSION) \
-	    --build-arg DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) \
-	    --build-arg DISTROLESS_IMAGE_TAG=$(DISTROLESS_IMAGE_TAG) \
-	    --build-arg MAINTAINER=$(MAINTAINER)
+	@make DOCKERFILE="$(ROOTDIR)/dockers/agent/sidecar/Dockerfile" \
+		IMAGE=$(AGENT_SIDECAR_IMAGE) \
+		docker/build/image
 
 .PHONY: docker/name/discoverer-k8s
 docker/name/discoverer-k8s:
@@ -75,14 +100,9 @@ docker/name/discoverer-k8s:
 .PHONY: docker/build/discoverer-k8s
 ## build discoverer-k8s image
 docker/build/discoverer-k8s:
-	$(DOCKER) build \
-	    $(DOCKER_OPTS) \
-	    -f dockers/discoverer/k8s/Dockerfile \
-	    -t $(ORG)/$(DISCOVERER_IMAGE):$(TAG) . \
-	    --build-arg GO_VERSION=$(GO_VERSION) \
-	    --build-arg DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) \
-	    --build-arg DISTROLESS_IMAGE_TAG=$(DISTROLESS_IMAGE_TAG) \
-	    --build-arg MAINTAINER=$(MAINTAINER)
+	@make DOCKERFILE="$(ROOTDIR)/dockers/discoverer/k8s/Dockerfile" \
+		IMAGE=$(DISCOVERER_IMAGE) \
+		docker/build/image
 
 .PHONY: docker/name/gateway-lb
 docker/name/gateway-lb:
@@ -91,13 +111,9 @@ docker/name/gateway-lb:
 .PHONY: docker/build/gateway-lb
 ## build gateway-lb image
 docker/build/gateway-lb:
-	$(DOCKER) build \
-	    $(DOCKER_OPTS) \
-	    -f dockers/gateway/lb/Dockerfile \
-	    -t $(ORG)/$(LB_GATEWAY_IMAGE):$(TAG) . \
-	    --build-arg GO_VERSION=$(GO_VERSION) \
-	    --build-arg DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) \
-	    --build-arg DISTROLESS_IMAGE_TAG=$(DISTROLESS_IMAGE_TAG)
+	@make DOCKERFILE="$(ROOTDIR)/dockers/gateway/lb/Dockerfile" \
+		IMAGE=$(LB_GATEWAY_IMAGE) \
+		docker/build/image
 
 .PHONY: docker/name/gateway-filter
 docker/name/gateway-filter:
@@ -106,13 +122,9 @@ docker/name/gateway-filter:
 .PHONY: docker/build/gateway-filter
 ## build gateway-filter image
 docker/build/gateway-filter:
-	$(DOCKER) build \
-	    $(DOCKER_OPTS) \
-	    -f dockers/gateway/filter/Dockerfile \
-	    -t $(ORG)/$(FILTER_GATEWAY_IMAGE):$(TAG) . \
-	    --build-arg GO_VERSION=$(GO_VERSION) \
-	    --build-arg DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) \
-	    --build-arg DISTROLESS_IMAGE_TAG=$(DISTROLESS_IMAGE_TAG)
+	@make DOCKERFILE="$(ROOTDIR)/dockers/gateway/filter/Dockerfile" \
+		IMAGE=$(FILTER_GATEWAY_IMAGE) \
+		docker/build/image
 
 .PHONY: docker/name/manager-index
 docker/name/manager-index:
@@ -121,14 +133,9 @@ docker/name/manager-index:
 .PHONY: docker/build/manager-index
 ## build manager-index image
 docker/build/manager-index:
-	$(DOCKER) build \
-	    $(DOCKER_OPTS) \
-	    -f dockers/manager/index/Dockerfile \
-	    -t $(ORG)/$(MANAGER_INDEX_IMAGE):$(TAG) . \
-	    --build-arg GO_VERSION=$(GO_VERSION) \
-	    --build-arg DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) \
-	    --build-arg DISTROLESS_IMAGE_TAG=$(DISTROLESS_IMAGE_TAG) \
-	    --build-arg MAINTAINER=$(MAINTAINER)
+	@make DOCKERFILE="$(ROOTDIR)/dockers/manager/index/Dockerfile" \
+		IMAGE=$(MANAGER_INDEX_IMAGE) \
+		docker/build/image
 
 .PHONY: docker/name/ci-container
 docker/name/ci-container:
@@ -137,12 +144,9 @@ docker/name/ci-container:
 .PHONY: docker/build/ci-container
 ## build ci-container image
 docker/build/ci-container:
-	$(DOCKER) build \
-	    $(DOCKER_OPTS) \
-	    -f dockers/ci/base/Dockerfile \
-	    -t $(ORG)/$(CI_CONTAINER_IMAGE):$(TAG) . \
-	    --build-arg MAINTAINER=$(MAINTAINER) \
-	    --build-arg GO_VERSION=$(GO_VERSION)
+	@make DOCKERFILE="$(ROOTDIR)/dockers/ci/base/Dockerfile" \
+		IMAGE=$(CI_CONTAINER_IMAGE) \
+		docker/build/image
 
 .PHONY: docker/name/dev-container
 docker/name/dev-container:
@@ -151,11 +155,9 @@ docker/name/dev-container:
 .PHONY: docker/build/dev-container
 ## build dev-container image
 docker/build/dev-container:
-	$(DOCKER) build \
-	    $(DOCKER_OPTS) \
-	    -f dockers/dev/Dockerfile \
-	    -t $(ORG)/$(DEV_CONTAINER_IMAGE):$(TAG) . \
-	    --build-arg MAINTAINER=$(MAINTAINER)
+	@make DOCKERFILE="$(ROOTDIR)/dockers/dev/Dockerfile" \
+		IMAGE=$(DEV_CONTAINER_IMAGE) \
+		docker/build/image
 
 .PHONY: docker/name/operator/helm
 docker/name/operator/helm:
@@ -164,16 +166,10 @@ docker/name/operator/helm:
 .PHONY: docker/build/operator/helm
 ## build helm-operator image
 docker/build/operator/helm:
-	$(DOCKER) build \
-	    $(DOCKER_OPTS) \
-	    -f dockers/operator/helm/Dockerfile \
-	    -t $(ORG)/$(HELM_OPERATOR_IMAGE):$(TAG) . \
-	    --build-arg GO_VERSION=$(GO_VERSION) \
-	    --build-arg DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) \
-	    --build-arg DISTROLESS_IMAGE_TAG=$(DISTROLESS_IMAGE_TAG) \
-	    --build-arg MAINTAINER=$(MAINTAINER) \
-	    --build-arg OPERATOR_SDK_VERSION=$(OPERATOR_SDK_VERSION) \
-	    --build-arg UPX_OPTIONS=$(UPX_OPTIONS)
+	@make DOCKERFILE="$(ROOTDIR)/dockers/operator/helm/Dockerfile" \
+		IMAGE=$(HELM_OPERATOR_IMAGE) \
+		EXTRA_ARGS="--build-arg OPERATOR_SDK_VERSION=$(OPERATOR_SDK_VERSION) --build-arg UPX_OPTIONS=$(UPX_OPTIONS)" \
+		docker/build/image
 
 .PHONY: docker/name/loadtest
 docker/name/loadtest:
@@ -182,12 +178,9 @@ docker/name/loadtest:
 .PHONY: docker/build/loadtest
 ## build loadtest image
 docker/build/loadtest:
-	$(DOCKER) build \
-	    $(DOCKER_OPTS) \
-	    -f dockers/tools/cli/loadtest/Dockerfile \
-	    -t $(ORG)/$(LOADTEST_IMAGE):$(TAG) . \
-	    --build-arg MAINTAINER=$(MAINTAINER) \
-	    --build-arg GO_VERSION=$(GO_VERSION)
+	@make DOCKERFILE="$(ROOTDIR)/dockers/tools/cli/loadtest/Dockerfile" \
+		IMAGE=$(LOADTEST_IMAGE) \
+		docker/build/image
 
 .PHONY: docker/name/index-correction
 docker/name/index-correction:
@@ -196,12 +189,9 @@ docker/name/index-correction:
 .PHONY: docker/build/index-correction
 ## build index-correction image
 docker/build/index-correction:
-	$(DOCKER) build \
-	    $(DOCKER_OPTS) \
-	    -f dockers/index/job/correction/Dockerfile \
-	    -t $(ORG)/$(INDEX_CORRECTION_IMAGE):$(TAG) . \
-	    --build-arg MAINTAINER=$(MAINTAINER) \
-	    --build-arg GO_VERSION=$(GO_VERSION)
+	@make DOCKERFILE="$(ROOTDIR)/dockers/index/job/correction/Dockerfile" \
+		IMAGE=$(INDEX_CORRECTION_IMAGE) \
+		docker/build/image
 
 .PHONY: docker/name/index-creation
 docker/name/index-creation:
@@ -210,12 +200,9 @@ docker/name/index-creation:
 .PHONY: docker/build/index-creation
 ## build index-creation image
 docker/build/index-creation:
-	$(DOCKER) build \
-	    $(DOCKER_OPTS) \
-	    -f dockers/index/job/creation/Dockerfile \
-	    -t $(ORG)/$(INDEX_CREATION_IMAGE):$(TAG) . \
-	    --build-arg MAINTAINER=$(MAINTAINER) \
-	    --build-arg GO_VERSION=$(GO_VERSION)
+	@make DOCKERFILE="$(ROOTDIR)/dockers/index/job/creation/Dockerfile" \
+		IMAGE=$(INDEX_CREATION_IMAGE) \
+		docker/build/image
 
 .PHONY: docker/name/index-save
 docker/name/index-save:
@@ -224,12 +211,9 @@ docker/name/index-save:
 .PHONY: docker/build/index-save
 ## build index-save image
 docker/build/index-save:
-	$(DOCKER) build \
-	    $(DOCKER_OPTS) \
-	    -f dockers/index/job/save/Dockerfile \
-	    -t $(ORG)/$(INDEX_SAVE_IMAGE):$(TAG) . \
-	    --build-arg MAINTAINER=$(MAINTAINER) \
-	    --build-arg GO_VERSION=$(GO_VERSION)
+	@make DOCKERFILE="$(ROOTDIR)/dockers/index/job/save/Dockerfile" \
+		IMAGE=$(INDEX_SAVE_IMAGE) \
+		docker/build/image
 
 .PHONY: docker/name/readreplica-rotate
 docker/name/readreplica-rotate:
@@ -238,9 +222,6 @@ docker/name/readreplica-rotate:
 .PHONY: docker/build/readreplica-rotate
 ## build readreplica-rotate image
 docker/build/readreplica-rotate:
-	$(DOCKER) build \
-	    $(DOCKER_OPTS) \
-	    -f dockers/index/job/readreplica/rotate/Dockerfile \
-	    -t $(ORG)/$(READREPLICA_ROTATE_IMAGE):$(TAG) . \
-	    --build-arg MAINTAINER=$(MAINTAINER) \
-	    --build-arg GO_VERSION=$(GO_VERSION)
+	@make DOCKERFILE="$(ROOTDIR)/dockers/index/job/readreplica/rotate/Dockerfile" \
+		IMAGE=$(READREPLICA_ROTATE_IMAGE) \
+		docker/build/image

--- a/dockers/agent/core/ngt/Dockerfile
+++ b/dockers/agent/core/ngt/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:latest
 #
 # Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
 #
@@ -19,9 +20,9 @@ ARG DISTROLESS_IMAGE=gcr.io/distroless/static
 ARG DISTROLESS_IMAGE_TAG=nonroot
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
-FROM golang:${GO_VERSION} AS golang
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS golang
 
-FROM ubuntu:devel AS builder
+FROM --platform=${BUILDPLATFORM} ubuntu:devel AS builder
 
 ENV GO111MODULE on
 ENV DEBIAN_FRONTEND noninteractive
@@ -92,7 +93,7 @@ RUN make REPO=${ORG} NAME=${REPO} cmd/${PKG}/${APP_NAME} \
 WORKDIR ${GOPATH}/src/github.com/${ORG}/${REPO}/cmd/${PKG}
 RUN cp sample.yaml /tmp/config.yaml
 
-FROM ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
+FROM --platform=${BUILDPLATFORM} ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
 LABEL maintainer="${MAINTAINER}"
 
 ENV APP_NAME ngt

--- a/dockers/agent/sidecar/Dockerfile
+++ b/dockers/agent/sidecar/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:latest
 #
 # Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
 #
@@ -19,9 +20,9 @@ ARG DISTROLESS_IMAGE=gcr.io/distroless/static
 ARG DISTROLESS_IMAGE_TAG=nonroot
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
-FROM golang:${GO_VERSION} AS golang
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS golang
 
-FROM ubuntu:devel AS builder
+FROM --platform=${BUILDPLATFORM} ubuntu:devel AS builder
 
 ENV GO111MODULE on
 ENV GOPATH /go
@@ -81,7 +82,7 @@ WORKDIR ${GOPATH}/src/github.com/${ORG}/${REPO}
 RUN make REPO=${ORG} NAME=${REPO} cmd/${PKG}/${APP_NAME} \
     && mv "cmd/${PKG}/${APP_NAME}" "/usr/bin/${APP_NAME}"
 
-FROM ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
+FROM --platform=${BUILDPLATFORM} ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
 LABEL maintainer="${MAINTAINER}"
 
 ENV APP_NAME sidecar

--- a/dockers/ci/base/Dockerfile
+++ b/dockers/ci/base/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:latest
 #
 # Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
 #
@@ -17,9 +18,9 @@
 ARG GO_VERSION=latest
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
-FROM golang:${GO_VERSION} AS golang
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS golang
 
-FROM ubuntu:devel AS builder
+FROM --platform=${BUILDPLATFORM} ubuntu:devel AS builder
 LABEL maintainer="${MAINTAINER}"
 
 ENV GO111MODULE on

--- a/dockers/dev/Dockerfile
+++ b/dockers/dev/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:latest
 #
 # Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
 #
@@ -17,7 +18,7 @@
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
 # skipcq: DOK-DL3026
-FROM mcr.microsoft.com/vscode/devcontainers/go:1 AS base
+FROM --platform=${BUILDPLATFORM} mcr.microsoft.com/vscode/devcontainers/go:1 AS base
 LABEL maintainer="${MAINTAINER}"
 
 # skipcq: DOK-DL3008

--- a/dockers/discoverer/k8s/Dockerfile
+++ b/dockers/discoverer/k8s/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:latest
 #
 # Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
 #
@@ -19,9 +20,9 @@ ARG DISTROLESS_IMAGE=gcr.io/distroless/static
 ARG DISTROLESS_IMAGE_TAG=nonroot
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
-FROM golang:${GO_VERSION} AS golang
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS golang
 
-FROM ubuntu:devel AS builder
+FROM --platform=${BUILDPLATFORM} ubuntu:devel AS builder
 
 ENV GO111MODULE on
 ENV DEBIAN_FRONTEND noninteractive
@@ -81,7 +82,7 @@ RUN make REPO=${ORG} NAME=${REPO} cmd/${PKG}/${APP_NAME} \
 WORKDIR ${GOPATH}/src/github.com/${ORG}/${REPO}/cmd/${PKG}
 RUN cp sample.yaml /tmp/config.yaml
 
-FROM ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
+FROM --platform=${BUILDPLATFORM} ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
 LABEL maintainer="${MAINTAINER}"
 
 ENV APP_NAME discoverer

--- a/dockers/gateway/filter/Dockerfile
+++ b/dockers/gateway/filter/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:latest
 #
 # Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
 #
@@ -19,9 +20,9 @@ ARG DISTROLESS_IMAGE=gcr.io/distroless/static
 ARG DISTROLESS_IMAGE_TAG=nonroot
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
-FROM golang:${GO_VERSION} AS golang
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS golang
 
-FROM ubuntu:devel AS builder
+FROM --platform=${BUILDPLATFORM} ubuntu:devel AS builder
 
 ENV GO111MODULE on
 ENV DEBIAN_FRONTEND noninteractive
@@ -80,7 +81,7 @@ RUN make REPO=${ORG} NAME=${REPO} cmd/${PKG}/${APP_NAME} \
 WORKDIR ${GOPATH}/src/github.com/${ORG}/${REPO}/cmd/${PKG}
 RUN cp sample.yaml /tmp/config.yaml
 
-FROM ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
+FROM --platform=${BUILDPLATFORM} ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
 LABEL maintainer="${MAINTAINER}"
 
 ENV APP_NAME filter

--- a/dockers/gateway/lb/Dockerfile
+++ b/dockers/gateway/lb/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:latest
 #
 # Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
 #
@@ -19,9 +20,9 @@ ARG DISTROLESS_IMAGE=gcr.io/distroless/static
 ARG DISTROLESS_IMAGE_TAG=nonroot
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
-FROM golang:${GO_VERSION} AS golang
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS golang
 
-FROM ubuntu:devel AS builder
+FROM --platform=${BUILDPLATFORM} ubuntu:devel AS builder
 
 ENV GO111MODULE on
 ENV DEBIAN_FRONTEND noninteractive
@@ -80,7 +81,7 @@ RUN make REPO=${ORG} NAME=${REPO} cmd/${PKG}/${APP_NAME} \
 WORKDIR ${GOPATH}/src/github.com/${ORG}/${REPO}/cmd/${PKG}
 RUN cp sample.yaml /tmp/config.yaml
 
-FROM ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
+FROM --platform=${BUILDPLATFORM} ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
 LABEL maintainer="${MAINTAINER}"
 
 ENV APP_NAME lb

--- a/dockers/index/job/correction/Dockerfile
+++ b/dockers/index/job/correction/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:latest
 #
 # Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
 #
@@ -19,9 +20,9 @@ ARG DISTROLESS_IMAGE=gcr.io/distroless/static
 ARG DISTROLESS_IMAGE_TAG=nonroot
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
-FROM golang:${GO_VERSION} AS golang
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS golang
 
-FROM ubuntu:devel AS builder
+FROM --platform=${BUILDPLATFORM} ubuntu:devel AS builder
 
 ENV GO111MODULE on
 ENV DEBIAN_FRONTEND noninteractive
@@ -80,7 +81,7 @@ RUN make REPO=${ORG} NAME=${REPO} cmd/${PKG}/${APP_NAME} \
 WORKDIR ${GOPATH}/src/github.com/${ORG}/${REPO}/cmd/${PKG}
 RUN cp sample.yaml /tmp/config.yaml
 
-FROM ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
+FROM --platform=${BUILDPLATFORM} ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
 LABEL maintainer="${MAINTAINER}"
 
 ENV APP_NAME index-correction

--- a/dockers/index/job/creation/Dockerfile
+++ b/dockers/index/job/creation/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:latest
 #
 # Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
 #
@@ -19,9 +20,9 @@ ARG DISTROLESS_IMAGE=gcr.io/distroless/static
 ARG DISTROLESS_IMAGE_TAG=nonroot
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
-FROM golang:${GO_VERSION} AS golang
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS golang
 
-FROM ubuntu:devel AS builder
+FROM --platform=${BUILDPLATFORM} ubuntu:devel AS builder
 
 ENV GO111MODULE on
 ENV DEBIAN_FRONTEND noninteractive
@@ -80,7 +81,7 @@ RUN make REPO=${ORG} NAME=${REPO} cmd/${PKG}/${APP_NAME} \
 WORKDIR ${GOPATH}/src/github.com/${ORG}/${REPO}/cmd/${PKG}
 RUN cp sample.yaml /tmp/config.yaml
 
-FROM ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
+FROM --platform=${BUILDPLATFORM} ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
 LABEL maintainer="${MAINTAINER}"
 
 ENV APP_NAME index-creation

--- a/dockers/index/job/save/Dockerfile
+++ b/dockers/index/job/save/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:latest
 #
 # Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
 #
@@ -19,9 +20,9 @@ ARG DISTROLESS_IMAGE=gcr.io/distroless/static
 ARG DISTROLESS_IMAGE_TAG=nonroot
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
-FROM golang:${GO_VERSION} AS golang
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS golang
 
-FROM ubuntu:devel AS builder
+FROM --platform=${BUILDPLATFORM} ubuntu:devel AS builder
 
 ENV GO111MODULE on
 ENV DEBIAN_FRONTEND noninteractive
@@ -80,7 +81,7 @@ RUN make REPO=${ORG} NAME=${REPO} cmd/${PKG}/${APP_NAME} \
 WORKDIR ${GOPATH}/src/github.com/${ORG}/${REPO}/cmd/${PKG}
 RUN cp sample.yaml /tmp/config.yaml
 
-FROM ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
+FROM --platform=${BUILDPLATFORM} ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
 LABEL maintainer="${MAINTAINER}"
 
 ENV APP_NAME index-save

--- a/dockers/manager/index/Dockerfile
+++ b/dockers/manager/index/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:latest
 #
 # Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
 #
@@ -19,9 +20,9 @@ ARG DISTROLESS_IMAGE=gcr.io/distroless/static
 ARG DISTROLESS_IMAGE_TAG=nonroot
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
-FROM golang:${GO_VERSION} AS golang
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS golang
 
-FROM ubuntu:devel AS builder
+FROM --platform=${BUILDPLATFORM} ubuntu:devel AS builder
 
 ENV GO111MODULE on
 ENV DEBIAN_FRONTEND noninteractive
@@ -80,7 +81,7 @@ RUN make REPO=${ORG} NAME=${REPO} cmd/${PKG}/${APP_NAME} \
 WORKDIR ${GOPATH}/src/github.com/${ORG}/${REPO}/cmd/${PKG}
 RUN cp sample.yaml /tmp/config.yaml
 
-FROM ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
+FROM --platform=${BUILDPLATFORM} ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
 LABEL maintainer="${MAINTAINER}"
 
 ENV APP_NAME index

--- a/dockers/operator/helm/Dockerfile
+++ b/dockers/operator/helm/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:latest
 #
 # Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
 #
@@ -25,9 +26,9 @@ ARG VALD_HELM_OPERATOR_KIND="ValdHelmOperatorRelease"
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
 # skipcq: DOK-DL3026
-FROM quay.io/operator-framework/helm-operator:${OPERATOR_SDK_VERSION} AS operator
-FROM golang:${GO_VERSION} AS golang
-FROM ubuntu:devel AS builder
+FROM --platform=${BUILDPLATFORM} quay.io/operator-framework/helm-operator:${OPERATOR_SDK_VERSION} AS operator
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS golang
+FROM --platform=${BUILDPLATFORM} ubuntu:devel AS builder
 
 ARG OPERATOR_SDK_VERSION
 ARG VERSION
@@ -123,7 +124,7 @@ COPY --from=operator /usr/local/bin/${APP_NAME} /usr/bin/${APP_NAME}
 
 RUN upx ${UPX_OPTIONS} "/usr/bin/${APP_NAME}"
 
-FROM ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
+FROM --platform=${BUILDPLATFORM} ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
 LABEL maintainer="${MAINTAINER}"
 
 ENV APP_NAME helm-operator

--- a/dockers/tools/cli/loadtest/Dockerfile
+++ b/dockers/tools/cli/loadtest/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:latest
 #
 # Copyright (C) 2019-2023 vdaas.org vald team <vald@vdaas.org>
 #
@@ -17,9 +18,9 @@
 ARG GO_VERSION=latest
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
-FROM golang:${GO_VERSION} AS golang
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS golang
 
-FROM ubuntu:devel AS builder
+FROM --platform=${BUILDPLATFORM} ubuntu:devel AS builder
 
 ENV GO111MODULE on
 ENV DEBIAN_FRONTEND noninteractive
@@ -107,9 +108,9 @@ RUN GO_VERSION="$(< GO_VERSION)" \
     && upx -9 -o "/usr/bin/${APP_NAME}" "${APP_NAME}"
 
 # Start From Scratch For Running Environment
-FROM ubuntu:devel
+FROM --platform=${BUILDPLATFORM} ubuntu:devel
 # Start From Alpine For Debug Environment
-# FROM alpine:latest
+# FROM --platform=${BUILDPLATFORM} alpine:latest
 LABEL maintainer="${MAINTAINER}"
 
 ENV APP_NAME loadtest

--- a/hack/license/gen/main.go
+++ b/hack/license/gen/main.go
@@ -50,6 +50,23 @@ var (
 {{.Escape}} limitations under the License.
 {{.Escape}}
 `))
+	docker = template.Must(template.New("Apache License").Parse(`{{.Escape}} syntax = docker/dockerfile:latest
+{{.Escape}}
+{{.Escape}} Copyright (C) 2019-{{.Year}} {{.Maintainer}}
+{{.Escape}}
+{{.Escape}} Licensed under the Apache License, Version 2.0 (the "License");
+{{.Escape}} You may not use this file except in compliance with the License.
+{{.Escape}} You may obtain a copy of the License at
+{{.Escape}}
+{{.Escape}}    https://www.apache.org/licenses/LICENSE-2.0
+{{.Escape}}
+{{.Escape}} Unless required by applicable law or agreed to in writing, software
+{{.Escape}} distributed under the License is distributed on an "AS IS" BASIS,
+{{.Escape}} WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+{{.Escape}} See the License for the specific language governing permissions and
+{{.Escape}} limitations under the License.
+{{.Escape}}
+`))
 
 	googleProtoApache = template.Must(template.New("Google Proto Apache License").Parse(`{{.Escape}}
 {{.Escape}} Copyright (C) {{.Year}} Google LLC
@@ -259,6 +276,10 @@ func readAndRewrite(path string) error {
 				tmpl = googleProtoApache
 			}
 			d.Escape = slushEscape
+		default:
+			if fi.Name() == "Dockerfile" {
+				tmpl = docker
+			}
 		}
 		lf := true
 		bf := false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

I've added Docker buildkit registry cache for vald docker image builds.
and compress each docker image with zstd for more efficient start up performance.

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.5
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.4
- NGT Version: 2.1.5

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
