### PR TITLE
[bugfix] resolve duplicated cluster wide resources name problem

### DIFF
--- a/charts/vald/templates/agent/networkpolicy.yaml
+++ b/charts/vald/templates/agent/networkpolicy.yaml
@@ -24,7 +24,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: agent-allow
+  name: {{ $agent.name }}-allow
 spec:
   podSelector:
     matchLabels:

--- a/charts/vald/templates/agent/readreplica/networkpolicy.yaml
+++ b/charts/vald/templates/agent/readreplica/networkpolicy.yaml
@@ -25,7 +25,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: agent-readreplica-allow
+  name: {{ $readreplica.component_name }}-allow
 spec:
   podSelector:
     matchLabels:

--- a/charts/vald/templates/discoverer/clusterrole.yaml
+++ b/charts/vald/templates/discoverer/clusterrole.yaml
@@ -18,7 +18,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: discoverer
+  name: {{ $discoverer.clusterRole.name }}
   labels:
     app.kubernetes.io/name: {{ include "vald.name" . }}
     helm.sh/chart: {{ include "vald.chart" . }}

--- a/charts/vald/templates/discoverer/networkpolicy.yaml
+++ b/charts/vald/templates/discoverer/networkpolicy.yaml
@@ -24,7 +24,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: discoverer-allow
+  name: {{ $discoverer.name }}-allow
 spec:
   podSelector:
     matchLabels:

--- a/charts/vald/templates/gateway/filter/networkpolicy.yaml
+++ b/charts/vald/templates/gateway/filter/networkpolicy.yaml
@@ -20,7 +20,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: filter-allow
+  name: {{ $filter.name }}-allow
 spec:
   podSelector:
     matchLabels:

--- a/charts/vald/templates/gateway/lb/networkpolicy.yaml
+++ b/charts/vald/templates/gateway/lb/networkpolicy.yaml
@@ -22,7 +22,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: lb-allow
+  name: {{ $lb.name }}-allow
 spec:
   podSelector:
     matchLabels:

--- a/charts/vald/templates/manager/index/networkpolicy.yaml
+++ b/charts/vald/templates/manager/index/networkpolicy.yaml
@@ -21,7 +21,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: index-allow
+  name: {{ $index.name }}-allow
 spec:
   podSelector:
     matchLabels:

--- a/k8s/discoverer/configmap.yaml
+++ b/k8s/discoverer/configmap.yaml
@@ -219,6 +219,9 @@ data:
           node_metrics:
             labels: {}
             fields: {}
+          service:
+            labels: {}
+            fields: {}
       net:
         dialer:
           dual_stack_enabled: false

--- a/k8s/discoverer/deployment.yaml
+++ b/k8s/discoverer/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: discoverer
       annotations:
-        checksum/configmap: 6eee25d7cd882f4ac6e09711a13d8f8fd13953a90157a8fe97ecc5ac2007a846
+        checksum/configmap: 4b9b2c59eb8cfa9fb3e0c24320d784743aa088b1ddf34aeffb16f183045293b3
         profefe.com/enable: "true"
         profefe.com/port: "6060"
         profefe.com/service: vald-discoverer

--- a/k8s/operator/helm/crds/valdrelease.yaml
+++ b/k8s/operator/helm/crds/valdrelease.yaml
@@ -2803,6 +2803,15 @@ spec:
                                 labels:
                                   type: object
                                   x-kubernetes-preserve-unknown-fields: true
+                            service:
+                              type: object
+                              properties:
+                                fields:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                labels:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
                     enabled:
                       type: boolean
                     env:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
SSIA
<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.5
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.4
- NGT Version: 2.1.6

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
