### PR TITLE
update large top-K ratio handling logic

### DIFF
--- a/pkg/gateway/lb/handler/grpc/handler.go
+++ b/pkg/gateway/lb/handler/grpc/handler.go
@@ -452,11 +452,8 @@ func (s *server) SearchByID(ctx context.Context, req *payload.Search_IDRequest) 
 // It ensures that the number of results is not less than the minimum required and adjusts based on the provided ratio.
 func (s *server) calculateNum(ctx context.Context, num uint32, ratio float32) (n uint32) {
 	min := float64(s.replica) / float64(len(s.gateway.Addrs(ctx)))
-	if ratio < 0.0 {
+	if ratio <= 0.0 {
 		return uint32(math.Ceil(float64(num) * min))
-	}
-	if ratio == 0.0 {
-		return num
 	}
 	n = uint32(math.Ceil(float64(num) * (min + ((1 - min) * float64(ratio)))))
 	sn := uint32(math.Ceil(float64(num) * min))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Update ratio handling with large top-K.
Merge the logic ratio is 0 and ratio is less than 0. 
<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Go Version: 1.22.3
- Rust Version: 1.77.2
- Docker Version: 20.10.8
- Kubernetes Version: v1.30.0
- NGT Version: 2.2.1

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved calculation logic for numerical values to handle edge cases where the ratio is zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->