### PR TITLE
Fix gRPC error handling for gateway/filter handler

### DIFF
--- a/pkg/gateway/filter/handler/grpc/handler.go
+++ b/pkg/gateway/filter/handler/grpc/handler.go
@@ -1448,10 +1448,13 @@ func (s *server) Search(
 	}
 	res, err = s.gateway.Search(ctx, req, s.copts...)
 	if err != nil {
-		st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.SearchRPCName+" gRPC error response")
+		st, ok := status.FromError(err)
+		if !ok || st == nil {
+			st = status.New(codes.Internal, "failed to convert "+vald.SearchRPCName+" gRPC error response")
+		}
 		if span != nil {
 			span.RecordError(err)
-			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+			span.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 			span.SetStatus(trace.StatusError, err.Error())
 		}
 		return nil, err
@@ -1531,10 +1534,13 @@ func (s *server) SearchByID(
 	}()
 	res, err = s.gateway.SearchByID(ctx, req, s.copts...)
 	if err != nil {
-		st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.SearchByIDRPCName+" gRPC error response")
+		st, ok := status.FromError(err)
+		if !ok || st == nil {
+			st = status.New(codes.Internal, "failed to convert "+vald.SearchByIDRPCName+" gRPC error response")
+		}
 		if span != nil {
 			span.RecordError(err)
-			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+			span.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 			span.SetStatus(trace.StatusError, err.Error())
 		}
 		return nil, err
@@ -2196,11 +2202,13 @@ func (s *server) StreamLinearSearchByID(
 			}, nil
 		})
 	if err != nil {
-		st, msg, err := status.ParseError(err, codes.Internal,
-			"failed to parse "+vald.StreamLinearSearchRPCName+" gRPC error response")
+		st, ok := status.FromError(err)
+		if !ok || st == nil {
+			st = status.New(codes.Internal, "failed to convert "+vald.StreamLinearSearchRPCName+" gRPC error response")
+		}
 		if span != nil {
 			span.RecordError(err)
-			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+			span.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 			span.SetStatus(trace.StatusError, err.Error())
 		}
 		log.Error(err)
@@ -3056,10 +3064,13 @@ func (s *server) StreamUpsert(stream vald.Upsert_StreamUpsertServer) (err error)
 			}, nil
 		})
 	if err != nil {
-		st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.StreamUpsertRPCName+" gRPC error response")
+		st, ok := status.FromError(err)
+		if !ok || st == nil {
+			st = status.New(codes.Internal, "failed to parse "+vald.StreamUpsertRPCName+" gRPC error response")
+		}
 		if span != nil {
 			span.RecordError(err)
-			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+			span.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 			span.SetStatus(trace.StatusError, err.Error())
 		}
 		log.Error(err)
@@ -3223,10 +3234,13 @@ func (s *server) StreamRemove(stream vald.Remove_StreamRemoveServer) (err error)
 			}, nil
 		})
 	if err != nil {
-		st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.StreamRemoveRPCName+" gRPC error response")
+		st, ok := status.FromError(err)
+		if !ok || st == nil {
+			st = status.New(codes.Internal, "failed to parse "+vald.StreamRemoveRPCName+" gRPC error response")
+		}
 		if span != nil {
 			span.RecordError(err)
-			span.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+			span.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 			span.SetStatus(trace.StatusError, err.Error())
 		}
 		log.Error(err)

