### PR TITLE
Fixed issue with updating vald version information at build time

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -87,7 +87,7 @@ runs:
         PRIMARY_TAG: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
     - name: Update Vald version
       shell: bash
-      run: echo "${PRIMARY_TAG}" >> versions/VALD_VERSION
+      run: echo "${PRIMARY_TAG}" > versions/VALD_VERSION
       env:
         PRIMARY_TAG: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
     - name: Add extra tags


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

When testing with other PR, I noticed a problem with the vald version, so I fixed it
The following is the area where there is a problem.

<img width="227" src="https://github.com/vdaas/vald/assets/25459661/41f87d86-5888-4c88-825e-c9c7f9ecc4a0">


<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Go Version: 1.22.0
- Docker Version: 20.10.8
- Kubernetes Version: v1.29.2
- NGT Version: 2.1.6

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->
