### PR TITLE
Revert dev Dockerfile to use official devcontainer image

### DIFF
--- a/Makefile.d/tools.mk
+++ b/Makefile.d/tools.mk
@@ -102,6 +102,42 @@ yamlfmt/install: $(GOPATH)/bin/yamlfmt
 $(GOPATH)/bin/yamlfmt:
 	$(call go-install, github.com/google/yamlfmt/cmd/yamlfmt)
 
+.PHONY: gopls/install
+gopls/install: $(GOPATH)/bin/gopls
+
+$(GOPATH)/bin/gopls:
+	$(call go-install, golang.org/x/tools/gopls)
+
+.PHONY: gomodifytags/install
+gomodifytags/install: $(GOPATH)/bin/gomodifytags
+
+$(GOPATH)/bin/gomodifytags:
+	$(call go-install, github.com/fatih/gomodifytags)
+
+.PHONY: impl/install
+impl/install: $(GOPATH)/bin/impl
+
+$(GOPATH)/bin/impl:
+	$(call go-install, github.com/josharian/impl)
+
+.PHONY: goplay/install
+goplay/install: $(GOPATH)/bin/goplay
+
+$(GOPATH)/bin/goplay:
+	$(call go-install, github.com/haya14busa/goplay/cmd/goplay)
+
+.PHONY: delve/install
+delve/install: $(GOPATH)/bin/dlv
+
+$(GOPATH)/bin/dlv:
+	$(call go-install, github.com/go-delve/delve/cmd/dlv)
+
+.PHONY: staticcheck/install
+staticcheck/install: $(GOPATH)/bin/staticcheck
+
+$(GOPATH)/bin/staticcheck:
+	$(call go-install, honnef.co/go/tools/cmd/staticcheck)
+
 .PHONY: rust/install
 rust/install: $(CARGO_HOME)/bin/cargo
 

--- a/dockers/dev/Dockerfile
+++ b/dockers/dev/Dockerfile
@@ -21,7 +21,7 @@ ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 # Ubuntu is not supported by a lot of devcontainer features like `docker-in-docker`, so we should stick to official debian based ones
 # https://github.com/devcontainers/features/blob/08fb370a59cc311d9f81a9e90be33cf2e6648baa/src/docker-in-docker/install.sh#L123
 # FIXME: change the tag to :1 when they support go 1.22
-FROM --platform=${BUILDPLATFORM} mcr.microsoft.com/vscode/devcontainers/go:dev-1.22 AS builder
+FROM --platform=${BUILDPLATFORM} mcr.microsoft.com/vscode/devcontainers/base:debian
 LABEL maintainer="${MAINTAINER}"
 
 ARG GO_VERSION
@@ -74,7 +74,6 @@ COPY rust rust
 COPY hack/go.mod.default hack/go.mod.default
 COPY example/client/go.mod.default example/client/go.mod.default
 
-# basic deps
 RUN --mount=type=cache,target="${GOPATH}/pkg",id="go-build-${TARGETARCH}" \
     --mount=type=cache,target="${HOME}/.cache/go-build",id="go-build-${TARGETARCH}" \
     make GOARCH=${TARGETARCH} GOOS=${TARGETOS} deps GO_CLEAN_DEPS=false \
@@ -92,4 +91,11 @@ RUN --mount=type=cache,target="${GOPATH}/pkg",id="go-build-${TARGETARCH}" \
     && make k9s/install \
     && make minikube/install \
     && make stern/install \
-    && make telepresence/install
+    && make telepresence/install \
+    && echo "installing golang vscode extension dependencies" \
+    && make gopls/install \
+    && make gotests/install \
+    && make gomodifytags/install \
+    && make impl/install \
+    && make delve/install \
+    && make staticcheck/install

--- a/dockers/dev/Dockerfile
+++ b/dockers/dev/Dockerfile
@@ -18,7 +18,10 @@
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
 # skipcq: DOK-DL3026
-FROM --platform=${BUILDPLATFORM} ubuntu:devel AS builder
+# Ubuntu is not supported by a lot of devcontainer features like `docker-in-docker`, so we should stick to official debian based ones
+# https://github.com/devcontainers/features/blob/08fb370a59cc311d9f81a9e90be33cf2e6648baa/src/docker-in-docker/install.sh#L123
+# FIXME: change the tag to :1 when they support go 1.22
+FROM --platform=${BUILDPLATFORM} mcr.microsoft.com/vscode/devcontainers/go:dev-1.22 AS builder
 LABEL maintainer="${MAINTAINER}"
 
 ARG GO_VERSION

--- a/dockers/dev/Dockerfile
+++ b/dockers/dev/Dockerfile
@@ -18,9 +18,7 @@
 ARG MAINTAINER="vdaas.org vald team <vald@vdaas.org>"
 
 # skipcq: DOK-DL3026
-# Ubuntu is not supported by a lot of devcontainer features like `docker-in-docker`, so we should stick to official debian based ones
-# https://github.com/devcontainers/features/blob/08fb370a59cc311d9f81a9e90be33cf2e6648baa/src/docker-in-docker/install.sh#L123
-# FIXME: change the tag to :1 when they support go 1.22
+# we should stick to official devcontainers as a base image because it is well tested to be used with the vscode devcontainer extension.
 FROM --platform=${BUILDPLATFORM} mcr.microsoft.com/vscode/devcontainers/base:debian
 LABEL maintainer="${MAINTAINER}"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

Current nightly devcontainer cannot be opened with vscode devcontainer extension. This PR fixes the issue.

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Go Version: 1.22.0
- Docker Version: 20.10.8
- Kubernetes Version: v1.29.1
- NGT Version: 2.1.6

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->

I don't know why it's trying to import buildcahe and fail when there is no buildcache because it's the first try. But should be fine in the main branch. Also it should not be a big problem since it succeeds to publish image anyway.
https://github.com/vdaas/vald/actions/runs/7826490855/job/21368714853?pr=2335#step:9:5209
