### PR TITLE
Enable only manual dispatch for protobuf update

### DIFF
--- a/.github/workflows/update-protobuf.yaml
+++ b/.github/workflows/update-protobuf.yaml
@@ -16,12 +16,12 @@
 name: "Update protobuf"
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - "*.*.*"
-      - "v*.*.*"
-      - "*.*.*-*"
-      - "v*.*.*-*"
+  # push:
+  #   tags:
+  #     - "*.*.*"
+  #     - "v*.*.*"
+  #     - "*.*.*-*"
+  #     - "v*.*.*-*"
 jobs:
   dump-contexts-to-log:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Because the client does not support two version deploy, only the manual dispatch method will be enabled.

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Go Version: 1.22.0
- Docker Version: 20.10.8
- Kubernetes Version: v1.29.2
- NGT Version: 2.1.6

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->
