### PR TITLE
Fix info path location

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,7 +23,7 @@ on:
 env:
   TARGET_LABEL_NAME_PREFIX: "actions/backport/"
   BACKPORT_BRANCH_NAME_PREFIX: "backport"
-  FETCHED_GITHUB_INFO_PATH: github_info.json
+  FETCHED_GITHUB_INFO_PATH: /tmp/github_info.json
   GITHUB_USER: ${{ secrets.DISPATCH_USER }}
   GITHUB_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
 jobs:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

The following error occurred in backport PR workflow. So I fixed the fetched GitHub info path.
https://github.com/vdaas/vald/actions/runs/10104382350/job/27943338799

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Go Version: 1.22.5
- Rust Version: 1.77.2
- Docker Version: 20.10.8
- Kubernetes Version: v1.30.3
- NGT Version: 2.2.3

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the environment variable for GitHub Actions to improve access to the GitHub information file, enhancing clarity and reducing potential file retrieval errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->