### PR TITLE
disable disconnection during non-IP-direct connection

### DIFF
--- a/internal/net/grpc/client.go
+++ b/internal/net/grpc/client.go
@@ -259,8 +259,8 @@ func (g *gRPCClient) StartConnectionMonitor(ctx context.Context) (<-chan error, 
 						disconnectTargets = append(disconnectTargets, addr)
 						return true
 					}
-					// for health check we don't need to reconnect when ip connection pool is healthy
-					if p.IsHealthy(ctx) && p.IsIPConn() {
+					// for health check we don't need to reconnect when connection is healthy
+					if p.IsHealthy(ctx) {
 						return true
 					}
 					// if connection is not ip direct or unhealthy let's re-connect
@@ -329,9 +329,22 @@ func (g *gRPCClient) StartConnectionMonitor(ctx context.Context) (<-chan error, 
 				}
 			})
 			cancel()
-			disconnected := make(map[string]bool, len(disconnectTargets))
+			var (
+				disconnectFlag bool
+				isIPv4, isIPv6 bool
+				host           string
+				port           uint16
+				disconnected   = make(map[string]bool, len(disconnectTargets))
+			)
 			for _, addr := range disconnectTargets {
-				if !disconnected[addr] {
+				host, port, _, isIPv4, isIPv6, err = net.Parse(addr)
+				disconnectFlag = isIPv4 || isIPv6 // Disconnect only if the connection is a direct IP connection; do not delete connections via DNS due to retry.
+				if err != nil {
+					log.Warnf("failed to parse addr %s for disconnection checking, will disconnect soon: host: %s, port %d, err: %v", addr, host, port, err)
+					disconnectFlag = true // Disconnect if the address connected to is not parseable.
+				}
+				if disconnectFlag &&
+					!disconnected[addr] {
 					err = g.Disconnect(ctx, addr)
 					if err != nil {
 						if !errors.Is(err, context.Canceled) &&

--- a/internal/net/grpc/pool/pool.go
+++ b/internal/net/grpc/pool/pool.go
@@ -359,7 +359,7 @@ func (p *pool) connect(ctx context.Context, ips ...string) (c Conn, err error) {
 				!errors.Is(ierr, context.Canceled) {
 				log.Warnf("An error occurred while dialing pool member connection to %s,\terror: %v", addr, ierr)
 			} else {
-				log.Debug("Connect loop operation canceled while dialing pool member connection to %s,\terror: %v", addr, ierr)
+				log.Debugf("Connect loop operation canceled while dialing pool member connection to %s,\terror: %v", addr, ierr)
 				return false
 			}
 		}
@@ -421,7 +421,7 @@ func (p *pool) singleTargetConnect(ctx context.Context) (c Conn, err error) {
 				}
 				return true
 			} else {
-				log.Debug("Connect loop operation canceled while dialing pool member connection to %s,\terror: %v", p.addr, ierr)
+				log.Debugf("Connect loop operation canceled while dialing pool member connection to %s,\terror: %v", p.addr, ierr)
 				return false
 			}
 		}
@@ -449,7 +449,7 @@ func (p *pool) Disconnect() (err error) {
 					log.Debugf("failed to close connection pool addr = %s\terror = %v", pc.addr, ierr)
 					emap[ierr.Error()] = err
 				} else {
-					log.Debug("Disconnect loop operation canceled while closing pool member connection to %s,\terror: %v", pc.addr, ierr)
+					log.Debugf("Disconnect loop operation canceled while closing pool member connection to %s,\terror: %v", pc.addr, ierr)
 					return false
 				}
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.5
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.4
- NGT Version: 2.1.6

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
