### PR TITLE
Change docker scan timeout longer

### DIFF
--- a/.github/actions/scan-docker-image/action.yaml
+++ b/.github/actions/scan-docker-image/action.yaml
@@ -33,6 +33,7 @@ runs:
         image-ref: ${{ inputs.image_ref }}
         format: "table"
         severity: ${{ inputs.severity }}
+        timeout: 30m
     - name: Run vulnerability scanner (sarif)
       uses: aquasecurity/trivy-action@master
       with:
@@ -40,6 +41,7 @@ runs:
         format: "sarif"
         output: "trivy-results.sarif"
         severity: ${{ inputs.severity }}
+        timeout: 30m
     - name: Upload Trivy scan results to Security tab
       uses: github/codeql-action/upload-sarif@v2
       with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

SSIA

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Go Version: 1.22.0
- Docker Version: 20.10.8
- Kubernetes Version: v1.29.2
- NGT Version: 2.1.6

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->
