### PR TITLE
Bugfix recreate benchmark job when operator reboot

### DIFF
--- a/charts/vald-benchmark-operator/crds/valdbenchmarkjob.yaml
+++ b/charts/vald-benchmark-operator/crds/valdbenchmarkjob.yaml
@@ -61,6 +61,7 @@ spec:
                 - Completed
                 - Available
                 - Healthy
+              default: Available
               type: string
             spec:
               type: object

--- a/charts/vald-benchmark-operator/crds/valdbenchmarkscenario.yaml
+++ b/charts/vald-benchmark-operator/crds/valdbenchmarkscenario.yaml
@@ -58,6 +58,7 @@ spec:
                 - Completed
                 - Available
                 - Healthy
+              default: Available
               type: string
             spec:
               type: object

--- a/k8s/tools/benchmark/operator/crds/valdbenchmarkjob.yaml
+++ b/k8s/tools/benchmark/operator/crds/valdbenchmarkjob.yaml
@@ -61,6 +61,7 @@ spec:
                 - Completed
                 - Available
                 - Healthy
+              default: Available
               type: string
             spec:
               type: object

--- a/k8s/tools/benchmark/operator/crds/valdbenchmarkscenario.yaml
+++ b/k8s/tools/benchmark/operator/crds/valdbenchmarkscenario.yaml
@@ -58,6 +58,7 @@ spec:
                 - Completed
                 - Available
                 - Healthy
+              default: Available
               type: string
             spec:
               type: object

--- a/pkg/tools/benchmark/operator/service/operator.go
+++ b/pkg/tools/benchmark/operator/service/operator.go
@@ -282,13 +282,15 @@ func (o *operator) benchJobReconcile(ctx context.Context, benchJobList map[strin
 			} else if oldJob.Status == "" {
 				jobStatus[oldJob.GetName()] = v1.BenchmarkJobAvailable
 			}
-		} else if len(job.Status) == 0 || job.Status == v1.BenchmarkJobNotReady {
-			log.Info("[reconcile benchmark job resource] create job: ", k)
-			err := o.createJob(ctx, job)
-			if err != nil {
-				log.Errorf("[reconcile benchmark job resource] failed to create job: %s", err.Error())
+		} else {
+			if job.Status == "" || job.Status == v1.BenchmarkJobAvailable {
+				log.Info("[reconcile benchmark job resource] create job: ", k)
+				err := o.createJob(ctx, job)
+				if err != nil {
+					log.Errorf("[reconcile benchmark job resource] failed to create job: %s", err.Error())
+				}
+				jobStatus[job.Name] = v1.BenchmarkJobHealthy
 			}
-			jobStatus[job.Name] = v1.BenchmarkJobAvailable
 			cbjl[k] = &job
 		}
 	}
@@ -325,22 +327,26 @@ func (o *operator) benchScenarioReconcile(ctx context.Context, scenarioList map[
 	for name := range scenarioList {
 		sc := scenarioList[name]
 		if oldScenario := cbsl[name]; oldScenario == nil {
-			// apply new crd which is not set yet.
-			jobNames, err := o.createBenchmarkJob(ctx, sc)
-			if err != nil {
-				log.Errorf("[reconcile benchmark scenario resource] failed to create benchmark job resource: %s", err.Error())
-			}
+			// init atomic values for current scenario
 			cbsl[name] = &scenario{
 				Crd: &sc,
-				BenchJobStatus: func() map[string]v1.BenchmarkJobStatus {
+			}
+			scenarioStatus[sc.GetName()] = sc.Status
+			// apply new crd which is not set yet.
+			if sc.Status == "" || sc.Status == v1.BenchmarkScenarioAvailable {
+				jobNames, err := o.createBenchmarkJob(ctx, sc)
+				if err != nil {
+					log.Errorf("[reconcile benchmark scenario resource] failed to create benchmark job resource: %s", err.Error())
+				}
+				cbsl[name].BenchJobStatus = func() map[string]v1.BenchmarkJobStatus {
 					s := map[string]v1.BenchmarkJobStatus{}
 					for _, v := range jobNames {
 						s[v] = v1.BenchmarkJobNotReady
 					}
 					return s
-				}(),
+				}()
+				scenarioStatus[sc.GetName()] = v1.BenchmarkScenarioHealthy
 			}
-			scenarioStatus[sc.GetName()] = v1.BenchmarkScenarioHealthy
 		} else {
 			// apply updated crd which is already applied.
 			if oldScenario.Crd.GetGeneration() < sc.GetGeneration() {
@@ -606,7 +612,7 @@ func (o *operator) checkAtomics() error {
 				return errors.ErrMismatchBenchmarkAtomics(cjl, cbjl, cbsl)
 			}
 		}
-		// check scenario and bench
+		// check scenario resource and bench resource
 		if owners := bj.GetOwnerReferences(); len(owners) > 0 {
 			var scenarioName string
 			for _, o := range owners {

--- a/pkg/tools/benchmark/operator/service/operator_test.go
+++ b/pkg/tools/benchmark/operator/service/operator_test.go
@@ -1084,7 +1084,7 @@ func Test_operator_benchJobReconcile(t *testing.T) {
 									Timestamp:            "",
 								},
 							},
-							Status: v1.BenchmarkJobAvailable,
+							Status: v1.BenchmarkJobHealthy,
 						},
 					},
 				},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->
I have fixed the `benchmark-operator` recreates `BenchmarkJobResource`  following `BenchmarkScenarioResource(VBJR)` even though the applied VBJR status is `Completed` when an operator reboots.

I have changed the default CR status to `Available` and fixed the operator's reconciliation logic to resolve this issue.
The operator will create child resources only if CRD status is `Available`.

```mermaid
stateDiagram-v2
    [*] --> Available: Apply Scenario
    Available --> Healthy: Create Benchmark Job Resource
    Healthy --> Completed: If ALL benchmarkJobResource are completed
    Completed --> [*]
```

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Go Version: 1.22.1
- Docker Version: 20.10.8
- Kubernetes Version: v1.29.2
- NGT Version: 2.2

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->
