### PR TITLE
Add Filter query configuration to Continuous Benchmark Job

### DIFF
--- a/charts/vald-benchmark-operator/crds/valdbenchmarkjob.yaml
+++ b/charts/vald-benchmark-operator/crds/valdbenchmarkjob.yaml
@@ -328,11 +328,11 @@ spec:
                 object_config:
                   type: object
                   properties:
-                    filter_config:
-                      type: object
-                      properties:
-                        host:
-                          type: string
+                    filter_configs:
+                      type: array
+                      items:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                 remove_config:
                   type: object
                   properties:

--- a/charts/vald-benchmark-operator/schemas/job-values.yaml
+++ b/charts/vald-benchmark-operator/schemas/job-values.yaml
@@ -140,15 +140,14 @@ remove_config:
 # @schema {"name": "object_config", "type": "object"}
 # object_config -- object config
 object_config:
-  # @schema {"name": "object_config.filter_config", "type": "object"}
-  # object_config.filter_config -- filter target config
-  filter_config:
-    # @schema {"name": "object_config.filter_config.host", "type": "string"}
-    # object_config.filter_config.host -- filter target host
-    host: 0.0.0.0
-    # @schema {"name": "object_config.filter_config.host", "type": "integer"}
-    # object_config.filter_config.port -- filter target host
-    port: 8081
+  # @schema {"name": "object_config.filter_configs", "type": "array", "items": {"type": "object"}}
+  # object_config.filter_configs -- filter configs
+  filter_configs:
+    - target:
+        host: 0.0.0.0
+        port: 8081
+      query:
+        query: ""
 # @schema {"name": "client_config", "type": "object"}
 # client_config -- gRPC client config for request to the Vald cluster
 client_config:

--- a/internal/config/benchmark.go
+++ b/internal/config/benchmark.go
@@ -192,7 +192,7 @@ func (cfg *FilterQuery) Bind() *FilterQuery {
 // FilterConfig defines the desired state of filter config
 type FilterConfig struct {
 	Target *FilterTarget `json:"target,omitempty" yaml:"target"`
-	Query  *FilterQuery  `json:"query,omitempty" yaml:"query"`
+	Query  *FilterQuery  `json:"query,omitempty"  yaml:"query"`
 }
 
 func (cfg *FilterConfig) Bind() *FilterConfig {

--- a/internal/config/benchmark.go
+++ b/internal/config/benchmark.go
@@ -156,11 +156,15 @@ func (cfg *RemoveConfig) Bind() *RemoveConfig {
 
 // ObjectConfig defines the desired state of object config
 type ObjectConfig struct {
-	FilterConfig FilterConfig `json:"filter_config,omitempty" yaml:"filter_config"`
+	FilterConfigs []*FilterConfig `json:"filter_configs,omitempty" yaml:"filter_configs"`
 }
 
 func (cfg *ObjectConfig) Bind() *ObjectConfig {
-	cfg.FilterConfig = *cfg.FilterConfig.Bind()
+	for i := 0; i < len(cfg.FilterConfigs); i++ {
+		if cfg.FilterConfigs[i] != nil {
+			cfg.FilterConfigs[i] = cfg.FilterConfigs[i].Bind()
+		}
+	}
 	return cfg
 }
 
@@ -175,14 +179,33 @@ func (cfg *FilterTarget) Bind() *FilterTarget {
 	return cfg
 }
 
+// FilterQuery defines the query passed to filter target.
+type FilterQuery struct {
+	Query string `json:"query,omitempty" yaml:"query"`
+}
+
+func (cfg *FilterQuery) Bind() *FilterQuery {
+	cfg.Query = GetActualValue(cfg.Query)
+	return cfg
+}
+
 // FilterConfig defines the desired state of filter config
 type FilterConfig struct {
-	Targets []*FilterTarget `json:"target,omitempty" yaml:"target"`
+	Target *FilterTarget `json:"target,omitempty" yaml:"target"`
+	Query  *FilterQuery  `json:"query,omitempty" yaml:"query"`
 }
 
 func (cfg *FilterConfig) Bind() *FilterConfig {
-	for i := 0; i < len(cfg.Targets); i++ {
-		cfg.Targets[i] = cfg.Targets[i].Bind()
+	if cfg.Target != nil {
+		cfg.Target = cfg.Target.Bind()
+	} else {
+		cfg.Target = (&FilterTarget{}).Bind()
+	}
+
+	if cfg.Query != nil {
+		cfg.Query = cfg.Query.Bind()
+	} else {
+		cfg.Query = (&FilterQuery{}).Bind()
 	}
 	return cfg
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

#### WHY

In the following PR, we made a change to pass a query to `FilterConfig`. 
This caused a build error of the Continuous Benchmark Job, but I fixed it in this PR.


#### WHAT

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.5
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.4
- NGT Version: 2.1.6

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
