### PR TITLE
[VALD-107] Fix linter CI fail when fokerd PR opened

### DIFF
--- a/.github/workflows/_detect-ci-container.yaml
+++ b/.github/workflows/_detect-ci-container.yaml
@@ -25,6 +25,22 @@ env:
 jobs:
   detect:
     runs-on: ubuntu-latest
+    if: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.fork == false) ||
+        (github.event.pull_request.head.repo.fork == true &&
+         github.event_name == 'pull_request_target' &&
+         (
+           (github.event.action == 'labeled' && github.event.label.name == 'ci/approved') ||
+           contains(github.event.pull_request.labels.*.name, 'ci/approved')
+         )
+        ) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/v')) ||
+        startsWith(github.ref, 'refs/tags/') ||
+        (github.event_name == 'schedule')
+      }}
     outputs:
       TAG: ${{ steps.get_tag_name.outputs.TAG }}
     steps:

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -18,6 +18,14 @@ on:
   pull_request:
     paths:
       - "charts/**"
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+    paths:
+      - "charts/**"
 jobs:
   dump-contexts-to-log:
     runs-on: ubuntu-latest

--- a/.github/workflows/reviewdog-k8s.yaml
+++ b/.github/workflows/reviewdog-k8s.yaml
@@ -19,6 +19,15 @@ on:
     paths:
       - "charts/**"
       - "k8s/**"
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+    paths:
+      - "charts/**"
+      - "k8s/**"
 jobs:
   dump-contexts-to-log:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->
SSIA

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.16
- Go Version: v1.24.2
- Rust Version: v1.86.0
- Docker Version: v28.0.4
- Kubernetes Version: v1.32.3
- Helm Version: v3.17.2
- NGT Version: v2.3.14
- Faiss Version: v1.10.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced our automation workflows with refined triggering conditions to ensure quality checks run only under precise scenarios such as pull requests, branch pushes, tag events, or scheduled updates.
  - Expanded automated triggers to improve efficiency and reliability in processing updates and reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->