### PR TITLE
Fix index job logic to pass DNS A record

### DIFF
--- a/charts/vald/templates/index/job/creation/configmap.yaml
+++ b/charts/vald/templates/index/job/creation/configmap.yaml
@@ -51,6 +51,12 @@ data:
       agent_namespace: {{ $creator.agent_namespace | quote }}
       node_name: {{ $creator.node_name | quote }}
       concurrency: {{ $creator.concurrency }}
+      {{- if $creator.target_addrs -}}
+      target_addrs:
+        {{ toYaml $creator.target_addrs | indent 8 }}
+      {{- else -}}
+      target_addrs: []
+      {{- end -}}
       target_addrs: {{ $creator.target_addrs }}
       discoverer:
         duration: {{ $creator.discoverer.duration }}

--- a/charts/vald/templates/index/job/creation/configmap.yaml
+++ b/charts/vald/templates/index/job/creation/configmap.yaml
@@ -51,13 +51,12 @@ data:
       agent_namespace: {{ $creator.agent_namespace | quote }}
       node_name: {{ $creator.node_name | quote }}
       concurrency: {{ $creator.concurrency }}
-      {{- if $creator.target_addrs -}}
+      {{- if $creator.target_addrs }}
       target_addrs:
-        {{ toYaml $creator.target_addrs | indent 8 }}
-      {{- else -}}
+        {{- toYaml $creator.target_addrs | nindent 8 }}
+      {{- else }}
       target_addrs: []
-      {{- end -}}
-      target_addrs: {{ $creator.target_addrs }}
+      {{- end }}
       discoverer:
         duration: {{ $creator.discoverer.duration }}
         client:

--- a/charts/vald/templates/index/job/save/configmap.yaml
+++ b/charts/vald/templates/index/job/save/configmap.yaml
@@ -51,12 +51,12 @@ data:
       agent_namespace: {{ $saver.agent_namespace | quote }}
       node_name: {{ $saver.node_name | quote }}
       concurrency: {{ $saver.concurrency }}
-      {{- if $saver.target_addrs -}}
+      {{- if $saver.target_addrs }}
       target_addrs:
-        {{ toYaml $saver.target_addrs | indent 8 }}
-      {{- else -}}
+        {{- toYaml $saver.target_addrs | nindent 8 }}
+      {{- else }}
       target_addrs: []
-      {{- end -}}
+      {{- end }}
       discoverer:
         duration: {{ $saver.discoverer.duration }}
         client:

--- a/charts/vald/templates/index/job/save/configmap.yaml
+++ b/charts/vald/templates/index/job/save/configmap.yaml
@@ -51,7 +51,12 @@ data:
       agent_namespace: {{ $saver.agent_namespace | quote }}
       node_name: {{ $saver.node_name | quote }}
       concurrency: {{ $saver.concurrency }}
-      target_addrs: {{ $saver.target_addrs }}
+      {{- if $saver.target_addrs -}}
+      target_addrs:
+        {{ toYaml $saver.target_addrs | indent 8 }}
+      {{- else -}}
+      target_addrs: []
+      {{- end -}}
       discoverer:
         duration: {{ $saver.discoverer.duration }}
         client:

--- a/pkg/index/job/creation/service/indexer.go
+++ b/pkg/index/job/creation/service/indexer.go
@@ -135,6 +135,7 @@ func (idx *index) Start(ctx context.Context) error {
 	return nil
 }
 
