### PR TITLE
Correct the link to cluster-role-binding.md in mirroring-configuration.md

### DIFF
--- a/docs/user-guides/mirroring-configuration.md
+++ b/docs/user-guides/mirroring-configuration.md
@@ -58,7 +58,7 @@ gateway:
 
 The cluster role configuration is required when you deploy Vald clusters with Vald Mirror Gateway on multiple Namespaces in the Kubernetes cluster.
 
-Please refer to [Cluster Role Configuration](./cluster-role-binding.md) about cluster role settings for Mirror Gateway.
+Please refer to [Cluster Role Configuration](../user-guides/cluster-role-binding.md) about cluster role settings for Mirror Gateway.
 
 ### Custom Resource Configuration
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The link to "Cluster Role Configuration" on the page https://vald.vdaas.org/docs/user-guides/mirroring-configuration/ was returning a 404 error. 
The incorrect link was pointing to https://vald.vdaas.org/docs/user-guides/mirroring-configuration/cluster-role-binding.
I corrected the link path.

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.13

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated a hyperlink in the Vald Mirror Gateway configuration guide to ensure users are directed to the correct resource for cluster role settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->