### PR TITLE
Bugfix that caused an error when argument has 3 or more nil arguments

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -265,22 +265,15 @@ func Join(errs ...error) error {
 	case *joinError:
 		if x != nil && len(x.errs) != 0 {
 			e = x
-		} else {
-			e = &joinError{
-				errs: make([]error, 0, l),
-			}
 		}
 		errs = errs[1:]
 	case interface{ Unwrap() []error }:
 		if x != nil && len(x.Unwrap()) != 0 {
 			e = &joinError{errs: x.Unwrap()}
-		} else {
-			e = &joinError{
-				errs: make([]error, 0, l),
-			}
 		}
 		errs = errs[1:]
-	default:
+	}
+	if e == nil {
 		e = &joinError{
 			errs: make([]error, 0, l),
 		}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -263,10 +263,22 @@ func Join(errs ...error) error {
 	var e *joinError
 	switch x := errs[0].(type) {
 	case *joinError:
-		e = x
+		if x != nil {
+			e = x
+		} else {
+			e = &joinError{
+				errs: make([]error, 0, l),
+			}
+		}
 		errs = errs[1:]
 	case interface{ Unwrap() []error }:
-		e = &joinError{errs: x.Unwrap()}
+		if x != nil && len(x.Unwrap()) != 0 {
+			e = &joinError{errs: x.Unwrap()}
+		} else {
+			e = &joinError{
+				errs: make([]error, 0, l),
+			}
+		}
 		errs = errs[1:]
 	default:
 		e = &joinError{
@@ -277,6 +289,9 @@ func Join(errs ...error) error {
 		if err != nil {
 			e.errs = append(e.errs, err)
 		}
+	}
+	if len(e.errs) == 0 {
+		return nil
 	}
 	return e
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -263,7 +263,7 @@ func Join(errs ...error) error {
 	var e *joinError
 	switch x := errs[0].(type) {
 	case *joinError:
-		if x != nil {
+		if x != nil && len(x.errs) != 0 {
 			e = x
 		} else {
 			e = &joinError{

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1674,11 +1674,37 @@ func TestJoin(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "succeeds to return nil",
+			name: "return nil when all errors are nil",
 			args: args{
 				errs: []error{
 					nil, nil, nil,
 				},
+			},
+		},
+		{
+			name: "returns an aggregated error when all errors are non-nil and different",
+			args: args{
+				errs: []error{
+					New("error1"), New("error2"), New("error3"),
+				},
+			},
+			want: want{
+				err: &joinError{
+					errs: []error{
+						New("error1"), New("error2"), New("error3"),
+					},
+				},
+			},
+		},
+		{
+			name: "returns an error when errors are mixed nil and non-nil",
+			args: args{
+				errs: []error{
+					nil, New("error1"), nil,
+				},
+			},
+			want: want{
+				err: New("error1"),
 			},
 		},
 	}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -18,6 +18,8 @@ import (
 	"math"
 	"reflect"
 	"testing"
+
+	"github.com/vdaas/vald/internal/test/goleak"
 )
 
 func TestErrTimeoutParseFailed(t *testing.T) {
@@ -1649,6 +1651,61 @@ func TestRemoveDuplicates(t *testing.T) {
 	}
 }
 
+func TestJoin(t *testing.T) {
+	type args struct {
+		errs []error
+	}
+	type want struct {
+		err error
+	}
+	type test struct {
+		name       string
+		args       args
+		want       want
+		checkFunc  func(want, error) error
+		beforeFunc func(*testing.T, args)
+		afterFunc  func(*testing.T, args)
+	}
+	defaultCheckFunc := func(w want, err error) error {
+		if !Is(err, w.err) {
+			return Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
+		}
+		return nil
+	}
+	tests := []test{
+		{
+			name: "succeeds to return nil",
+			args: args{
+				errs: []error{
+					nil, nil, nil,
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		test := tc
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
+			if test.beforeFunc != nil {
+				test.beforeFunc(tt, test.args)
+			}
+			if test.afterFunc != nil {
+				defer test.afterFunc(tt, test.args)
+			}
+			checkFunc := test.checkFunc
+			if test.checkFunc == nil {
+				checkFunc = defaultCheckFunc
+			}
+
+			err := Join(test.args.errs...)
+			if err := checkFunc(test.want, err); err != nil {
+				tt.Errorf("error = %v", err)
+			}
+		})
+	}
+}
+
 // NOT IMPLEMENTED BELOW
 //
 // func TestUnwrap(t *testing.T) {
@@ -1729,92 +1786,6 @@ func TestRemoveDuplicates(t *testing.T) {
 // 			}
 //
 // 			err := Unwrap(test.args.err)
-// 			if err := checkFunc(test.want, err); err != nil {
-// 				tt.Errorf("error = %v", err)
-// 			}
-//
-// 		})
-// 	}
-// }
-//
-// func TestJoin(t *testing.T) {
-// 	type args struct {
-// 		errs []error
-// 	}
-// 	type want struct {
-// 		err error
-// 	}
-// 	type test struct {
-// 		name       string
-// 		args       args
-// 		want       want
-// 		checkFunc  func(want, error) error
-// 		beforeFunc func(*testing.T, args)
-// 		afterFunc  func(*testing.T, args)
-// 	}
-// 	defaultCheckFunc := func(w want, err error) error {
-// 		if !Is(err, w.err) {
-// 			return Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
-// 		}
-// 		return nil
-// 	}
-// 	tests := []test{
-// 		// TODO test cases
-// 		/*
-// 		   {
-// 		       name: "test_case_1",
-// 		       args: args {
-// 		           errs:nil,
-// 		       },
-// 		       want: want{},
-// 		       checkFunc: defaultCheckFunc,
-// 		       beforeFunc: func(t *testing.T, args args) {
-// 		           t.Helper()
-// 		       },
-// 		       afterFunc: func(t *testing.T, args args) {
-// 		           t.Helper()
-// 		       },
-// 		   },
-// 		*/
-//
-// 		// TODO test cases
-// 		/*
-// 		   func() test {
-// 		       return test {
-// 		           name: "test_case_2",
-// 		           args: args {
-// 		           errs:nil,
-// 		           },
-// 		           want: want{},
-// 		           checkFunc: defaultCheckFunc,
-// 		           beforeFunc: func(t *testing.T, args args) {
-// 		               t.Helper()
-// 		           },
-// 		           afterFunc: func(t *testing.T, args args) {
-// 		               t.Helper()
-// 		           },
-// 		       }
-// 		   }(),
-// 		*/
-// 	}
-//
-// 	for _, tc := range tests {
-// 		test := tc
-// 		t.Run(test.name, func(tt *testing.T) {
-// 			tt.Parallel()
-// 			defer goleak.VerifyNone(tt, goleak.IgnoreCurrent())
-// 			if test.beforeFunc != nil {
-// 				test.beforeFunc(tt, test.args)
-// 			}
-// 			if test.afterFunc != nil {
-// 				defer test.afterFunc(tt, test.args)
-// 			}
-// 			checkFunc := test.checkFunc
-// 			if test.checkFunc == nil {
-// 				checkFunc = defaultCheckFunc
-// 			}
-//
-// 			err := Join(test.args.errs...)
 // 			if err := checkFunc(test.want, err); err != nil {
 // 				tt.Errorf("error = %v", err)
 // 			}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description

I fixed a problem that the result of Join does not return nil when three or more nil arguments are given.

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Go Version: 1.22.3
- Rust Version: 1.77.2
- Docker Version: 20.10.8
- Kubernetes Version: v1.30.0
- NGT Version: 2.2.1

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to return `nil` for empty or `nil` error lists.

- **Tests**
  - Added tests for enhanced error handling scenarios to ensure reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->