### PR TITLE
Add release branch build for bench and mirror

### DIFF
--- a/.github/workflows/dockers-release-branch-image.yaml
+++ b/.github/workflows/dockers-release-branch-image.yaml
@@ -71,6 +71,13 @@ jobs:
       target: gateway-filter
     secrets: inherit
 
+  gateway-mirror:
+    needs: [dump-contexts-to-log]
+    uses: ./.github/workflows/_docker-image.yaml
+    with:
+      target: gateway-mirror
+    secrets: inherit
+
   index-correction:
     needs: [dump-contexts-to-log]
     uses: ./.github/workflows/_docker-image.yaml
@@ -119,4 +126,18 @@ jobs:
     uses: ./.github/workflows/_docker-image.yaml
     with:
       target: readreplica-rotate
+    secrets: inherit
+
+  benchmark-job:
+    needs: [dump-contexts-to-log]
+    uses: ./.github/workflows/_docker-image.yaml
+    with:
+      target: benchmark-job
+    secrets: inherit
+
+  benchmark-operator:
+    needs: [dump-contexts-to-log]
+    uses: ./.github/workflows/_docker-image.yaml
+    with:
+      target: benchmark-operator
     secrets: inherit

--- a/charts/vald/values/multi-vald/dev-vald-with-mirror.yaml
+++ b/charts/vald/values/multi-vald/dev-vald-with-mirror.yaml
@@ -15,7 +15,7 @@
 #
 defaults:
   image:
-    tag: pr-2262 # TODO: Delete it later.
+    tag: nightly
   server_config:
     metrics:
       pprof:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

Added rule to create docker images for the release branches of bench and mirror.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.5
- Docker Version: 20.10.8
- Kubernetes Version: v1.28.4
- NGT Version: 2.1.6

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
