### PR TITLE
Add rollout restart testing for E2E V2 Strategic testing.

### DIFF
--- a/.gitfiles
+++ b/.gitfiles
@@ -2020,6 +2020,7 @@ tests/v2/e2e/crud/crud_test.go
 tests/v2/e2e/crud/dataset_test.go
 tests/v2/e2e/crud/grpc_test.go
 tests/v2/e2e/crud/index_test.go
+tests/v2/e2e/crud/kubernetes_test.go
 tests/v2/e2e/crud/modification_test.go
 tests/v2/e2e/crud/object_test.go
 tests/v2/e2e/crud/search_test.go

--- a/Makefile
+++ b/Makefile
@@ -475,7 +475,7 @@ files:
 		printf '\n%.0s' {1..15} > $(ROOTDIR)/.gitfiles; \
 	else \
 		head -n 15 $(ROOTDIR)/.gitfiles > $(ROOTDIR)/.gitfiles.tmp; \
-		git ls-files >> $(ROOTDIR)/.gitfiles.tmp; \
+		git ls-files | uniq >> $(ROOTDIR)/.gitfiles.tmp; \
 		mv $(ROOTDIR)/.gitfiles.tmp $(ROOTDIR)/.gitfiles; \
 	fi
 

--- a/tests/v2/e2e/assets/multi_crud.yaml
+++ b/tests/v2/e2e/assets/multi_crud.yaml
@@ -189,7 +189,7 @@ strategies:
   - concurrency: 1
     name: Initial Insert and Wait
     operations:
-      - name: Inset Operation
+      - name: Insert -> IndexInfo
         executions:
           - name: Insert
             type: insert
@@ -202,7 +202,6 @@ strategies:
           - mode: unary
             name: IndexInfo
             type: index_info
-        name: Insert -> IndexInfo
   - concurrency: 4
     name: Parallel Search Opeation (Search, SearchByID, LinearSearch, LinearSearchByID) x (ConcurrentQueue, SortSlice, SortPoolSlice, PairingHeap) = 16
     operations:

--- a/tests/v2/e2e/assets/rollout.yaml
+++ b/tests/v2/e2e/assets/rollout.yaml
@@ -13,14 +13,199 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+time_zone: UTC
+logging:
+  format: raw
+  level: info
+  logger: glg
+dataset:
+  name: _E2E_DATASET_PATH_
+kubernetes:
+  kube_config: $HOME/.kube/config
+  port_forward:
+    enabled: true
+    local_port: 8082
+    namespace: _E2E_TARGET_NAMESPACE_
+    service_name: _E2E_TARGET_NAME_
+    target_port: 8081
 target:
   addrs:
-    - localhost
-dataset:
-  name: "fashion-mnist-784-euclidean.hdf5"
-index:
-  wait_after_inesrt: "2m"
-kubernetes:
-  kubeconfig: ${HOME}/.kube/config
-  portforward:
+    - 127.0.0.1:8082
+  health_check_duration: "1s"
+  connection_pool:
+    enable_dns_resolver: true
+    enable_rebalance: true
+    old_conn_close_duration: 2m
+    rebalance_duration: 30m
+    size: 3
+  backoff:
+    backoff_factor: 1.1
+    backoff_time_limit: 5s
+    enable_error_log: false
+    initial_duration: 5ms
+    jitter_limit: 100ms
+    maximum_duration: 5s
+    retry_count: 100
+  call_option:
+    content_subtype: ""
+    max_recv_msg_size: 0
+    max_retry_rpc_buffer_size: 0
+    max_send_msg_size: 0
+    wait_for_ready: true
+  dial_option:
+    authority: ""
+    backoff_base_delay: 1s
+    backoff_jitter: 0.2
+    backoff_max_delay: 120s
+    backoff_multiplier: 1.6
+    disable_retry: false
+    enable_backoff: true
+    idle_timeout: 1h
+    initial_connection_window_size: 2097152
+    initial_window_size: 1048576
+    insecure: true
+    interceptors: []
+    keepalive:
+      permit_without_stream: false
+      time: ""
+      timeout: 30s
+    max_call_attempts: 0
+    max_header_list_size: 0
+    max_msg_size: 0
+    min_connection_timeout: 20s
+    net:
+      dialer:
+        dual_stack_enabled: true
+        keepalive: ""
+        timeout: ""
+      dns:
+        cache_enabled: true
+        cache_expiration: 1h
+        refresh_duration: 30m
+      network: tcp
+      socket_option:
+        ip_recover_destination_addr: false
+        ip_transparent: false
+        reuse_addr: true
+        reuse_port: true
+        tcp_cork: false
+        tcp_defer_accept: false
+        tcp_fast_open: false
+        tcp_no_delay: false
+        tcp_quick_ack: false
+      tls:
+        ca: /path/to/ca
+        cert: /path/to/cert
+        enabled: false
+        insecure_skip_verify: false
+        key: /path/to/key
+    read_buffer_size: 0
+    shared_write_buffer: false
+    timeout: ""
+    user_agent: Vald-gRPC
+    write_buffer_size: 0
+  tls:
+    ca: /path/to/ca
+    cert: /path/to/cert
     enabled: false