+// skipcq: GO-R1005
 func (idx *index) doCreateIndex(ctx context.Context, fn func(_ context.Context, _ agent.AgentClient, _ ...grpc.CallOption) (*payload.Empty, error)) (errs error) {
 	ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, grpcMethodName), apiName+"/service/index.doCreateIndex")
 	defer func() {

--- a/pkg/index/job/creation/service/indexer.go
+++ b/pkg/index/job/creation/service/indexer.go
@@ -42,9 +42,8 @@ type Indexer interface {
 }
 
 type index struct {
-	client         discoverer.Client
-	targetAddrs    []string
-	targetAddrList map[string]bool
+	client      discoverer.Client
+	targetAddrs []string
 
 	creationPoolSize uint32
 	concurrency      int

--- a/pkg/index/job/creation/service/indexer.go
+++ b/pkg/index/job/creation/service/indexer.go
@@ -145,6 +145,12 @@ func (idx *index) doCreateIndex(ctx context.Context, fn func(_ context.Context, 
 
 	targetAddrs := idx.client.GetAddrs(ctx)
 	if len(idx.targetAddrs) != 0 {
+		// If target addresses is specified, that addresses are used in priority.
+		for _, addr := range idx.targetAddrs {
+			if _, err := idx.client.GetClient().Connect(ctx, addr); err != nil {
+				return err
+			}
+		}
 		targetAddrs = idx.targetAddrs
 	}
 	log.Infof("target agent addrs: %v", targetAddrs)

--- a/pkg/index/job/creation/service/indexer.go
+++ b/pkg/index/job/creation/service/indexer.go
@@ -147,6 +147,7 @@ func (idx *index) doCreateIndex(ctx context.Context, fn func(_ context.Context, 
 	if len(idx.targetAddrs) != 0 {
 		// If target addresses is specified, that addresses are used in priority.
 		for _, addr := range idx.targetAddrs {
+			log.Infof("connect to target agent (%s)", addr)
 			if _, err := idx.client.GetClient().Connect(ctx, addr); err != nil {
 				return err
 			}

--- a/pkg/index/job/creation/service/indexer_test.go
+++ b/pkg/index/job/creation/service/indexer_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/net/grpc"
 	"github.com/vdaas/vald/internal/net/grpc/codes"
+	"github.com/vdaas/vald/internal/net/grpc/pool"
 	"github.com/vdaas/vald/internal/net/grpc/status"
 	"github.com/vdaas/vald/internal/test/goleak"
 	clientmock "github.com/vdaas/vald/internal/test/mock/client"
@@ -67,7 +68,6 @@ func Test_index_Start(t *testing.T) {
 				args: args{
 					ctx: context.Background(),
 				},
-
 				fields: fields{
 					client: &clientmock.DiscovererClientMock{
 						GetAddrsFunc: func(_ context.Context) []string {
@@ -95,6 +95,8 @@ func Test_index_Start(t *testing.T) {
 				fields: fields{
 					targetAddrs: []string{
 						"127.0.0.1:8080",
+						"127.0.0.1:8081",
+						"127.0.0.1:8083",
 					},
 					client: &clientmock.DiscovererClientMock{
 						GetAddrsFunc: func(_ context.Context) []string {
@@ -106,6 +108,9 @@ func Test_index_Start(t *testing.T) {
 									_ func(_ context.Context, _ string, _ *grpc.ClientConn, _ ...grpc.CallOption) error,
 								) error {
 									return nil
+								},
+								ConnectFunc: func(_ context.Context, _ string, _ ...grpc.DialOption) (pool.Conn, error) {
+									return nil, nil
 								},
 							}
 						},
@@ -156,7 +161,6 @@ func Test_index_Start(t *testing.T) {
 				args: args{
 					ctx: context.Background(),
 				},
-
 				fields: fields{
 					client: &clientmock.DiscovererClientMock{
 						GetAddrsFunc: func(_ context.Context) []string {

--- a/pkg/index/job/save/service/indexer.go
+++ b/pkg/index/job/save/service/indexer.go
@@ -142,6 +142,12 @@ func (idx *index) doSaveIndex(ctx context.Context, fn func(_ context.Context, _ 
 
 	targetAddrs := idx.client.GetAddrs(ctx)
 	if len(idx.targetAddrs) != 0 {
+		// If target addresses is specified, that addresses are used in priority.
+		for _, addr := range idx.targetAddrs {
+			if _, err := idx.client.GetClient().Connect(ctx, addr); err != nil {
+				return err
+			}
+		}
 		targetAddrs = idx.targetAddrs
 	}
 	log.Infof("target agent addrs: %v", targetAddrs)

--- a/pkg/index/job/save/service/indexer.go
+++ b/pkg/index/job/save/service/indexer.go
@@ -42,16 +42,15 @@ type Indexer interface {
 }
 
 type index struct {
-	client         discoverer.Client
-	targetAddrs    []string
-	targetAddrList map[string]bool
+	client      discoverer.Client
+	targetAddrs []string
 
 	concurrency int
 }
 
 // New returns Indexer object if no error occurs.
 func New(opts ...Option) (Indexer, error) {
-	idx := new(index)
+	idx := &index{}
 	for _, opt := range append(defaultOpts, opts...) {
 		if err := opt(idx); err != nil {
 			oerr := errors.ErrOptionFailed(err, reflect.ValueOf(opt))
@@ -63,11 +62,21 @@ func New(opts ...Option) (Indexer, error) {
 			log.Warn(oerr)
 		}
 	}
-	idx.targetAddrList = make(map[string]bool, len(idx.targetAddrs))
-	for _, addr := range idx.targetAddrs {
-		idx.targetAddrList[addr] = true
-	}
+	idx.targetAddrs = delDuplicateAddrs(idx.targetAddrs)
 	return idx, nil
+}
+
+func delDuplicateAddrs(targetAddrs []string) []string {
+	addrs := make([]string, 0, len(targetAddrs))
+	exist := make(map[string]bool)
+
+	for _, addr := range targetAddrs {
+		if !exist[addr] {
+			addrs = append(addrs, addr)
+			exist[addr] = true
+		}
+	}
+	return addrs
 }
 
 // StartClient starts the gRPC client.
@@ -133,12 +142,7 @@ func (idx *index) doSaveIndex(ctx context.Context, fn func(_ context.Context, _ 
 
 	targetAddrs := idx.client.GetAddrs(ctx)
 	if len(idx.targetAddrs) != 0 {
-		targetAddrs = idx.extractTargetAddrs(targetAddrs)
-
-		// If targetAddrs is empty, an invalid target addresses may be registered in targetAddrList.
-		if len(targetAddrs) == 0 {
-			return errors.ErrGRPCTargetAddrNotFound
-		}
+		targetAddrs = idx.targetAddrs
 	}
 	log.Infof("target agent addrs: %v", targetAddrs)
 
@@ -199,17 +203,4 @@ func (idx *index) doSaveIndex(ctx context.Context, fn func(_ context.Context, _ 
 		},
 	)
 	return errors.Join(err, errs)
-}
-
-// extractTargetAddresses filters and extracts target addresses registered in targetAddrList from the given address list.
-func (idx *index) extractTargetAddrs(addrs []string) []string {
-	res := make([]string, 0, len(addrs))
-	for _, addr := range addrs {
-		if !idx.targetAddrList[addr] {
-			log.Warnf("the gRPC target address not found: %s", addr)
-		} else {
-			res = append(res, addr)
-		}
-	}
-	return res
 }

--- a/pkg/index/job/save/service/indexer.go
+++ b/pkg/index/job/save/service/indexer.go
@@ -132,6 +132,7 @@ func (idx *index) Start(ctx context.Context) error {
 	return nil
 }
 
+// skipcq: GO-R1005
 func (idx *index) doSaveIndex(ctx context.Context, fn func(_ context.Context, _ agent.AgentClient, _ ...grpc.CallOption) (*payload.Empty, error)) (errs error) {
 	ctx, span := trace.StartSpan(grpc.WrapGRPCMethod(ctx, grpcMethodName), apiName+"/service/index.doSaveIndex")
 	defer func() {

--- a/pkg/index/job/save/service/indexer_test.go
+++ b/pkg/index/job/save/service/indexer_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/net/grpc"
 	"github.com/vdaas/vald/internal/net/grpc/codes"
+	"github.com/vdaas/vald/internal/net/grpc/pool"
 	"github.com/vdaas/vald/internal/net/grpc/status"
 	"github.com/vdaas/vald/internal/test/goleak"
 	clientmock "github.com/vdaas/vald/internal/test/mock/client"
@@ -65,7 +66,6 @@ func Test_index_Start(t *testing.T) {
 				args: args{
 					ctx: context.Background(),
 				},
-
 				fields: fields{
 					client: &clientmock.DiscovererClientMock{
 						GetAddrsFunc: func(_ context.Context) []string {
@@ -93,6 +93,8 @@ func Test_index_Start(t *testing.T) {
 				fields: fields{
 					targetAddrs: []string{
 						"127.0.0.1:8080",
+						"127.0.0.1:8081",
+						"127.0.0.1:8083",
 					},
 					client: &clientmock.DiscovererClientMock{
 						GetAddrsFunc: func(_ context.Context) []string {
@@ -104,6 +106,9 @@ func Test_index_Start(t *testing.T) {
 									_ func(_ context.Context, _ string, _ *grpc.ClientConn, _ ...grpc.CallOption) error,
 								) error {
 									return nil
+								},
+								ConnectFunc: func(_ context.Context, _ string, _ ...grpc.DialOption) (pool.Conn, error) {
+									return nil, nil
 								},
 							}
 						},
@@ -154,7 +159,6 @@ func Test_index_Start(t *testing.T) {
 				args: args{
 					ctx: context.Background(),
 				},
-
 				fields: fields{
 					client: &clientmock.DiscovererClientMock{
 						GetAddrsFunc: func(_ context.Context) []string {

--- a/pkg/index/job/save/service/indexer_test.go
+++ b/pkg/index/job/save/service/indexer_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func Test_index_Start(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		ctx context.Context
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

In the previous implementation, it was possible to set a DNS A record to a job.
However, since only IP was enabled internally, even if a DNS A record was set, it could not be properly connected.
Therefore, I will modify the logic so that when a user specifies a target address (`A record:port` or `ip:port`), it will be preferentially selected.

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Go Version: 1.22.0
- Docker Version: 20.10.8
- Kubernetes Version: v1.29.2
- NGT Version: 2.1.6

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->
