### PR TITLE
Backport PR #2718 to release/v1.7 for Fix bind DOCKER_OPTS option

### DIFF
--- a/Makefile.d/docker.mk
+++ b/Makefile.d/docker.mk
@@ -304,7 +304,7 @@ docker/name/loadtest:
 ## build loadtest image
 docker/build/loadtest:
 	@make DOCKERFILE="$(ROOTDIR)/dockers/tools/cli/loadtest/Dockerfile" \
-		DOCKER_OPTS="--build-arg ZLIB_VERSION=$(ZLIB_VERSION) --build-arg HDF5_VERSION=$(HDF5_VERSION)" \
+		DOCKER_OPTS="$${DOCKER_OPTS:+$${DOCKER_OPTS}} --build-arg ZLIB_VERSION=$(ZLIB_VERSION) --build-arg HDF4_VERSION=$(HDF5_VERSION)" \
 		IMAGE=$(LOADTEST_IMAGE) \
 		docker/build/image
 
@@ -372,7 +372,7 @@ docker/name/benchmark-job:
 docker/build/benchmark-job:
 	@make DOCKERFILE="$(ROOTDIR)/dockers/tools/benchmark/job/Dockerfile" \
 		IMAGE=$(BENCHMARK_JOB_IMAGE) \
-		DOCKER_OPTS="--build-arg ZLIB_VERSION=$(ZLIB_VERSION) --build-arg HDF5_VERSION=$(HDF5_VERSION)" \
+		DOCKER_OPTS="$${DOCKER_OPTS:+$${DOCKER_OPTS}} --build-arg ZLIB_VERSION=$(ZLIB_VERSION) --build-arg HDF4_VERSION=$(HDF5_VERSION)" \
 		docker/build/image
 
 .PHONY: docker/name/benchmark-operator
@@ -395,5 +395,5 @@ docker/name/example-client:
 docker/build/example-client:
 	@make DOCKERFILE="$(ROOTDIR)/dockers/example/client/Dockerfile" \
 		IMAGE=$(EXAMPLE_CLIENT_IMAGE) \
-		DOCKER_OPTS="--build-arg ZLIB_VERSION=$(ZLIB_VERSION) --build-arg HDF5_VERSION=$(HDF5_VERSION)" \
+		DOCKER_OPTS="$${DOCKER_OPTS:+$${DOCKER_OPTS}} --build-arg ZLIB_VERSION=$(ZLIB_VERSION) --build-arg HDF4_VERSION=$(HDF5_VERSION)" \
 		docker/build/image

--- a/Makefile.d/docker.mk
+++ b/Makefile.d/docker.mk
@@ -304,7 +304,7 @@ docker/name/loadtest:
 ## build loadtest image
 docker/build/loadtest:
 	@make DOCKERFILE="$(ROOTDIR)/dockers/tools/cli/loadtest/Dockerfile" \
-		DOCKER_OPTS="$${DOCKER_OPTS:+$${DOCKER_OPTS}} --build-arg ZLIB_VERSION=$(ZLIB_VERSION) --build-arg HDF4_VERSION=$(HDF5_VERSION)" \
+		DOCKER_OPTS="$${DOCKER_OPTS:+$${DOCKER_OPTS}} --build-arg ZLIB_VERSION=$(ZLIB_VERSION) --build-arg HDF5_VERSION=$(HDF5_VERSION)" \
 		IMAGE=$(LOADTEST_IMAGE) \
 		docker/build/image
 
@@ -372,7 +372,7 @@ docker/name/benchmark-job:
 docker/build/benchmark-job:
 	@make DOCKERFILE="$(ROOTDIR)/dockers/tools/benchmark/job/Dockerfile" \
 		IMAGE=$(BENCHMARK_JOB_IMAGE) \
-		DOCKER_OPTS="$${DOCKER_OPTS:+$${DOCKER_OPTS}} --build-arg ZLIB_VERSION=$(ZLIB_VERSION) --build-arg HDF4_VERSION=$(HDF5_VERSION)" \
+		DOCKER_OPTS="$${DOCKER_OPTS:+$${DOCKER_OPTS}} --build-arg ZLIB_VERSION=$(ZLIB_VERSION) --build-arg HDF5_VERSION=$(HDF5_VERSION)" \
 		docker/build/image
 
 .PHONY: docker/name/benchmark-operator
@@ -395,5 +395,5 @@ docker/name/example-client:
 docker/build/example-client:
 	@make DOCKERFILE="$(ROOTDIR)/dockers/example/client/Dockerfile" \
 		IMAGE=$(EXAMPLE_CLIENT_IMAGE) \
-		DOCKER_OPTS="$${DOCKER_OPTS:+$${DOCKER_OPTS}} --build-arg ZLIB_VERSION=$(ZLIB_VERSION) --build-arg HDF4_VERSION=$(HDF5_VERSION)" \
+		DOCKER_OPTS="$${DOCKER_OPTS:+$${DOCKER_OPTS}} --build-arg ZLIB_VERSION=$(ZLIB_VERSION) --build-arg HDF5_VERSION=$(HDF5_VERSION)" \
 		docker/build/image


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->
SSIA

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.13
- Go Version: v1.23.2
- Rust Version: v1.81.0
- Docker Version: v27.3.1
- Kubernetes Version: v1.31.1
- Helm Version: v3.16.2
- NGT Version: v2.2.4
- Faiss Version: v1.9.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in Docker build options by allowing additional arguments to be appended without overwriting existing settings.
	- Updated build arguments for specific targets to include `HDF4_VERSION`.

- **Bug Fixes**
	- Corrected the versioning reference from `HDF5_VERSION` to `HDF4_VERSION` in relevant build targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->