### PR TITLE
Fix e2e regressions

### DIFF
--- a/.github/workflows/e2e-max-dim.yml
+++ b/.github/workflows/e2e-max-dim.yml
@@ -65,7 +65,7 @@ jobs:
 
             sleep 3
 
-            kubectl rollout restart statefulset vald-agent-ngt
+            kubectl rollout restart statefulset vald-agent
 
             sleep 30
 
@@ -100,7 +100,7 @@ jobs:
           echo "MAX_BIT=${BIT}"
         env:
           DEFAULT_IMAGE_TAG: ${{ steps.setup_e2e.outputs.DEFAULT_IMAGE_TAG }}
-          WAIT_FOR_SELECTOR: app=vald-agent-ngt
+          WAIT_FOR_SELECTOR: app=vald-agent
           WAIT_FOR_TIMEOUT: 29m
           VALUES: .github/helm/values/values-max-dim.yaml
         timeout-minutes: 60

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -344,7 +344,7 @@ jobs:
         with:
           helm_extra_options: ${{ steps.setup_e2e.outputs.HELM_EXTRA_OPTIONS }}
           values: .github/helm/values/values-readreplica.yaml
-          wait_for_selector: app=vald-agent-ngt
+          wait_for_selector: app=vald-agent
 
       - name: Deploy Vald Read Replica
         id: deploy_vald_readreplica

--- a/Makefile.d/k8s.mk
+++ b/Makefile.d/k8s.mk
@@ -111,6 +111,7 @@ k8s/vald/deploy:
 	@echo "Permitting error because there's some cases nothing to apply"
 	kubectl apply -f $(TEMP_DIR)/vald/templates/manager/index || true
 	kubectl apply -f $(TEMP_DIR)/vald/templates/agent || true
+	kubectl apply -f $(TEMP_DIR)/vald/templates/agent/ngt || true
 	kubectl apply -f $(TEMP_DIR)/vald/templates/agent/readreplica || true
 	kubectl apply -f $(TEMP_DIR)/vald/templates/discoverer || true
 	kubectl apply -f $(TEMP_DIR)/vald/templates/gateway || true
@@ -152,6 +153,7 @@ k8s/vald/delete:
 	kubectl delete -f $(TEMP_DIR)/vald/templates/manager/index
 	kubectl delete -f $(TEMP_DIR)/vald/templates/discoverer
 	kubectl delete -f $(TEMP_DIR)/vald/templates/agent/readreplica || true
+	kubectl apply -f $(TEMP_DIR)/vald/templates/agent/ngt || true
 	kubectl delete -f $(TEMP_DIR)/vald/templates/agent
 	kubectl delete -f $(TEMP_DIR)/vald/crds
 	rm -rf $(TEMP_DIR)

--- a/Makefile.d/k8s.mk
+++ b/Makefile.d/k8s.mk
@@ -153,7 +153,7 @@ k8s/vald/delete:
 	kubectl delete -f $(TEMP_DIR)/vald/templates/manager/index
 	kubectl delete -f $(TEMP_DIR)/vald/templates/discoverer
 	kubectl delete -f $(TEMP_DIR)/vald/templates/agent/readreplica || true
-	kubectl apply -f $(TEMP_DIR)/vald/templates/agent/ngt || true
+	kubectl delete -f $(TEMP_DIR)/vald/templates/agent/ngt || true
 	kubectl delete -f $(TEMP_DIR)/vald/templates/agent
 	kubectl delete -f $(TEMP_DIR)/vald/crds
 	rm -rf $(TEMP_DIR)

--- a/tests/e2e/crud/crud_test.go
+++ b/tests/e2e/crud/crud_test.go
@@ -853,12 +853,12 @@ func TestE2EReadReplica(t *testing.T) {
 	sleep(t, waitAfterInsertDuration)
 
 	t.Log("starting to restart all the agent pods to make it backup index to pvc...")
-	if err := kubectl.RolloutResource(ctx, t, "statefulsets/vald-agent-ngt"); err != nil {
+	if err := kubectl.RolloutResource(ctx, t, "statefulsets/vald-agent"); err != nil {
 		t.Fatalf("failed to restart all the agent pods: %s", err)
 	}
 
 	t.Log("starting to create read replica rotators...")
-	pods, err := kubeClient.GetPods(ctx, namespace, "app=vald-agent-ngt")
+	pods, err := kubeClient.GetPods(ctx, namespace, "app=vald-agent")
 	if err != nil {
 		t.Fatalf("GetPods failed: %s", err)
 	}

--- a/tests/e2e/crud/crud_test.go
+++ b/tests/e2e/crud/crud_test.go
@@ -790,8 +790,8 @@ func TestE2EIndexJobCorrection(t *testing.T) {
 	}
 
 	t.Log("Test case 2: execute index correction after one agent removed")
-	t.Log("removing vald-agent-ngt-0...")
-	cmd := exec.CommandContext(ctx, "sh", "-c", "kubectl delete pod vald-agent-ngt-0 && kubectl wait --for=condition=Ready pod/vald-agent-ngt-0")
+	t.Log("removing vald-agent-0...")
+	cmd := exec.CommandContext(ctx, "sh", "-c", "kubectl delete pod vald-agent-0 && kubectl wait --for=condition=Ready pod/vald-agent-0")
 	out, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

https://github.com/vdaas/vald/pull/2303 changed agent name from `vald-agent-ngt` to `vald-agent`, and it broke the e2e tests. This PR fixes it.

### Related Issue:

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions:

<!--- Please change the versions below along with your environment -->

- Go Version: 1.21.6
- Docker Version: 20.10.8
- Kubernetes Version: v1.29.1
- NGT Version: 2.1.6

### Checklist:

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer:

<!-- Please tell us anything you would like to share to reviewers related this PR -->
