### PR TITLE
Automatically add backport main label for release-pr

### DIFF
--- a/.github/workflows/_release-pr.yml
+++ b/.github/workflows/_release-pr.yml
@@ -111,14 +111,24 @@ jobs:
           git commit -S --signoff -m ":bookmark: :robot: Release ${RELEASE_TAG}"
           git push -u origin ${PREPARE_RELEASE_BRANCH_NAME}
 
-          curl --include --verbose --fail \
+          PR_NUM=$(curl --fail \
             -H "Accept: application/json" \
             -H "Content-Type:application/json" \
             -H "Authorization: token ${GITHUB_TOKEN}" \
             --request POST \
             --data "{\"title\": \":bookmark: :robot: Release ${RELEASE_TAG}\", \"head\": \"${PREPARE_RELEASE_BRANCH_NAME}\", \"base\": \"${RELEASE_BRANCH_NAME}\", \"body\": \"Release PR for ${RELEASE_TAG}.\", \"maintainer_can_modify\": true}" \
-            $API_URL
+            ${API_BASE_URL}/pulls | jq '.number' )
+          echo ${PR_NUM}
+
+          curl --fail \
+            -H "Accept: application/json" \
+            -H "Content-Type:application/json" \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            --request POST \
+            --data "{\"labels\":[\"${BACKPORT_MAIN_LABEL_NAME}\"]}" \
+            ${API_BASE_URL}/issues/${PR_NUM}/labels
         env:
           GITHUB_USER: ${{ secrets.DISPATCH_USER }}
           GITHUB_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
-          API_URL: https://api.github.com/repos/vdaas/vald/pulls
+          BACKPORT_MAIN_LABEL_NAME: "actions/backport/main"
+          API_BASE_URL: https://api.github.com/repos/vdaas/vald

--- a/.github/workflows/_release-pr.yml
+++ b/.github/workflows/_release-pr.yml
@@ -130,5 +130,5 @@ jobs:
         env:
           GITHUB_USER: ${{ secrets.DISPATCH_USER }}
           GITHUB_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
-          BACKPORT_MAIN_LABEL_NAME: "actions/backport/main"
+          BACKPORT_MAIN_LABEL_NAME: actions/backport/main
           API_BASE_URL: https://api.github.com/repos/vdaas/vald


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

The `actions/backport/main` label should be added to the [release PR](https://github.com/vdaas/vald/pull/2360) created by the vdaas-ci bot. 
But since there is a possibility of forgetting to add it, I will fix it to automatically add the `actions/backport/main` label.

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Go Version: 1.22.1
- Docker Version: 20.10.8
- Kubernetes Version: v1.29.2
- NGT Version: 2.2

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->
