### PR TITLE
Fix docker build error (benchmark-job, loadtest)

### DIFF
--- a/Makefile.d/tools.mk
+++ b/Makefile.d/tools.mk
@@ -259,7 +259,8 @@ $(LIB_PATH)/libhdf5.a: $(LIB_PATH) \
 	&& make -j$(CORES) \
 	&& make install \
 	&& cd $(ROOTDIR) \
-	&& rm -rf $(TEMP_DIR)/hdf5.tar.gz $(TEMP_DIR)/hdf5
+	&& rm -rf $(TEMP_DIR)/hdf5.tar.gz $(TEMP_DIR)/hdf5 \
+	&& ldconfig
 
 .PHONY: yq/install
 ## install yq

--- a/dockers/ci/base/Dockerfile
+++ b/dockers/ci/base/Dockerfile
@@ -88,7 +88,6 @@ RUN --mount=type=bind,target=.,rw \
     graphviz \
     jq \
     libaec-dev \
-    libhdf5-dev \
     sed \
     zip \
     && ldconfig \

--- a/dockers/dev/Dockerfile
+++ b/dockers/dev/Dockerfile
@@ -88,7 +88,6 @@ RUN --mount=type=bind,target=.,rw \
     graphviz \
     jq \
     libaec-dev \
-    libhdf5-dev \
     sed \
     zip \
     && ldconfig \

--- a/dockers/example/client/Dockerfile
+++ b/dockers/example/client/Dockerfile
@@ -71,7 +71,6 @@ RUN --mount=type=bind,target=.,rw \
     gcc \
     libssl-dev \
     unzip \
-    libhdf5-dev \
     libaec-dev \
     && ldconfig \
     && echo "${LANG} UTF-8" > /etc/locale.gen \

--- a/dockers/tools/benchmark/job/Dockerfile
+++ b/dockers/tools/benchmark/job/Dockerfile
@@ -71,7 +71,6 @@ RUN --mount=type=bind,target=.,rw \
     gcc \
     libssl-dev \
     unzip \
-    libhdf5-dev \
     libaec-dev \
     && ldconfig \
     && echo "${LANG} UTF-8" > /etc/locale.gen \

--- a/dockers/tools/cli/loadtest/Dockerfile
+++ b/dockers/tools/cli/loadtest/Dockerfile
@@ -71,7 +71,6 @@ RUN --mount=type=bind,target=.,rw \
     gcc \
     libssl-dev \
     unzip \
-    libhdf5-dev \
     libaec-dev \
     && ldconfig \
     && echo "${LANG} UTF-8" > /etc/locale.gen \

--- a/hack/docker/gen/main.go
+++ b/hack/docker/gen/main.go
@@ -483,7 +483,6 @@ var (
 		"graphviz",
 		"jq",
 		"libaec-dev",
-		"libhdf5-dev",
 		"sed",
 		"zip",
 	}

--- a/hack/docker/gen/main.go
+++ b/hack/docker/gen/main.go
@@ -746,7 +746,7 @@ func main() {
 		"vald-benchmark-job": {
 			AppName:       "job",
 			PackageDir:    "tools/benchmark/job",
-			ExtraPackages: append(clangBuildDeps, "libhdf5-dev", "libaec-dev"),
+			ExtraPackages: append(clangBuildDeps, "libaec-dev"),
 			Preprocess: []string{
 				"make hdf5/install",
 			},
@@ -797,7 +797,7 @@ func main() {
 		"vald-loadtest": {
 			AppName:       "loadtest",
 			PackageDir:    "tools/cli/loadtest",
-			ExtraPackages: append(clangBuildDeps, "libhdf5-dev", "libaec-dev"),
+			ExtraPackages: append(clangBuildDeps, "libaec-dev"),
 			Preprocess: []string{
 				"make hdf5/install",
 			},
@@ -836,7 +836,7 @@ func main() {
 		"vald-example-client": {
 			AppName:       "client",
 			PackageDir:    "example/client",
-			ExtraPackages: append(clangBuildDeps, "libhdf5-dev", "libaec-dev"),
+			ExtraPackages: append(clangBuildDeps, "libaec-dev"),
 			Preprocess: []string{
 				"make hdf5/install",
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->
SSIA

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.16
- Go Version: v1.23.5
- Rust Version: v1.83.0
- Docker Version: v27.4.0
- Kubernetes Version: v1.32.0
- Helm Version: v3.16.3
- NGT Version: v2.3.5
- Faiss Version: v1.9.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Management**
	- Removed `libhdf5-dev` package from multiple Dockerfiles across different project environments
	- Updated Makefile to include `ldconfig` after HDF5 installation to refresh dynamic linker cache

<!-- end of auto-generated comment: release notes by coderabbit.ai -->