+    insecure_skip_verify: false
+    key: /path/to/key
+metadata:
+  key1: sample metadata value1
+  key2: sample metadata value2
+  key3: sample metadata value3
+metadata_string: key4=value4,key5=value5
+strategies:
+  - concurrency: 1
+    name: check Index Property
+    operations:
+      - name: IndexProperty
+        executions:
+          - mode: unary
+            name: IndexProperty
+            type: index_property
+            wait: 3s
+  - concurrency: 1
+    name: Initial Insert and Wait
+    operations:
+      - name: Insert Operation
+        executions:
+          - name: Insert
+            type: insert
+            mode: unary
+            parallelism: 10
+            num: 60000
+            qps: 3000
+            wait: 2m
+          - mode: unary
+            name: IndexInfo
+            type: index_info
+  - name: Search_with_RolloutRestartAgent
+    concurrency: 2
+    operations:
+      - name: Search
+        executions:
+          - name: Search
+            type: search
+            mode: unary
+            parallelism: 100
+            num: 10000000
+            qps: 3000
+            offset: 0
+            delay: ""
+            wait: 2m
+            timeout: ""
+            # for search configurations
+            search:
+              k: 10
+              radius: -1
+              epsilon: 0.05
+              algorithm: cq
+              min_num: 10
+              ratio: 0
+              timeout: 3s
+            expected_status_codes:
+              - ok
+              - not_found
+      - name: RolloutRestartAgentPods
+        executions:
+          - name: RolloutRestart
+            type: kubernetes
+            mode: other
+            kubernetes:
+              kind: "statefulset"
+              namespace: "default"
+              name: "vald-agent"
+              action: rollout
+          - name: WaitForAgentReady
+            type: kubernetes
+            mode: other
+            kubernetes:
+              kind: "statefulset"
+              namespace: "default"
+              name: "vald-agent"
+              action: wait
+              status: available
+  - name: RemoveVectors
+    operations:
+      - name: Remove
+        delay: ""
+        wait: ""
+        timeout: ""
+        executions:
+          - name: Remove
+            type: remove
+            mode: stream
+            parallelism: 0
+            num: 60000
+            offset: 0
+            bulk_size: 20
+            wait: "2m"
+            # for modification like (Insert, Update, Upsert, Remove, RemoveByTimestamp)
+            modification:
+              skip_strict_exist_check: false
+              timestamp: 0
+            # expected patterns of test status codes
+            expected_status_codes:
+              - ok
+              - not_found

--- a/tests/v2/e2e/assets/stream_crud.yaml
+++ b/tests/v2/e2e/assets/stream_crud.yaml
@@ -189,7 +189,7 @@ strategies:
   - concurrency: 1
     name: Initial Insert and Wait
     operations:
