### PR TITLE
Bugfix docker build command for ci-container

### DIFF
--- a/Makefile.d/docker.mk
+++ b/Makefile.d/docker.mk
@@ -172,7 +172,7 @@ docker/name/ci-container:
 docker/build/ci-container:
 	@make DOCKERFILE="$(ROOTDIR)/dockers/ci/base/Dockerfile" \
 		IMAGE=$(CI_CONTAINER_IMAGE) \
-		EXTRA_ARGS="--add-host=registry.npmjs.org:104.16.20.35" \
+		EXTRA_ARGS="--add-host=registry.npmjs.org:104.16.20.35 $(EXTRA_ARGS)" \
 		docker/build/image
 
 .PHONY: docker/name/dev-container


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

The `EXTRA_ARGS` is passed on the CI side, but the passed `EXTRA_ARGS` is disabled because it is internally overwritten.
<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Go Version: 1.22.1
- Docker Version: 20.10.8
- Kubernetes Version: v1.29.2
- NGT Version: 2.1.6

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->
