### PR TITLE
correct distance_type lorentz value to match schema

### DIFF
--- a/internal/core/algorithm/ngt/ngt.go
+++ b/internal/core/algorithm/ngt/ngt.go
@@ -275,7 +275,7 @@ const (
 	Cosine
 	// Poincare is poincare distance.
 	Poincare
-	// Lorentz is lorenz distance.
+	// Lorentz is lorentz distance.
 	Lorentz
 	// Jaccard is jaccard distance.
 	Jaccard

--- a/internal/core/algorithm/ngt/option.go
+++ b/internal/core/algorithm/ngt/option.go
@@ -123,7 +123,7 @@ func WithDistanceTypeByString(dt string) Option {
 		d = Cosine
 	case "poincare", "poinc", "poi", "po", "pc":
 		d = Poincare
-	case "lorentz", "loren", "lor", "lo", "lz":
+	case "lorentz", "lorent", "lorenz", "loren", "lor", "lo", "lz":
 		d = Lorentz
 	case "jaccard", "jac":
 		d = Jaccard

--- a/internal/core/algorithm/ngt/option.go
+++ b/internal/core/algorithm/ngt/option.go
@@ -123,7 +123,7 @@ func WithDistanceTypeByString(dt string) Option {
 		d = Cosine
 	case "poincare", "poinc", "poi", "po", "pc":
 		d = Poincare
-	case "lorenz", "loren", "lor", "lo", "lz":
+	case "lorentz", "loren", "lor", "lo", "lz":
 		d = Lorentz
 	case "jaccard", "jac":
 		d = Jaccard


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

`lorentz` could not be used with `distablce_type`, so I fixed the typo.

When `lorentz` is selected, the following error occurs in the agent pod:

```log
2025-03-02 08:51:20     [WARN]: (github.com/vdaas/vald/internal/core/algorithm/ngt/ngt.go:504): failed to load ngt core options err: failed to setup option :        github.com/vdaas/vald/internal/core/algorithm/ngt.WithDistanceTypeByString.WithDistanceType.func1: invalid critical option, name: distanceType, val: Unknown: unsupported DistanceType
2025-03-02 08:51:20     [ERR]:  (github.com/vdaas/vald/internal/core/algorithm/ngt/ngt.go:558): failed to setup option :        github.com/vdaas/vald/internal/core/algorithm/ngt.WithDistanceTypeByString.WithDistanceType.func1: invalid critical option, name: distanceType, val: Unknown: unsupported DistanceType
2025-03-02 08:51:20     [FATAL]:        (github.com/vdaas/vald/cmd/agent/core/ngt/main.go:56):  failed to setup option :        github.com/vdaas/vald/internal/core/algorithm/ngt.WithDistanceTypeByString.WithDistanceType.func1: invalid critical option, name: distanceType, val: Unknown: unsupported DistanceType
algorithm info       -> NGT-2.3.5
build cpu info flags -> [fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl tsc_reliable nonstop_tsc cpuid extd_apicid aperfmperf pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves user_shstk clzero xsaveerptr rdpru arat npt nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold v_vmsave_vmload umip vaes vpclmulqdq rdpid fsrm]
build time           -> 2025/02/20_05:34:41+0000
cgo call             -> 1
cgo enabled          -> true
git commit           -> cb121b24abe11a8ff37fdec0a21291a68f87c570
go arch              -> amd64
go max procs         -> 12
go os                -> linux
go version           -> 1.24.0
goroutine count      -> 2
runtime cpu cores    -> 12
server name          -> agent ngt
stack trace-000      -> https://github.com/vdaas/vald/blob/cb121b24abe11a8ff37fdec0a21291a68f87c570/cmd/agent/core/ngt/main.go#L56      github.com/vdaas/vald/cmd/agent/core/ngt/main.go#L56 main.main
vald version         -> cb121b24
```

In the [sourcecode](https://github.com/vdaas/vald/blob/v1.7.16/internal/core/algorithm/ngt/option.go#L126), it seems to accept `lorenz`, so I changed it to that, but an error occurred.

```sh
 % helm install vald vald/vald --values values.yaml
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
vald:
- agent.ngt.distance_type: agent.ngt.distance_type must be one of the following: "l1", "l2", "ang", "angle", "ham", "hamming", "cos", "cosine", "poincare", "poinc", "lorentz", "loren", "jac", "jaccard", "spjac", "sparsejaccard", "norml2", "normalizedl2", "normang", "normalizedangle", "normcos", "normalizedcosine", "dotproduct", "innerproduct", "dp", "ip"
```

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.16
- Go Version: v1.24.0
- Rust Version: v1.84.1
- Docker Version: v27.4.0
- Kubernetes Version: v1.32.0
- Helm Version: v3.16.3
- NGT Version: v2.3.5
- Faiss Version: v1.9.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of distance type strings to ensure that abbreviated inputs are correctly recognized and interpreted across various use cases.
  - Updated comments for consistency in naming conventions related to distance types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->