-      - name: Inset Operation
+      - name: Insert -> IndexInfo
         executions:
           - name: Insert
             type: insert
@@ -201,7 +201,6 @@ strategies:
           - mode: unary
             name: IndexInfo
             type: index_info
-        name: Insert -> IndexInfo
   - concurrency: 4
     name: Parallel Search Opeation (Search, SearchByID, LinearSearch, LinearSearchByID) x (ConcurrentQueue, SortSlice, SortPoolSlice, PairingHeap) = 16
     operations:

--- a/tests/v2/e2e/assets/unary_crud.yaml
+++ b/tests/v2/e2e/assets/unary_crud.yaml
@@ -189,7 +189,7 @@ strategies:
   - concurrency: 1
     name: Initial Insert and Wait
     operations:
-      - name: Inset Operation
+      - name: Insert -> IndexInfo
         executions:
           - name: Insert
             type: insert
@@ -201,7 +201,6 @@ strategies:
           - mode: unary
             name: IndexInfo
             type: index_info
-        name: Insert -> IndexInfo
   - concurrency: 4
     name: Parallel Search Opeation (Search, SearchByID, LinearSearch, LinearSearchByID) x (ConcurrentQueue, SortSlice, SortPoolSlice, PairingHeap) = 16
     operations:

--- a/tests/v2/e2e/config/enums.go
+++ b/tests/v2/e2e/config/enums.go
@@ -95,6 +95,7 @@ const (
 	KubernetesActionCreate  KubernetesAction = "create"
 	KubernetesActionPatch   KubernetesAction = "patch"
 	KubernetesActionScale   KubernetesAction = "scale"
+	KubernetesActionWait    KubernetesAction = "wait"
 )
 
 type KubernetesKind string
@@ -109,4 +110,23 @@ const (
 	Secret      KubernetesKind = "secret"
 	Service     KubernetesKind = "service"
 	StatefulSet KubernetesKind = "statefulset"
+)
+
+type KubernetesStatus string
+
+const (
+	KubernetesStatusUnknown       KubernetesStatus = "unknown"
+	KubernetesStatusPending       KubernetesStatus = "pending"
+	KubernetesStatusUpdating      KubernetesStatus = "updating"
+	KubernetesStatusAvailable     KubernetesStatus = "available"
+	KubernetesStatusDegraded      KubernetesStatus = "degraded"
+	KubernetesStatusFailed        KubernetesStatus = "failed"
+	KubernetesStatusCompleted     KubernetesStatus = "completed"
+	KubernetesStatusScheduled     KubernetesStatus = "scheduled"
+	KubernetesStatusScaling       KubernetesStatus = "scaling"
+	KubernetesStatusPaused        KubernetesStatus = "paused"
+	KubernetesStatusTerminating   KubernetesStatus = "terminating"
+	KubernetesStatusNotReady      KubernetesStatus = "notready"
+	KubernetesStatusBound         KubernetesStatus = "bound"
+	KubernetesStatusLoadBalancing KubernetesStatus = "loadbalancing"
 )

