### PR TITLE
Change license/gen to skip symlink

### DIFF
--- a/hack/license/gen/main.go
+++ b/hack/license/gen/main.go
@@ -226,7 +226,24 @@ func dirwalk(dir string) []string {
 	return paths
 }
 
+func isSymlink(path string) (bool, error) {
+	lst, err := os.Lstat(path)
+	if err != nil {
+		return false, err
+	}
+	return lst.Mode()&os.ModeSymlink != 0, nil
+}
+
 func readAndRewrite(path string) error {
+	// return if it is a symlink
+	isSym, err := isSymlink(path)
+	if err != nil {
+		return err
+	}
+	if isSym {
+		return nil
+	}
+
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_SYNC, fs.ModePerm)
 	if err != nil {
 		return errors.Errorf("filepath %s, could not open", path)

--- a/hack/license/gen/main_test.go
+++ b/hack/license/gen/main_test.go
@@ -15,3 +15,58 @@
 //
 
 package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	symlinkPath := filepath.Join(dir, "target")
+	filePath := filepath.Join(dir, "file")
+
+	_, err := os.Create(filePath)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = os.Symlink(filePath, symlinkPath)
+	if err != nil {
+		t.Error(err)
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "return true when it is a symlink",
+			path:     symlinkPath,
+			expected: true,
+		},
+		{
+			name:     "return false when it is a normal file",
+			path:     filePath,
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		test := tc
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			isSymlink, err := isSymlink(test.path)
+			if err != nil {
+				tt.Error(err)
+			}
+			if isSymlink != test.expected {
+				tt.Errorf("expected %v, got %v", test.expected, isSymlink)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR adds a logic to license/gen to skip symlink. This is required to avoid symlink files like `values.yaml` in vald-readreplica to become normal file on `make format`.

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.5
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.4
- NGT Version: 2.1.6

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
