### PR TITLE
Change default image tag from latest to nightly

### DIFF
--- a/charts/vald/values/agent-ngt-standalone.yaml
+++ b/charts/vald/values/agent-ngt-standalone.yaml
@@ -16,7 +16,7 @@
 
 defaults:
   image:
-    tag: latest
+    tag: nightly
 agent:
   ngt:
     auto_index_duration_limit: 30m

--- a/charts/vald/values/vald-backup-via-pv-and-s3.yaml
+++ b/charts/vald/values/vald-backup-via-pv-and-s3.yaml
@@ -15,7 +15,7 @@
 #
 defaults:
   image:
-    tag: latest
+    tag: nightly
 
 gateway:
   lb:

--- a/charts/vald/values/vald-backup-via-pv.yaml
+++ b/charts/vald/values/vald-backup-via-pv.yaml
@@ -15,7 +15,7 @@
 #
 defaults:
   image:
-    tag: latest
+    tag: nightly
 gateway:
   lb:
     resources:

--- a/charts/vald/values/vald-backup-via-s3.yaml
+++ b/charts/vald/values/vald-backup-via-s3.yaml
@@ -15,7 +15,7 @@
 #
 defaults:
   image:
-    tag: latest
+    tag: nightly
 
 gateway:
   lb:

--- a/charts/vald/values/vald-in-memory-mode-no-backup.yaml
+++ b/charts/vald/values/vald-in-memory-mode-no-backup.yaml
@@ -15,7 +15,7 @@
 #
 defaults:
   image:
-    tag: latest
+    tag: nightly
 gateway:
   lb:
     resources:

--- a/example/helm/values-standalone-agent-ngt.yaml
+++ b/example/helm/values-standalone-agent-ngt.yaml
@@ -18,7 +18,7 @@ default:
   logging:
     level: debug
   image:
-    tag: latest
+    tag: nightly
 agent:
   minReplicas: 4
   maxReplicas: 8

--- a/example/helm/values-with-pyroscope.yaml
+++ b/example/helm/values-with-pyroscope.yaml
@@ -18,7 +18,7 @@ defaults:
   logging:
     level: debug
   image:
-    tag: latest
+    tag: nightly
   time_zone: Asia/Tokyo
   server_config:
     metrics:

--- a/example/helm/values.yaml
+++ b/example/helm/values.yaml
@@ -18,7 +18,7 @@ defaults:
   logging:
     level: debug
   image:
-    tag: latest
+    tag: nightly
   server_config:
     healths:
       liveness:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

The latest tag is not used and should be changed to use the nightly tag

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Go Version: 1.22.3
- Rust Version: 1.77.2
- Docker Version: 20.10.8
- Kubernetes Version: v1.30.0
- NGT Version: 2.2.1

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
	- Updated the image tag from `latest` to `nightly` across various configuration files for improved stability and performance.
	- Modified auto index duration limits and replica settings in relevant configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->