--- a/tests/v2/e2e/crud/kubernetes_test.go
+++ b/tests/v2/e2e/crud/kubernetes_test.go
@@ -1,0 +1,150 @@
+//go:build e2e
+
+//
+// Copyright (C) 2019-2025 vdaas.org vald team <vald@vdaas.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// package crud provides end-to-end tests using ann-benchmarks datasets.
+package crud
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vdaas/vald/internal/log"
+	"github.com/vdaas/vald/tests/v2/e2e/config"
+	"github.com/vdaas/vald/tests/v2/e2e/kubernetes"
+)
+
+func (r *runner) processKubernetes(t *testing.T, ctx context.Context, plan *config.Execution) {
+	t.Helper()
+	if plan == nil || plan.Kubernetes == nil {
+		t.Fatal("kubernetes plan is nil")
+		return
+	}
+	var err error
+	switch plan.Kubernetes.Action {
+	case config.KubernetesActionRollout:
+		switch plan.Kubernetes.Kind {
+		case config.Deployment:
+			err = kubernetes.RolloutRestart(ctx, kubernetes.Deployment(r.k8s, plan.Kubernetes.Namespace), plan.Kubernetes.Name)
+		case config.DaemonSet:
+			err = kubernetes.RolloutRestart(ctx, kubernetes.DaemonSet(r.k8s, plan.Kubernetes.Namespace), plan.Kubernetes.Name)
+		case config.StatefulSet:
+			err = kubernetes.RolloutRestart(ctx, kubernetes.StatefulSet(r.k8s, plan.Kubernetes.Namespace), plan.Kubernetes.Name)
+		case config.CronJob:
+			err = kubernetes.RolloutRestart(ctx, kubernetes.CronJob(r.k8s, plan.Kubernetes.Namespace), plan.Kubernetes.Name)
+		case config.Job:
+			err = kubernetes.RolloutRestart(ctx, kubernetes.Job(r.k8s, plan.Kubernetes.Namespace), plan.Kubernetes.Name)
+		default:
+		}
+		if err != nil {
+			t.Errorf("failed to rollout restart %s: %v", plan.Kubernetes.Kind, err)
+		}
+	case config.KubernetesActionDelete:
+		switch plan.Kubernetes.Kind {
+		case config.ConfigMap:
+			err = kubernetes.ConfigMap(r.k8s, plan.Kubernetes.Namespace).Delete(ctx, plan.Kubernetes.Name, kubernetes.EmptyDeleteOptions)
+		case config.CronJob:
+			err = kubernetes.CronJob(r.k8s, plan.Kubernetes.Namespace).Delete(ctx, plan.Kubernetes.Name, kubernetes.EmptyDeleteOptions)
+		case config.DaemonSet:
+			err = kubernetes.DaemonSet(r.k8s, plan.Kubernetes.Namespace).Delete(ctx, plan.Kubernetes.Name, kubernetes.EmptyDeleteOptions)
+		case config.Deployment:
+			err = kubernetes.Deployment(r.k8s, plan.Kubernetes.Namespace).Delete(ctx, plan.Kubernetes.Name, kubernetes.EmptyDeleteOptions)
+		case config.Job:
+			err = kubernetes.Job(r.k8s, plan.Kubernetes.Namespace).Delete(ctx, plan.Kubernetes.Name, kubernetes.EmptyDeleteOptions)
+		case config.Pod:
+			err = kubernetes.Pod(r.k8s, plan.Kubernetes.Namespace).Delete(ctx, plan.Kubernetes.Name, kubernetes.EmptyDeleteOptions)
+		case config.Secret:
+			err = kubernetes.Secret(r.k8s, plan.Kubernetes.Namespace).Delete(ctx, plan.Kubernetes.Name, kubernetes.EmptyDeleteOptions)
+		case config.Service:
+			err = kubernetes.Service(r.k8s, plan.Kubernetes.Namespace).Delete(ctx, plan.Kubernetes.Name, kubernetes.EmptyDeleteOptions)
+		case config.StatefulSet:
+			err = kubernetes.StatefulSet(r.k8s, plan.Kubernetes.Namespace).Delete(ctx, plan.Kubernetes.Name, kubernetes.EmptyDeleteOptions)
+		default:
+		}
+		if err != nil {
+			t.Errorf("failed to delete %s: %v", plan.Kubernetes.Kind, err)
+		}
+	case config.KubernetesActionGet:
+		var obj kubernetes.Object
+		switch plan.Kubernetes.Kind {
+		case config.ConfigMap:
+			obj, err = kubernetes.ConfigMap(r.k8s, plan.Kubernetes.Namespace).Get(ctx, plan.Kubernetes.Name, kubernetes.EmptyGetOptions)
+		case config.CronJob:
+			obj, err = kubernetes.CronJob(r.k8s, plan.Kubernetes.Namespace).Get(ctx, plan.Kubernetes.Name, kubernetes.EmptyGetOptions)
+		case config.DaemonSet:
+			obj, err = kubernetes.DaemonSet(r.k8s, plan.Kubernetes.Namespace).Get(ctx, plan.Kubernetes.Name, kubernetes.EmptyGetOptions)
+		case config.Deployment:
+			obj, err = kubernetes.Deployment(r.k8s, plan.Kubernetes.Namespace).Get(ctx, plan.Kubernetes.Name, kubernetes.EmptyGetOptions)
+		case config.Job:
+			obj, err = kubernetes.Job(r.k8s, plan.Kubernetes.Namespace).Get(ctx, plan.Kubernetes.Name, kubernetes.EmptyGetOptions)
+		case config.Pod:
+			obj, err = kubernetes.Pod(r.k8s, plan.Kubernetes.Namespace).Get(ctx, plan.Kubernetes.Name, kubernetes.EmptyGetOptions)
+		case config.Secret:
+			obj, err = kubernetes.Secret(r.k8s, plan.Kubernetes.Namespace).Get(ctx, plan.Kubernetes.Name, kubernetes.EmptyGetOptions)
+		case config.Service:
+			obj, err = kubernetes.Service(r.k8s, plan.Kubernetes.Namespace).Get(ctx, plan.Kubernetes.Name, kubernetes.EmptyGetOptions)
+		case config.StatefulSet:
+			obj, err = kubernetes.StatefulSet(r.k8s, plan.Kubernetes.Namespace).Get(ctx, plan.Kubernetes.Name, kubernetes.EmptyGetOptions)
+		default:
+		}
+		if err != nil {
+			t.Errorf("failed to get %s: %v", plan.Kubernetes.Kind, err)
+		}
+		if obj != nil {
+			log.Infof("kubernetes object: %v", obj)
+		}
+	case config.KubernetesActionWait:
+		var ok bool
+		switch plan.Kubernetes.Kind {
+		case config.ConfigMap:
+			_, ok, err = kubernetes.WaitForStatus(ctx, kubernetes.ConfigMap(r.k8s, plan.Kubernetes.Namespace), plan.Kubernetes.Name, plan.Kubernetes.Status.Status())
+		case config.CronJob:
+			_, ok, err = kubernetes.WaitForStatus(ctx, kubernetes.CronJob(r.k8s, plan.Kubernetes.Namespace), plan.Kubernetes.Name, plan.Kubernetes.Status.Status())
+		case config.DaemonSet:
+			_, ok, err = kubernetes.WaitForStatus(ctx, kubernetes.DaemonSet(r.k8s, plan.Kubernetes.Namespace), plan.Kubernetes.Name, plan.Kubernetes.Status.Status())
+		case config.Deployment:
+			_, ok, err = kubernetes.WaitForStatus(ctx, kubernetes.Deployment(r.k8s, plan.Kubernetes.Namespace), plan.Kubernetes.Name, plan.Kubernetes.Status.Status())
+		case config.Job:
+			_, ok, err = kubernetes.WaitForStatus(ctx, kubernetes.Job(r.k8s, plan.Kubernetes.Namespace), plan.Kubernetes.Name, plan.Kubernetes.Status.Status())
+		case config.Pod:
+			_, ok, err = kubernetes.WaitForStatus(ctx, kubernetes.Pod(r.k8s, plan.Kubernetes.Namespace), plan.Kubernetes.Name, plan.Kubernetes.Status.Status())
+		case config.Secret:
+			_, ok, err = kubernetes.WaitForStatus(ctx, kubernetes.Secret(r.k8s, plan.Kubernetes.Namespace), plan.Kubernetes.Name, plan.Kubernetes.Status.Status())
+		case config.Service:
+			_, ok, err = kubernetes.WaitForStatus(ctx, kubernetes.Service(r.k8s, plan.Kubernetes.Namespace), plan.Kubernetes.Name, plan.Kubernetes.Status.Status())
+		case config.StatefulSet:
+			_, ok, err = kubernetes.WaitForStatus(ctx, kubernetes.StatefulSet(r.k8s, plan.Kubernetes.Namespace), plan.Kubernetes.Name, plan.Kubernetes.Status.Status())
+		default:
+		}
+		if !ok {
+			t.Errorf("failed to wait for %s: %v", plan.Kubernetes.Kind, err)
+		}
+	case config.KubernetesActionExec:
+		t.Errorf("kubernetes action %s is not supported yet", plan.Kubernetes.Action)
+	case config.KubernetesActionApply:
+		t.Errorf("kubernetes action %s is not supported yet", plan.Kubernetes.Action)
+	case config.KubernetesActionCreate:
+		t.Errorf("kubernetes action %s is not supported yet", plan.Kubernetes.Action)
+	case config.KubernetesActionPatch:
+		t.Errorf("kubernetes action %s is not supported yet", plan.Kubernetes.Action)
+	case config.KubernetesActionScale:
+		t.Errorf("kubernetes action %s is not supported yet", plan.Kubernetes.Action)
+	default:
+		t.Errorf("kubernetes action %s is not supported yet", plan.Kubernetes.Action)
+	}
+	return
+}

