### PR TITLE
Add option to disable dns resolve

### DIFF
--- a/apis/grpc/v1/payload/payload.pb.go
+++ b/apis/grpc/v1/payload/payload.pb.go
@@ -6960,6 +6960,7 @@ var (
 		(*anypb.Any)(nil),                   // 105: google.protobuf.Any
 	}
 )
+
 var file_v1_payload_payload_proto_depIdxs = []int32{
 	22,  // 0: payload.v1.Search.Request.config:type_name -> payload.v1.Search.Config
 	16,  // 1: payload.v1.Search.MultiRequest.requests:type_name -> payload.v1.Search.Request

--- a/apis/grpc/v1/rpc/errdetails/error_details.pb.go
+++ b/apis/grpc/v1/rpc/errdetails/error_details.pb.go
@@ -1108,6 +1108,7 @@ var (
 		(*durationpb.Duration)(nil),           // 15: google.protobuf.Duration
 	}
 )
+
 var file_v1_rpc_errdetails_error_details_proto_depIdxs = []int32{
 	10, // 0: rpc.v1.ErrorInfo.metadata:type_name -> rpc.v1.ErrorInfo.MetadataEntry
 	15, // 1: rpc.v1.RetryInfo.retry_delay:type_name -> google.protobuf.Duration

--- a/internal/test/mock/grpc/grpc_client_mock.go
+++ b/internal/test/mock/grpc/grpc_client_mock.go
@@ -30,10 +30,11 @@ type GRPCClientMock struct {
 			addr string,
 			conn *grpc.ClientConn,
 			copts ...grpc.CallOption) error) error
-	ConnectFunc        func(ctx context.Context, addr string, dopts ...grpc.DialOption) (pool.Conn, error)
-	DisconnectFunc     func(ctx context.Context, addr string) error
-	IsConnectedFunc    func(ctx context.Context, addr string) bool
-	ConnectedAddrsFunc func() []string
+	ConnectFunc                  func(ctx context.Context, addr string, dopts ...grpc.DialOption) (pool.Conn, error)
+	DisconnectFunc               func(ctx context.Context, addr string) error
+	IsConnectedFunc              func(ctx context.Context, addr string) bool
+	ConnectedAddrsFunc           func() []string
+	SetDisableResolveDNSAddrFunc func(addr string, disabled bool)
 }
 
 // OrderedRangeConcurrent calls the OrderedRangeConcurrentFunc object.
@@ -69,4 +70,9 @@ func (gc *GRPCClientMock) Disconnect(ctx context.Context, addr string) error {
 // IsConnected calls the IsConnectedFunc object.
 func (gc *GRPCClientMock) IsConnected(ctx context.Context, addr string) bool {
 	return gc.IsConnectedFunc(ctx, addr)
+}
+
+// SetDisableResolveDNSAddr calls the SetDisableResolveDNSAddr object.
+func (gc *GRPCClientMock) SetDisableResolveDNSAddr(addr string, disabled bool) {
+	gc.SetDisableResolveDNSAddrFunc(addr, disabled)
 }

--- a/internal/test/mock/grpc_testify_mock.go
+++ b/internal/test/mock/grpc_testify_mock.go
@@ -213,3 +213,5 @@ func (c *ClientInternal) Close(ctx context.Context) error {
 	args := c.Called(ctx)
 	return args.Error(0)
 }
+
+func (c *ClientInternal) SetDisableResolveDNSAddr(addr string, distributed bool) {}

--- a/pkg/gateway/mirror/service/mirror.go
+++ b/pkg/gateway/mirror/service/mirror.go
@@ -319,6 +319,7 @@ func (m *mirr) Connect(ctx context.Context, targets ...*payload.Mirror_Target) e
 		if !m.isSelfMirrorAddr(addr) && !m.isGatewayAddr(addr) {
 			_, ok := m.addrs.Load(addr)
 			if !ok || !m.IsConnected(ctx, addr) {
+				m.gateway.GRPCClient().SetDisableResolveDNSAddr(addr, true)
 				_, err := m.gateway.GRPCClient().Connect(ctx, addr)
 				if err != nil {
 					m.addrs.Delete(addr)

--- a/pkg/gateway/mirror/service/mirror_test.go
+++ b/pkg/gateway/mirror/service/mirror_test.go
@@ -87,6 +87,7 @@ func Test_mirr_Connect(t *testing.T) {
 								ConnectFunc: func(_ context.Context, _ string, _ ...grpc.DialOption) (conn pool.Conn, err error) {
 									return conn, err
 								},
+								SetDisableResolveDNSAddrFunc: func(addr string, disabled bool) {},
 							}
 						},
 					},
@@ -118,6 +119,7 @@ func Test_mirr_Connect(t *testing.T) {
 								ConnectFunc: func(_ context.Context, _ string, _ ...grpc.DialOption) (pool.Conn, error) {
 									return nil, errors.New("missing port in address")
 								},
+								SetDisableResolveDNSAddrFunc: func(addr string, disabled bool) {},
 							}
 						},
 					},
@@ -221,6 +223,7 @@ func Test_mirr_Disconnect(t *testing.T) {
 								DisconnectFunc: func(_ context.Context, _ string) error {
 									return nil
 								},
+								SetDisableResolveDNSAddrFunc: func(addr string, disabled bool) {},
 							}
 						},
 					},
@@ -252,6 +255,7 @@ func Test_mirr_Disconnect(t *testing.T) {
 								DisconnectFunc: func(_ context.Context, _ string) error {
 									return errors.New("missing port in address")
 								},
+								SetDisableResolveDNSAddrFunc: func(addr string, disabled bool) {},
 							}
 						},
 					},
@@ -373,6 +377,7 @@ func Test_mirr_MirrorTargets(t *testing.T) {
 								IsConnectedFunc: func(_ context.Context, addr string) bool {
 									return connected[addr]
 								},
+								SetDisableResolveDNSAddrFunc: func(addr string, disabled bool) {},
 							}
 						},
 					},
@@ -498,6 +503,7 @@ func Test_mirr_connectedOtherMirrorAddrs(t *testing.T) {
 								IsConnectedFunc: func(_ context.Context, addr string) bool {
 									return connected[addr]
 								},
+								SetDisableResolveDNSAddrFunc: func(addr string, disabled bool) {},
 							}
 						},
 					},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

When we verified the mirror gateway to connect to multiple locations, we could not connect when dns resolve was enabled. Therefore, I added an interface to disable it.

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.13
- Go Version: v1.23.1
- Rust Version: v1.81.0
- Docker Version: v27.2.1
- Kubernetes Version: v1.31.0
- Helm Version: v3.16.0
- NGT Version: v2.2.4
- Faiss Version: v1.8.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share to reviewers related this PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to disable DNS resolution for specific addresses, enhancing connection management flexibility.
	- Improved error handling and fallback mechanisms in the gateway service for more reliable gRPC operations.
	- Adjusted connection logic to bypass DNS resolution for certain addresses, potentially improving performance.
	- Added functionality in mock tests to control DNS resolution behavior for more precise testing scenarios.

- **Bug Fixes**
	- Enhanced robustness of the gRPC call handling, allowing for alternative connections in case of failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->