--- a/pkg/gateway/filter/handler/grpc/handler.go
+++ b/pkg/gateway/filter/handler/grpc/handler.go
@@ -236,11 +236,8 @@ func (s *server) MultiSearchObject(
 			}()
 			r, err := s.SearchObject(ctx, query)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.SearchObjectRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -285,11 +282,8 @@ func (s *server) StreamSearchObject(stream vald.Filter_StreamSearchObjectServer)
 
 			res, err := s.SearchObject(ctx, req)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.SearchObjectRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -470,11 +464,8 @@ func (s *server) MultiLinearSearchObject(
 
 			r, err := s.LinearSearchObject(ctx, query)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.LinearSearchObjectRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -523,11 +514,8 @@ func (s *server) StreamLinearSearchObject(stream vald.Filter_StreamSearchObjectS
 
 			res, err := s.LinearSearchObject(ctx, req)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.LinearSearchObjectRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -708,11 +696,8 @@ func (s *server) StreamInsertObject(stream vald.Filter_StreamInsertObjectServer)
 
 			loc, err := s.InsertObject(ctx, req)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.InsertObjectRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -770,11 +755,8 @@ func (s *server) MultiInsertObject(
 
 			loc, err := s.InsertObject(ctx, query)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.InsertObjectRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -954,11 +936,8 @@ func (s *server) StreamUpdateObject(stream vald.Filter_StreamUpdateObjectServer)
 			}()
 			loc, err := s.UpdateObject(ctx, req)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.UpdateObjectRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -1015,11 +994,8 @@ func (s *server) MultiUpdateObject(
 			}()
 			loc, err := s.UpdateObject(ctx, query)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.UpdateObjectRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -1207,11 +1183,8 @@ func (s *server) StreamUpsertObject(stream vald.Filter_StreamUpsertObjectServer)
 
 			loc, err := s.UpsertObject(ctx, req)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.UpsertObjectRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -1268,11 +1241,8 @@ func (s *server) MultiUpsertObject(
 			}()
 			loc, err := s.UpsertObject(ctx, query)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.UpsertObjectRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -1381,11 +1351,8 @@ func (s *server) Search(
 	}
 	res, err = s.gateway.Search(ctx, req, s.copts...)
 	if err != nil {
-		st, ok := status.FromError(err)
-		if !ok || st == nil {
-			st = status.New(codes.Internal, "failed to convert "+vald.SearchRPCName+" gRPC error response")
-		}
-		if span != nil {
+		st, _ := status.FromError(err)
+		if st != nil && span != nil {
 			span.RecordError(err)
 			span.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 			span.SetStatus(trace.StatusError, err.Error())
@@ -1467,11 +1434,8 @@ func (s *server) SearchByID(
 	}()
 	res, err = s.gateway.SearchByID(ctx, req, s.copts...)
 	if err != nil {
-		st, ok := status.FromError(err)
-		if !ok || st == nil {
-			st = status.New(codes.Internal, "failed to convert "+vald.SearchByIDRPCName+" gRPC error response")
-		}
-		if span != nil {
+		st, _ := status.FromError(err)
+		if st != nil && span != nil {
 			span.RecordError(err)
 			span.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 			span.SetStatus(trace.StatusError, err.Error())
@@ -1559,11 +1523,8 @@ func (s *server) StreamSearch(stream vald.Search_StreamSearchServer) (err error)
 			}()
 			res, err := s.Search(ctx, req)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.SearchRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -1609,11 +1570,8 @@ func (s *server) StreamSearchByID(stream vald.Search_StreamSearchByIDServer) (er
 			}()
 			res, err := s.SearchByID(ctx, req)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.SearchByIDRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -1669,11 +1627,8 @@ func (s *server) MultiSearch(
 			}()
 			r, err := s.Search(ctx, query)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.SearchRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -1727,11 +1682,8 @@ func (s *server) MultiSearchByID(
 			}()
 			r, err := s.SearchByID(ctx, query)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.SearchByIDRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -1990,11 +1942,8 @@ func (s *server) StreamLinearSearch(stream vald.Search_StreamLinearSearchServer)
 			}()
 			res, err := s.LinearSearch(ctx, req)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.LinearSearchRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -2045,11 +1994,8 @@ func (s *server) StreamLinearSearchByID(
 			}()
 			res, err := s.LinearSearchByID(ctx, req)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.LinearSearchByIDRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -2067,11 +2013,8 @@ func (s *server) StreamLinearSearchByID(
 			}, nil
 		})
 	if err != nil {
-		st, ok := status.FromError(err)
-		if !ok || st == nil {
-			st = status.New(codes.Internal, "failed to convert "+vald.StreamLinearSearchRPCName+" gRPC error response")
-		}
-		if span != nil {
+		st, _ := status.FromError(err)
+		if st != nil && span != nil {
 			span.RecordError(err)
 			span.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 			span.SetStatus(trace.StatusError, err.Error())
@@ -2109,11 +2052,8 @@ func (s *server) MultiLinearSearch(
 			}()
 			r, err := s.LinearSearch(ctx, query)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.LinearSearchRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -2167,11 +2107,8 @@ func (s *server) MultiLinearSearchByID(
 			}()
 			r, err := s.LinearSearchByID(ctx, query)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.LinearSearchByIDRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -2357,11 +2294,8 @@ func (s *server) StreamInsert(stream vald.Insert_StreamInsertServer) (err error)
 			}()
 			res, err := s.Insert(ctx, req)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.InsertRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -2417,11 +2351,8 @@ func (s *server) MultiInsert(
 			}()
 			r, err := s.Insert(ctx, query)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.InsertRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -2601,11 +2532,8 @@ func (s *server) StreamUpdate(stream vald.Update_StreamUpdateServer) (err error)
 			}()
 			res, err := s.Update(ctx, req)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.UpdateRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -2655,11 +2583,8 @@ func (s *server) MultiUpdate(
 			}()
 			r, err := s.Update(ctx, query)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.UpdateRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -2840,11 +2765,8 @@ func (s *server) StreamUpsert(stream vald.Upsert_StreamUpsertServer) (err error)
 			}()
 			res, err := s.Upsert(ctx, req)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.UpsertRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -2862,11 +2784,8 @@ func (s *server) StreamUpsert(stream vald.Upsert_StreamUpsertServer) (err error)
 			}, nil
 		})
 	if err != nil {
-		st, ok := status.FromError(err)
-		if !ok || st == nil {
-			st = status.New(codes.Internal, "failed to parse "+vald.StreamUpsertRPCName+" gRPC error response")
-		}
-		if span != nil {
+		st, _ := status.FromError(err)
+		if st != nil && span != nil {
 			span.RecordError(err)
 			span.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 			span.SetStatus(trace.StatusError, err.Error())
@@ -2905,11 +2824,8 @@ func (s *server) MultiUpsert(
 
 			r, err := s.Upsert(ctx, query)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.UpsertRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -2998,11 +2914,8 @@ func (s *server) StreamRemove(stream vald.Remove_StreamRemoveServer) (err error)
 			}()
 			res, err := s.Remove(ctx, req)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.RemoveRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -3020,11 +2933,8 @@ func (s *server) StreamRemove(stream vald.Remove_StreamRemoveServer) (err error)
 			}, nil
 		})
 	if err != nil {
-		st, ok := status.FromError(err)
-		if !ok || st == nil {
-			st = status.New(codes.Internal, "failed to parse "+vald.StreamRemoveRPCName+" gRPC error response")
-		}
-		if span != nil {
+		st, _ := status.FromError(err)
+		if st != nil && span != nil {
 			span.RecordError(err)
 			span.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 			span.SetStatus(trace.StatusError, err.Error())
@@ -3062,11 +2972,8 @@ func (s *server) MultiRemove(
 			}()
 			r, err := s.Remove(ctx, query)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.RemoveRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
@@ -3253,11 +3160,8 @@ func (s *server) StreamGetObject(stream vald.Object_StreamGetObjectServer) (err 
 			}()
 			res, err := s.GetObject(ctx, req)
 			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok || st == nil {
-					st = status.New(codes.Internal, "failed to convert "+vald.GetObjectRPCName+" gRPC error response")
-				}
-				if sspan != nil {
+				st, _ := status.FromError(err)
+				if st != nil && sspan != nil {
 					sspan.RecordError(err)
 					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())

--- a/pkg/gateway/filter/handler/grpc/handler.go
+++ b/pkg/gateway/filter/handler/grpc/handler.go
@@ -236,27 +236,13 @@ func (s *server) MultiSearchObject(
 			}()
 			r, err := s.SearchObject(ctx, query)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.NotFound,
-					vald.MultiSearchObjectRPCName+" API object "+string(query.GetObject())+"'s search request result not found",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetConfig().GetRequestId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.BadRequest{
-						FieldViolations: []*errdetails.BadRequestFieldViolation{
-							{
-								Field:       "vectorizer targets",
-								Description: err.Error(),
-							},
-						},
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.SearchObjectRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get())
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.SearchObjectRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				mu.Lock()
@@ -299,19 +285,13 @@ func (s *server) StreamSearchObject(stream vald.Filter_StreamSearchObjectServer)
 
 			res, err := s.SearchObject(ctx, req)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.SearchObjectRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetConfig().GetRequestId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.SearchObjectRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.SearchObjectRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				return &payload.Search_StreamResponse{
@@ -490,19 +470,13 @@ func (s *server) MultiLinearSearchObject(
 
 			r, err := s.LinearSearchObject(ctx, query)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.NotFound,
-					vald.MultiLinearSearchObjectRPCName+" API object "+string(query.GetObject())+"'s search request result not found",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetConfig().GetRequestId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.LinearSearchObjectRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get())
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.LinearSearchObjectRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 
@@ -549,19 +523,13 @@ func (s *server) StreamLinearSearchObject(stream vald.Filter_StreamSearchObjectS
 
 			res, err := s.LinearSearchObject(ctx, req)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.LinearSearchObjectRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetConfig().GetRequestId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.LinearSearchObjectRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.LinearSearchObjectRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				return &payload.Search_StreamResponse{
@@ -740,19 +708,13 @@ func (s *server) StreamInsertObject(stream vald.Filter_StreamInsertObjectServer)
 
 			loc, err := s.InsertObject(ctx, req)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.InsertObjectRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetObject().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertObjectRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.InsertObjectRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				return &payload.Object_StreamLocation{
@@ -808,18 +770,13 @@ func (s *server) MultiInsertObject(
 
 			loc, err := s.InsertObject(ctx, query)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.InsertObjectRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetObject().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertObjectRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get())
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.InsertObjectRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 
@@ -997,19 +954,13 @@ func (s *server) StreamUpdateObject(stream vald.Filter_StreamUpdateObjectServer)
 			}()
 			loc, err := s.UpdateObject(ctx, req)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.UpdateObjectRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetObject().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateObjectRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.UpdateObjectRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				return &payload.Object_StreamLocation{
@@ -1064,19 +1015,13 @@ func (s *server) MultiUpdateObject(
 			}()
 			loc, err := s.UpdateObject(ctx, query)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.NotFound, "failed to parse "+vald.UpdateObjectRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetObject().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateObjectRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.UpdateObjectRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				log.Warn(err)
@@ -1262,19 +1207,13 @@ func (s *server) StreamUpsertObject(stream vald.Filter_StreamUpsertObjectServer)
 
 			loc, err := s.UpsertObject(ctx, req)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.UpsertObjectRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetObject().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpsertObjectRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.UpsertObjectRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				return &payload.Object_StreamLocation{
@@ -1329,19 +1268,13 @@ func (s *server) MultiUpsertObject(
 			}()
 			loc, err := s.UpsertObject(ctx, query)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.UpsertObjectRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetObject().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpsertObjectRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.UpsertObjectRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				mu.Lock()
@@ -1626,19 +1559,13 @@ func (s *server) StreamSearch(stream vald.Search_StreamSearchServer) (err error)
 			}()
 			res, err := s.Search(ctx, req)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.StreamSearchRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetConfig().GetRequestId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.SearchRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.SearchRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				return &payload.Search_StreamResponse{
@@ -1682,27 +1609,13 @@ func (s *server) StreamSearchByID(stream vald.Search_StreamSearchByIDServer) (er
 			}()
 			res, err := s.SearchByID(ctx, req)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.SearchByIDRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetConfig().GetRequestId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.BadRequest{
-						FieldViolations: []*errdetails.BadRequestFieldViolation{
-							{
-								Field:       "vectorizer targets",
-								Description: err.Error(),
-							},
-						},
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.SearchByIDRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.SearchByIDRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				return &payload.Search_StreamResponse{
@@ -1756,27 +1669,13 @@ func (s *server) MultiSearch(
 			}()
 			r, err := s.Search(ctx, query)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.NotFound, "failed to parse "+vald.SearchRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetConfig().GetRequestId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.BadRequest{
-						FieldViolations: []*errdetails.BadRequestFieldViolation{
-							{
-								Field:       "vectorizer targets",
-								Description: err.Error(),
-							},
-						},
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.SearchRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.SearchRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				mu.Lock()
@@ -1828,27 +1727,13 @@ func (s *server) MultiSearchByID(
 			}()
 			r, err := s.SearchByID(ctx, query)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.NotFound, "failed to parse "+vald.SearchByIDRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetConfig().GetRequestId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.BadRequest{
-						FieldViolations: []*errdetails.BadRequestFieldViolation{
-							{
-								Field:       "vectorizer targets",
-								Description: err.Error(),
-							},
-						},
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.SearchByIDRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.SearchByIDRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				mu.Lock()
@@ -2105,27 +1990,13 @@ func (s *server) StreamLinearSearch(stream vald.Search_StreamLinearSearchServer)
 			}()
 			res, err := s.LinearSearch(ctx, req)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.LinearSearchRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetConfig().GetRequestId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.BadRequest{
-						FieldViolations: []*errdetails.BadRequestFieldViolation{
-							{
-								Field:       "vectorizer targets",
-								Description: err.Error(),
-							},
-						},
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.LinearSearchRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.LinearSearchRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				return &payload.Search_StreamResponse{
@@ -2174,19 +2045,13 @@ func (s *server) StreamLinearSearchByID(
 			}()
 			res, err := s.LinearSearchByID(ctx, req)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.LinearSearchByIDRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetConfig().GetRequestId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.LinearSearchByIDRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.LinearSearchByIDRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				return &payload.Search_StreamResponse{
@@ -2244,19 +2109,13 @@ func (s *server) MultiLinearSearch(
 			}()
 			r, err := s.LinearSearch(ctx, query)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.LinearSearchByIDRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetConfig().GetRequestId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.LinearSearchRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.LinearSearchRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				mu.Lock()
@@ -2308,19 +2167,13 @@ func (s *server) MultiLinearSearchByID(
 			}()
 			r, err := s.LinearSearchByID(ctx, query)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.LinearSearchByIDRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetConfig().GetRequestId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.LinearSearchByIDRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.LinearSearchByIDRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				mu.Lock()
@@ -2504,28 +2357,13 @@ func (s *server) StreamInsert(stream vald.Insert_StreamInsertServer) (err error)
 			}()
 			res, err := s.Insert(ctx, req)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.InsertRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetVector().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.BadRequest{
-						FieldViolations: []*errdetails.BadRequestFieldViolation{
-							{
-								Field:       "vectorizer targets",
-								Description: err.Error(),
-							},
-						},
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertObjectRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
-
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.InsertRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				return &payload.Object_StreamLocation{
@@ -2579,27 +2417,13 @@ func (s *server) MultiInsert(
 			}()
 			r, err := s.Insert(ctx, query)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.InsertRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetVector().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.BadRequest{
-						FieldViolations: []*errdetails.BadRequestFieldViolation{
-							{
-								Field:       "vectorizer targets",
-								Description: err.Error(),
-							},
-						},
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.InsertRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.InsertRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				mu.Lock()
@@ -2777,19 +2601,13 @@ func (s *server) StreamUpdate(stream vald.Update_StreamUpdateServer) (err error)
 			}()
 			res, err := s.Update(ctx, req)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.UpdateRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetVector().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.UpdateRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				return &payload.Object_StreamLocation{
@@ -2837,27 +2655,13 @@ func (s *server) MultiUpdate(
 			}()
 			r, err := s.Update(ctx, query)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.UpdateRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetVector().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.BadRequest{
-						FieldViolations: []*errdetails.BadRequestFieldViolation{
-							{
-								Field:       "vectorizer targets",
-								Description: err.Error(),
-							},
-						},
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpdateRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.UpdateRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				mu.Lock()
@@ -3036,19 +2840,13 @@ func (s *server) StreamUpsert(stream vald.Upsert_StreamUpsertServer) (err error)
 			}()
 			res, err := s.Upsert(ctx, req)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.UpsertRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetVector().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpsertRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.UpsertRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				return &payload.Object_StreamLocation{
@@ -3107,19 +2905,13 @@ func (s *server) MultiUpsert(
 
 			r, err := s.Upsert(ctx, query)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.UpsertRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetVector().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.UpsertRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.UpsertRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				mu.Lock()
@@ -3206,19 +2998,13 @@ func (s *server) StreamRemove(stream vald.Remove_StreamRemoveServer) (err error)
 			}()
 			res, err := s.Remove(ctx, req)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.RemoveRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetId().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.RemoveRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				return &payload.Object_StreamLocation{
@@ -3276,19 +3062,13 @@ func (s *server) MultiRemove(
 			}()
 			r, err := s.Remove(ctx, query)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.NotFound,
-					fmt.Sprintf(vald.MultiRemoveRPCName+" API ID = %v not found", query.GetId().GetId()),
-					&errdetails.RequestInfo{
-						RequestId:   query.GetId().GetId(),
-						ServingData: errdetails.Serialize(reqs),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.RemoveRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get())
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.RemoveRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 
@@ -3473,19 +3253,13 @@ func (s *server) StreamGetObject(stream vald.Object_StreamGetObjectServer) (err 
 			}()
 			res, err := s.GetObject(ctx, req)
 			if err != nil {
-				st, msg, err := status.ParseError(err, codes.Internal, "failed to parse "+vald.GetObjectRPCName+" gRPC error response",
-					&errdetails.RequestInfo{
-						RequestId:   req.GetId().GetId(),
-						ServingData: errdetails.Serialize(req),
-					},
-					&errdetails.ResourceInfo{
-						ResourceType: errdetails.ValdGRPCResourceTypePrefix + "/vald.v1." + vald.GetObjectRPCName,
-						ResourceName: fmt.Sprintf("%s: %s(%s)", apiName, s.name, s.ip),
-					}, info.Get(),
-				)
+				st, ok := status.FromError(err)
+				if !ok || st == nil {
+					st = status.New(codes.Internal, "failed to convert "+vald.GetObjectRPCName+" gRPC error response")
+				}
 				if sspan != nil {
 					sspan.RecordError(err)
-					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), msg)...)
+					sspan.SetAttributes(trace.FromGRPCStatus(st.Code(), st.Message())...)
 					sspan.SetStatus(trace.StatusError, err.Error())
 				}
 				return &payload.Object_StreamVector{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

use FromError instead of ParseError

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.13
- Go Version: v1.23.2
- Rust Version: v1.81.0
- Docker Version: v27.3.1
- Kubernetes Version: v1.31.1
- Helm Version: v3.16.1
- NGT Version: v2.2.4
- Faiss Version: v1.8.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [X] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [X] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling across several gRPC methods for more robust reporting.
	- Enhanced consistency in error responses, aiding in traceability.

- **Improvements**
	- Adjusted logging for better context during error occurrences, facilitating easier debugging.
	- Streamlined error handling logic by removing redundant variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->