--- a/tests/v2/e2e/crud/strategy_test.go
+++ b/tests/v2/e2e/crud/strategy_test.go
@@ -240,10 +240,25 @@ func (r *runner) processExecution(t *testing.T, ctx context.Context, idx int, e 
 				config.OpIndexStatisticsDetail,
 				config.OpIndexProperty,
 				config.OpFlush:
-				log.Infof("type: %s, mode: %s, execution: %d", e.Type, e.Mode, idx)
+				start := time.Now()
+				log.Infof("started %s execution at %s, type: %s, mode: %s, execution: %d",
+					e.Name, start.Format("2006-01-02 15:04:05"), e.Type, e.Mode, idx)
+				defer func() {
+					log.Infof("finished %s execution in %s, type: %s, mode: %s, execution: %d",
+						e.Name, time.Since(start).String(), e.Type, e.Mode, idx)
+				}()
 				r.processIndex(ttt, ctx, e)
 			case config.OpKubernetes:
-				// TODO implement kubernetes operation here, eg. delete pod, rollout restart, etc.
+				if e.Kubernetes != nil {
+					start := time.Now()
+					log.Infof("started %s execution at %s, type: %s, mode: %s, execution: %d, kubernetes action: %s, kind: %s, namespace: %s, name: %s, status: %s",
+						e.Name, start.Format("2006-01-02 15:04:05"), e.Type, e.Mode, idx, e.Kubernetes.Action, e.Kubernetes.Kind, e.Kubernetes.Namespace, e.Kubernetes.Name, e.Kubernetes.Status)
+					defer func() {
+						log.Infof("finished %s execution in %s, type: %s, mode: %s, execution: %d, kubernetes action: %s, kind: %s, namespace: %s, name: %s, status: %s",
+							e.Name, time.Since(start).String(), e.Type, e.Mode, idx, e.Kubernetes.Action, e.Kubernetes.Kind, e.Kubernetes.Namespace, e.Kubernetes.Name, e.Kubernetes.Status)
+					}()
+					r.processKubernetes(ttt, ctx, e)
+				}
 			case config.OpClient:
 				// TODO implement gRPC client operation here, eg. start, stop, etc.
 			case config.OpWait:

--- a/tests/v2/e2e/kubernetes/resources.go
+++ b/tests/v2/e2e/kubernetes/resources.go
@@ -169,6 +169,14 @@ var (
 	_ PersistentVolumeClaimClient = (*pvc)(nil)
 	_ PersistentVolumeClient      = (*pv)(nil)
 	_ EndpointClient              = (*endponts)(nil)
+
+	EmptyGetOptions    = metav1.GetOptions{}
+	EmptyListOptions   = metav1.ListOptions{}
+	EmptyCreateOptions = metav1.CreateOptions{}
+	EmptyUpdateOptions = metav1.UpdateOptions{}
+	EmptyPatchOptions  = metav1.PatchOptions{}
+	EmptyApplyOptions  = metav1.ApplyOptions{}
+	EmptyDeleteOptions = metav1.DeleteOptions{}
 )
 
 func Pod(c Client, namespace string) PodClient {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
This pull request includes significant updates to the end-to-end (E2E) testing framework, configuration files, and Makefile. The changes aim to enhance the functionality and robustness of the testing suite, particularly for Kubernetes environments.

### Enhancements to E2E Testing Framework:

* **New Test Files:**
  * Added `kubernetes_test.go` to the list of CRUD tests in `tests/v2/e2e/crud/`.
  
* **Configuration Updates:**
  * Introduced extensive configuration options for Kubernetes, logging, and connection pool settings in `rollout.yaml`.

### Improvements to Configuration Binding:

* **Enhanced Error Handling:**
  * Improved error messages in the `Bind` methods for various configuration structs to include more context about the failure. [[1]](diffhunk://#diff-03584846bd1a89bd475ac5c4c7f462d0f33ea0e0e89ca77676e2d06c66bd612cL168-R190) [[2]](diffhunk://#diff-03584846bd1a89bd475ac5c4c7f462d0f33ea0e0e89ca77676e2d06c66bd612cL203-R237) [[3]](diffhunk://#diff-03584846bd1a89bd475ac5c4c7f462d0f33ea0e0e89ca77676e2d06c66bd612cL241-R254) [[4]](diffhunk://#diff-03584846bd1a89bd475ac5c4c7f462d0f33ea0e0e89ca77676e2d06c66bd612cL262-R290) [[5]](diffhunk://#diff-03584846bd1a89bd475ac5c4c7f462d0f33ea0e0e89ca77676e2d06c66bd612cL294-R306) [[6]](diffhunk://#diff-03584846bd1a89bd475ac5c4c7f462d0f33ea0e0e89ca77676e2d06c66bd612cL309-R327)

* **Kubernetes Configuration:**
  * Added support for binding Kubernetes status in `KubernetesConfig`. [[1]](diffhunk://#diff-03584846bd1a89bd475ac5c4c7f462d0f33ea0e0e89ca77676e2d06c66bd612cR124) [[2]](diffhunk://#diff-03584846bd1a89bd475ac5c4c7f462d0f33ea0e0e89ca77676e2d06c66bd612cR603-R605)

### Makefile Optimization:

* **Unique File Listing:**
  * Modified the `Makefile` to ensure unique entries in `.gitfiles` by using `uniq` with `git ls-files`.

### Miscellaneous Updates:

* **Import Statements:**
  * Added import for `kubernetes` package in `config.go`.

* **Operation Naming:**
  * Corrected operation names in multiple YAML files from "Inset Operation" to "Insert -> IndexInfo". [[1]](diffhunk://#diff-07a8be9495cb0d79717ddb9ec3df2b28b14e34c9e3ed35f866292d75e0131daeL192-R192) [[2]](diffhunk://#diff-be86900ce4e4c9288b17219ebd39530411d453e92031ae2b617a66d1a9292019L192-R192) [[3]](diffhunk://#diff-50eac61d5c292253e8eba795432b04df9395c6a84335bf0f7d0a12b5e63e00aeL192-R192)

These changes collectively improve the maintainability, clarity, and functionality of the testing and configuration setup.

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.16
- Go Version: v1.24.2
- Rust Version: v1.85.1
- Docker Version: v28.0.4
- Kubernetes Version: v1.32.3
- Helm Version: v3.17.2
- NGT Version: v2.3.14
- Faiss Version: v1.10.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced Kubernetes configurations with updated logging, connection management, metadata, and dynamic target settings.
  - Expanded status and action parameters for improved Kubernetes integration.

- **Tests**
  - Added new end-to-end tests for Kubernetes operations featuring detailed logging and execution timing.

- **Chores**
  - Optimized build processes to ensure file listings remain unique and streamlined.
  - Introduced predefined empty options for various Kubernetes operations to simplify resource management.
  - Corrected naming conventions in operation strategies for clarity in configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->