### PR TITLE
Fix workflow trigger for backport pr creation

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,7 +21,6 @@ on:
       - "release/v*.*"
       - "!release/v*.*.*"
 env:
-  BASE_BRANCH: "main"
   TARGET_LABEL_NAME_PREFIX: "actions/backport/"
   BACKPORT_BRANCH_NAME_PREFIX: "backport"
   FETCHED_GITHUB_INFO_PATH: github_info.json

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,16 +15,21 @@
 #
 name: "Run backport PR"
 on:
-  pull_request:
-    types:
-      - "closed"
+  push:
+    branches:
+      - main
+      - "release/v*.*"
+      - "!release/v*.*.*"
 env:
+  BASE_BRANCH: "main"
   TARGET_LABEL_NAME_PREFIX: "actions/backport/"
   BACKPORT_BRANCH_NAME_PREFIX: "backport"
+  FETCHED_GITHUB_INFO_PATH: github_info.json
+  GITHUB_USER: ${{ secrets.DISPATCH_USER }}
+  GITHUB_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
 jobs:
   dump-contexts-to-log:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.merged == true }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dump-context
@@ -44,28 +49,34 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           git_user_signingkey: true
           git_commit_gpgsign: true
+      - name: Fetch PR info
+        run: |
+          # gh pr list --limit 10 --json number,title,body,labels,headRefName,headRefOid,mergeCommit --state merged --base ${BASE_BRANCH} | \
+          gh pr list --limit 10 --json number,title,body,labels,headRefName,headRefOid,mergeCommit --state merged | \
+            jq --arg oid "${GITHUB_SHA}" '.[] | select(.mergeCommit.oid == $oid)' > ${FETCHED_GITHUB_INFO_PATH}
+          cat ${FETCHED_GITHUB_INFO_PATH}
+          echo ${GITHUB_SHA}
       - name: Set context
         id: set_context
         run: |
-          LABEL_NAMES=`cat ${GITHUB_EVENT_PATH} | jq -r --arg PREFIX $TARGET_LABEL_NAME_PREFIX '[.pull_request.labels[]? | select(.name | startswith($PREFIX)) | .name] | join(" ")'`
+          LABEL_NAMES=`cat ${FETCHED_GITHUB_INFO_PATH} | jq -r --arg PREFIX $TARGET_LABEL_NAME_PREFIX '[.labels[]? | select(.name | startswith($PREFIX)) | .name] | join(" ")'`
           echo "LABEL_NAMES=${LABEL_NAMES}" >> $GITHUB_OUTPUT # e.g.) actions/backport/v1.7 actions/backport/v1.8
           echo "${LABEL_NAMES}"
       - name: Create PR
         if: ${{ steps.set_context.outputs.LABEL_NAMES != '' }}
         env:
           LABEL_NAMES: ${{ steps.set_context.outputs.LABEL_NAMES }}
-          GITHUB_USER: ${{ secrets.DISPATCH_USER }}
-          GITHUB_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
-          PR_TITLE=`cat $GITHUB_EVENT_PATH | jq -r ".pull_request.title"`
-          PR_BODY=`cat $GITHUB_EVENT_PATH | jq -r ".pull_request.body"`
-          PR_NUM=`cat $GITHUB_EVENT_PATH | jq -r ".pull_request.number"`
+          PR_TITLE=`cat $FETCHED_GITHUB_INFO_PATH | jq -r ".title"`
+          PR_BODY=`cat $FETCHED_GITHUB_INFO_PATH | jq -r ".body"`
+          PR_NUM=`cat $FETCHED_GITHUB_INFO_PATH | jq -r ".number"`
+          PR_BRANCH_NAME=`cat $FETCHED_GITHUB_INFO_PATH | jq -r ".headRefName"`
 
           echo "${PR_NUM} ${PR_TITLE}: ${PR_BODY}"
 
           for LABEL_NAME in ${LABEL_NAMES}; do
               BRANCH_NAME=`echo "${LABEL_NAME}" | sed -e "s:^${TARGET_LABEL_NAME_PREFIX}::"`           # e.g) release/vx.x, main
-              BACKPORT_BRANCH_NAME="${BACKPORT_BRANCH_NAME_PREFIX}/${BRANCH_NAME}/${GITHUB_HEAD_REF}"  # e.g) backport/release/vx.x/{current branch name}
+              BACKPORT_BRANCH_NAME="${BACKPORT_BRANCH_NAME_PREFIX}/${BRANCH_NAME}/${PR_BRANCH_NAME}"   # e.g) backport/release/vx.x/{current branch name}
 
               echo "BRANCH_NAME=${BRANCH_NAME}"
               echo "BACKPORT_BRANCH_NAME=${BACKPORT_BRANCH_NAME}"
@@ -75,7 +86,7 @@ jobs:
               git checkout -b ${BACKPORT_BRANCH_NAME}
 
               # Force cherry-pick. The conflicts will be modified within the backport PR.
-              git cherry-pick $GITHUB_SHA || (git add -A && git cherry-pick --continue --no-edit)
+              git cherry-pick ${GITHUB_SHA} || (git add -A && git cherry-pick --continue --no-edit)
               git push origin ${BACKPORT_BRANCH_NAME}
 
               gh pr create --base ${BRANCH_NAME} \

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -51,7 +51,6 @@ jobs:
           git_commit_gpgsign: true
       - name: Fetch PR info
         run: |
-          # gh pr list --limit 10 --json number,title,body,labels,headRefName,headRefOid,mergeCommit --state merged --base ${BASE_BRANCH} | \
           gh pr list --limit 10 --json number,title,body,labels,headRefName,headRefOid,mergeCommit --state merged | \
             jq --arg oid "${GITHUB_SHA}" '.[] | select(.mergeCommit.oid == $oid)' > ${FETCHED_GITHUB_INFO_PATH}
           cat ${FETCHED_GITHUB_INFO_PATH}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

## WHY
The workflow status for backport PR creation was `Pending`, although we have approved the Forked PR.
It may be due to the approve being removed at the moment the PR is closed, so I fix the workflow trigger.

## WHAT

- Change workflow trigger from `closed` event to `push` event

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Go Version: 1.22.1
- Docker Version: 20.10.8
- Kubernetes Version: v1.29.2
- NGT Version: 2.2

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->