### PR TITLE
[VALD-336] Implement expect in E2E v2 to assert API results

### DIFF
--- a/.gitfiles
+++ b/.gitfiles
@@ -1170,6 +1170,8 @@ internal/io/io.go
 internal/io/io_test.go
 internal/iter/doc.go
 internal/iter/iter.go
+internal/jsonpath/jsonpath.go
+internal/jsonpath/jsonpath_test.go
 internal/k8s/client/client.go
 internal/k8s/client/client_test.go
 internal/k8s/client/doc.go

--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -83,7 +83,7 @@ runs:
     - uses: ./.github/actions/setup-k3d
       if: ${{ inputs.require_k3d == 'true' }}
       with:
-        agents: 2
+        agents: 3
         ingress_port: ${{ inputs.ingress_port }}
     - name: Setup Minikube environment
       if: ${{ inputs.require_minikube == 'true' }}

--- a/.github/e2e/multi_crud.yaml
+++ b/.github/e2e/multi_crud.yaml
@@ -468,5 +468,4 @@ strategies:
             mode: unary
             type: index_info
             expect:
-              - path: "$"
-                value: {}
+              - value: {}

--- a/.github/e2e/multi_crud.yaml
+++ b/.github/e2e/multi_crud.yaml
@@ -164,10 +164,10 @@ strategies:
   #             skip_strict_exist_check: false
   #             timestamp: 0
   #           # expected patterns of test status codes
-  #           expected_status_codes:
-  #             - ok
-  #             - already_exists
-  #             - not_found
+  #           expect:
+  #             - status_code: ok
+  #             - status_code: already_exists
+  #             - status_code: not_found
   #           # for kubernetes configurations
   #           kubernetes:
   #             kind: "statefulset"
@@ -183,6 +183,11 @@ strategies:
             name: IndexProperty
             type: index_property
             wait: 3s
+            expect:
+              - status_code: ok
+                path: $.details.length()
+                op: eq
+                value: 3
   - concurrency: 1
     name: Initial Insert and Wait
     operations:
@@ -199,6 +204,11 @@ strategies:
           - mode: unary
             name: IndexInfo
             type: index_info
+            expect:
+              - status_code: ok
+                path: $.stored
+                op: gt
+                value: 5000
   - concurrency: 1
     name: Parallel Search Operation (Search, SearchByID, LinearSearch, LinearSearchByID) x (ConcurrentQueue, SortSlice, SortPoolSlice, PairingHeap) = 16
     operations:
@@ -458,3 +468,7 @@ strategies:
           - name: IndexInfo
             mode: unary
             type: index_info
+            expect:
+              - path: "$.length()"
+                op: eq
+                value: 0

--- a/.github/e2e/multi_crud.yaml
+++ b/.github/e2e/multi_crud.yaml
@@ -186,7 +186,6 @@ strategies:
             expect:
               - status_code: ok
                 path: $.details.length()
-                op: eq
                 value: 3
   - concurrency: 1
     name: Initial Insert and Wait
@@ -469,6 +468,5 @@ strategies:
             mode: unary
             type: index_info
             expect:
-              - path: "$.length()"
-                op: eq
-                value: 0
+              - path: "$"
+                value: {}

--- a/.github/e2e/stream_crud.yaml
+++ b/.github/e2e/stream_crud.yaml
@@ -447,5 +447,4 @@ strategies:
             mode: unary
             type: index_info
             expect:
-              - path: "$"
-                value: {}
+              - value: {}

--- a/.github/e2e/stream_crud.yaml
+++ b/.github/e2e/stream_crud.yaml
@@ -186,7 +186,6 @@ strategies:
             expect:
               - status_code: ok
                 path: $.details.length()
-                op: eq
                 value: 3
   - concurrency: 1
     name: Initial Insert and Wait
@@ -448,6 +447,5 @@ strategies:
             mode: unary
             type: index_info
             expect:
-              - path: "$.length()"
-                op: eq
-                value: 0
+              - path: "$"
+                value: {}

--- a/.github/e2e/stream_crud.yaml
+++ b/.github/e2e/stream_crud.yaml
@@ -164,10 +164,10 @@ strategies:
   #             skip_strict_exist_check: false
   #             timestamp: 0
   #           # expected patterns of test status codes
-  #           expected_status_codes:
-  #             - ok
-  #             - already_exists
-  #             - not_found
+  #           expect:
+  #             - status_code: ok
+  #             - status_code: already_exists
+  #             - status_code: not_found
   #           # for kubernetes configurations
   #           kubernetes:
   #             kind: "statefulset"
@@ -183,6 +183,11 @@ strategies:
             name: IndexProperty
             type: index_property
             wait: 3s
+            expect:
+              - status_code: ok
+                path: $.details.length()
+                op: eq
+                value: 3
   - concurrency: 1
     name: Initial Insert and Wait
     operations:
@@ -198,6 +203,11 @@ strategies:
           - mode: unary
             name: IndexInfo
             type: index_info
+            expect:
+              - status_code: ok
+                path: $.stored
+                op: gt
+                value: 5000
   - concurrency: 2
     name: Parallel Search Opeation (Search, SearchByID, LinearSearch, LinearSearchByID) x (ConcurrentQueue, SortSlice, SortPoolSlice, PairingHeap) = 16
     operations:
@@ -437,3 +447,7 @@ strategies:
           - name: IndexInfo
             mode: unary
             type: index_info
+            expect:
+              - path: "$.length()"
+                op: eq
+                value: 0

--- a/.github/e2e/unary_crud.yaml
+++ b/.github/e2e/unary_crud.yaml
@@ -447,5 +447,4 @@ strategies:
             mode: unary
             type: index_info
             expect:
-              - path: "$"
-                value: {}
+              - value: {}

--- a/.github/e2e/unary_crud.yaml
+++ b/.github/e2e/unary_crud.yaml
@@ -186,7 +186,6 @@ strategies:
             expect:
               - status_code: ok
                 path: $.details.length()
-                op: eq
                 value: 3
   - concurrency: 1
     name: Initial Insert and Wait
@@ -448,6 +447,5 @@ strategies:
             mode: unary
             type: index_info
             expect:
-              - path: "$.length()"
-                op: eq
-                value: 0
+              - path: "$"
+                value: {}

--- a/.github/e2e/unary_crud.yaml
+++ b/.github/e2e/unary_crud.yaml
@@ -164,10 +164,10 @@ strategies:
   #             skip_strict_exist_check: false
   #             timestamp: 0
   #           # expected patterns of test status codes
-  #           expected_status_codes:
-  #             - ok
-  #             - already_exists
-  #             - not_found
+  #           expect:
+  #             - status_code: ok
+  #             - status_code: already_exists
+  #             - status_code: not_found
   #           # for kubernetes configurations
   #           kubernetes:
   #             kind: "statefulset"
@@ -183,6 +183,11 @@ strategies:
             name: IndexProperty
             type: index_property
             wait: 3s
+            expect:
+              - status_code: ok
+                path: $.details.length()
+                op: eq
+                value: 3
   - concurrency: 1
     name: Initial Insert and Wait
     operations:
@@ -198,6 +203,11 @@ strategies:
           - mode: unary
             name: IndexInfo
             type: index_info
+            expect:
+              - status_code: ok
+                path: $.stored
+                op: gt
+                value: 5000
   - concurrency: 1
     name: Parallel Search Opeation (Search, SearchByID, LinearSearch, LinearSearchByID) x (ConcurrentQueue, SortSlice, SortPoolSlice, PairingHeap) = 16
     operations:
@@ -437,3 +447,7 @@ strategies:
           - name: IndexInfo
             mode: unary
             type: index_info
+            expect:
+              - path: "$.length()"
+                op: eq
+                value: 0

--- a/.github/workflows/e2e.v2.yaml
+++ b/.github/workflows/e2e.v2.yaml
@@ -89,7 +89,7 @@ jobs:
         if: ${{ matrix.deployment == 'helm-chart' && matrix.environment != 'mirror' }}
         uses: ./.github/actions/e2e-deploy-vald
         with:
-          helm_extra_options: "${{ steps.setup_e2e.outputs.HELM_EXTRA_OPTIONS }} --set agent.minReplicas=2"
+          helm_extra_options: "${{ steps.setup_e2e.outputs.HELM_EXTRA_OPTIONS }}"
           values: .github/helm/values/values-${{ contains('profile', matrix.environment) && matrix.environment || 'lb' }}.yaml
           wait_for_selector: "app=vald-lb-gateway"
       - name: Deploy Vald-01
@@ -97,7 +97,7 @@ jobs:
         uses: ./.github/actions/e2e-deploy-vald
         with:
           namespace: vald-01
-          helm_extra_options: "${{ steps.setup_e2e.outputs.HELM_EXTRA_OPTIONS }} --set agent.minReplicas=2"
+          helm_extra_options: "${{ steps.setup_e2e.outputs.HELM_EXTRA_OPTIONS }}"
           values: .github/helm/values/values-mirror-01.yaml
           wait_for_selector: app=vald-mirror-gateway
       - name: Deploy Vald-02
@@ -105,7 +105,7 @@ jobs:
         uses: ./.github/actions/e2e-deploy-vald
         with:
           namespace: vald-02
-          helm_extra_options: "${{ steps.setup_e2e.outputs.HELM_EXTRA_OPTIONS }} --set agent.minReplicas=2"
+          helm_extra_options: "${{ steps.setup_e2e.outputs.HELM_EXTRA_OPTIONS }}"
           values: .github/helm/values/values-mirror-02.yaml
           wait_for_selector: app=vald-mirror-gateway
       - name: Deploy Mirror Target
@@ -144,7 +144,7 @@ jobs:
         if: ${{ matrix.deployment == 'helm-operator' }}
         uses: ./.github/actions/e2e-deploy-vald-helm-operator
         with:
-          helm_extra_options: "${{ steps.vald_helm_operator.outputs.HELM_EXTRA_OPTIONS }} --set agent.minReplicas=2"
+          helm_extra_options: "${{ steps.vald_helm_operator.outputs.HELM_EXTRA_OPTIONS }}"
           valdrelease: ./.github/valdrelease/valdrelease.yaml
           wait_for_selector: app=vald-lb-gateway
 

--- a/internal/jsonpath/jsonpath.go
+++ b/internal/jsonpath/jsonpath.go
@@ -32,7 +32,7 @@ func JSONPathEval(jsonData []byte, path string) (any, error) {
 	}
 
 	if !strings.Contains(path, ".") {
-		return jsonData, nil
+		return data, nil
 	}
 
 	parts := strings.Split(path, ".")[1:]

--- a/internal/jsonpath/jsonpath.go
+++ b/internal/jsonpath/jsonpath.go
@@ -1,0 +1,65 @@
+//
+// Copyright (C) 2019-2025 vdaas.org vald team <vald@vdaas.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// package jsonpath provides utilities for working with JSONPath in Go.
+package jsonpath
+
+import (
+	"fmt"
+
+	"github.com/vdaas/vald/internal/encoding/json"
+	"github.com/vdaas/vald/internal/strings"
+)
+
+// JSONPathEval supports .field and .length() syntax for JSONPath evaluation.
+func JSONPathEval(jsonData []byte, path string) (any, error) {
+	var data any
+	if err := json.Unmarshal(jsonData, &data); err != nil {
+		return nil, err
+	}
+
+	if !strings.Contains(path, ".") {
+		return jsonData, nil
+	}
+
+	parts := strings.Split(path, ".")[1:]
+
+	current := data
+	for _, part := range parts {
+		switch typed := current.(type) {
+		case map[string]any:
+			if part == "length()" {
+				return len(typed), nil
+			}
+			val, exists := typed[part]
+			if !exists {
+				return nil, fmt.Errorf("key '%s' not found", part)
+			}
+			current = val
+
+		case []any:
+			if part == "length()" {
+				return len(typed), nil
+			}
+			return nil, fmt.Errorf("unexpected array when accessing '%s'", part)
+
+		default:
+			return nil, fmt.Errorf("cannot access '%s' on non-object", part)
+		}
+	}
+
+	return current, nil
+}

--- a/internal/jsonpath/jsonpath_test.go
+++ b/internal/jsonpath/jsonpath_test.go
@@ -1,0 +1,110 @@
+//
+// Copyright (C) 2019-2025 vdaas.org vald team <vald@vdaas.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// package jsonpath provides utilities for working with JSONPath in Go.
+package jsonpath
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestJSONPathEval(t *testing.T) {
+	jsonStr := []byte(`{
+		"test": [1, 2, 3],
+		"obj": {"key": "value"}
+	}`)
+
+	tests := []struct {
+		json     []byte
+		name     string
+		path     string
+		expected any
+		wantErr  bool
+	}{
+		{
+			json:     []byte("{}"),
+			name:     "empty length",
+			path:     "$.length()",
+			expected: 0,
+			wantErr:  false,
+		},
+		{
+			json:     jsonStr,
+			name:     "root",
+			path:     "$",
+			expected: jsonStr,
+			wantErr:  false,
+		},
+		{
+			json:     jsonStr,
+			name:     "access map length",
+			path:     "$.length()",
+			expected: 2,
+			wantErr:  false,
+		},
+		{
+			json:     jsonStr,
+			name:     "access array",
+			path:     ".test",
+			expected: []any{float64(1), float64(2), float64(3)},
+			wantErr:  false,
+		},
+		{
+			json:     jsonStr,
+			name:     "access array length",
+			path:     ".test.length()",
+			expected: 3,
+			wantErr:  false,
+		},
+		{
+			json:    jsonStr,
+			name:    "missing key",
+			path:    ".missing",
+			wantErr: true,
+		},
+		{
+			json:     jsonStr,
+			name:     "length on non-array",
+			path:     "$.obj.length()",
+			expected: 1,
+			wantErr:  false,
+		},
+		{
+			json:     jsonStr,
+			name:     "nested key access",
+			path:     ".obj.key",
+			expected: "value",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := JSONPathEval(tt.json, tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("got error = %v, wantErr = %v", err, tt.wantErr)
+				if err != nil {
+					t.Errorf("error details: %v", err)
+				}
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("got = %#v, expected = %#v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/jsonpath/jsonpath_test.go
+++ b/internal/jsonpath/jsonpath_test.go
@@ -43,10 +43,10 @@ func TestJSONPathEval(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			json:     jsonStr,
+			json:     []byte("{}"),
 			name:     "root",
 			path:     "$",
-			expected: jsonStr,
+			expected: map[string]any{},
 			wantErr:  false,
 		},
 		{

--- a/tests/v2/e2e/assets/multi_crud.yaml
+++ b/tests/v2/e2e/assets/multi_crud.yaml
@@ -199,9 +199,8 @@ strategies:
             name: IndexInfo
             type: index_info
             expect:
-              - path: "$.length()"
-                op: eq
-                value: 0
+              - path: "$"
+                value: {}
           - name: Insert
             type: insert
             mode: unary

--- a/tests/v2/e2e/assets/multi_crud.yaml
+++ b/tests/v2/e2e/assets/multi_crud.yaml
@@ -167,10 +167,10 @@ strategies:
   #             skip_strict_exist_check: false
   #             timestamp: 0
   #           # expected patterns of test status codes
-  #           expected_status_codes:
-  #             - ok
-  #             - already_exists
-  #             - not_found
+  #           expect:
+  #             - status_code: ok
+  #             - status_code: already_exists
+  #             - status_code: not_found
   #           # for kubernetes configurations
   #           kubernetes:
   #             kind: "statefulset"
@@ -191,17 +191,32 @@ strategies:
     operations:
       - name: Insert -> IndexInfo
         executions:
+          - name: Flush
+            mode: unary
+            type: flush
+            wait: 2m
+          - mode: unary
+            name: IndexInfo
+            type: index_info
+            expect:
+              - path: "$.length()"
+                op: eq
+                value: 0
           - name: Insert
             type: insert
-            mode: multiple
+            mode: unary
             parallelism: 10
-            bulk_size: 10
-            num: 30000
+            num: 60000
             qps: 3000
             wait: 2m
           - mode: unary
             name: IndexInfo
             type: index_info
+            expect:
+              - status_code: ok
+                path: $.stored
+                op: gt
+                value: 30000
   - concurrency: 4
     name: Parallel Search Opeation (Search, SearchByID, LinearSearch, LinearSearchByID) x (ConcurrentQueue, SortSlice, SortPoolSlice, PairingHeap) = 16
     operations:

--- a/tests/v2/e2e/assets/multi_crud.yaml
+++ b/tests/v2/e2e/assets/multi_crud.yaml
@@ -199,8 +199,7 @@ strategies:
             name: IndexInfo
             type: index_info
             expect:
-              - path: "$"
-                value: {}
+              - value: {}
           - name: Insert
             type: insert
             mode: unary

--- a/tests/v2/e2e/assets/rollout.yaml
+++ b/tests/v2/e2e/assets/rollout.yaml
@@ -138,8 +138,7 @@ strategies:
             name: IndexInfo
             type: index_info
             expect:
-              - path: "$"
-                value: {}
+              - value: {}
           - name: Insert
             type: insert
             mode: unary

--- a/tests/v2/e2e/assets/rollout.yaml
+++ b/tests/v2/e2e/assets/rollout.yaml
@@ -138,9 +138,8 @@ strategies:
             name: IndexInfo
             type: index_info
             expect:
-              - path: "$.length()"
-                op: eq
-                value: 0
+              - path: "$"
+                value: {}
           - name: Insert
             type: insert
             mode: unary

--- a/tests/v2/e2e/assets/rollout.yaml
+++ b/tests/v2/e2e/assets/rollout.yaml
@@ -130,6 +130,12 @@ strategies:
     operations:
       - name: Insert Operation
         executions:
+          - mode: unary
+            name: IndexInfo
+            type: index_info
+            expect:
+              results:
+                - {}
           - name: Insert
             type: insert
             mode: unary
@@ -140,6 +146,9 @@ strategies:
           - mode: unary
             name: IndexInfo
             type: index_info
+            expect:
+              results:
+                - stored: 60000
   - name: Search_with_RolloutRestartAgent
     concurrency: 2
     operations:

--- a/tests/v2/e2e/assets/rollout.yaml
+++ b/tests/v2/e2e/assets/rollout.yaml
@@ -130,12 +130,17 @@ strategies:
     operations:
       - name: Insert Operation
         executions:
+          - name: Flush
+            mode: unary
+            type: flush
+            wait: 2m
           - mode: unary
             name: IndexInfo
             type: index_info
             expect:
-              results:
-                - {}
+              - path: "$.length()"
+                op: eq
+                value: 0
           - name: Insert
             type: insert
             mode: unary
@@ -147,8 +152,10 @@ strategies:
             name: IndexInfo
             type: index_info
             expect:
-              results:
-                - stored: 60000
+              - status_code: ok
+                path: $.stored
+                op: gt
+                value: 30000
   - name: Search_with_RolloutRestartAgent
     concurrency: 2
     operations:
@@ -173,9 +180,8 @@ strategies:
               ratio: 0
               timeout: 3s
             expect:
-              status_codes:
-                - ok
-                - not_found
+              - status_code: ok
+              - status_code: not_found
       - name: RolloutRestartAgentPods
         executions:
           - name: RolloutRestart
@@ -217,6 +223,5 @@ strategies:
               timestamp: 0
             expect:
               # expected patterns of test status codes
-              status_codes:
-                - ok
-                - not_found
+              - status_code: ok
+              - status_code: not_found

--- a/tests/v2/e2e/assets/rollout.yaml
+++ b/tests/v2/e2e/assets/rollout.yaml
@@ -163,9 +163,10 @@ strategies:
               min_num: 10
               ratio: 0
               timeout: 3s
-            expected_status_codes:
-              - ok
-              - not_found
+            expect:
+              status_codes:
+                - ok
+                - not_found
       - name: RolloutRestartAgentPods
         executions:
           - name: RolloutRestart
@@ -205,7 +206,8 @@ strategies:
             modification:
               skip_strict_exist_check: false
               timestamp: 0
-            # expected patterns of test status codes
-            expected_status_codes:
-              - ok
-              - not_found
+            expect:
+              # expected patterns of test status codes
+              status_codes:
+                - ok
+                - not_found

--- a/tests/v2/e2e/assets/stream_crud.yaml
+++ b/tests/v2/e2e/assets/stream_crud.yaml
@@ -168,10 +168,9 @@ strategies:
   #             timestamp: 0
   #           # expected patterns of test status codes
   #           expect:
-  #             status_codes:
-  #               - ok
-  #               - already_exists
-  #               - not_found
+  #             - status_code: ok
+  #             - status_code: already_exists
+  #             - status_code: not_found
   #           # for kubernetes configurations
   #           kubernetes:
   #             kind: "statefulset"
@@ -192,16 +191,32 @@ strategies:
     operations:
       - name: Insert -> IndexInfo
         executions:
+          - name: Flush
+            mode: unary
+            type: flush
+            wait: 2m
+          - mode: unary
+            name: IndexInfo
+            type: index_info
+            expect:
+              - path: "$.length()"
+                op: eq
+                value: 0
           - name: Insert
             type: insert
-            mode: stream
+            mode: unary
             parallelism: 10
-            num: 30000
+            num: 60000
             qps: 3000
             wait: 2m
           - mode: unary
             name: IndexInfo
             type: index_info
+            expect:
+              - status_code: ok
+                path: $.stored
+                op: gt
+                value: 30000
   - concurrency: 4
     name: Parallel Search Opeation (Search, SearchByID, LinearSearch, LinearSearchByID) x (ConcurrentQueue, SortSlice, SortPoolSlice, PairingHeap) = 16
     operations:

--- a/tests/v2/e2e/assets/stream_crud.yaml
+++ b/tests/v2/e2e/assets/stream_crud.yaml
@@ -167,10 +167,11 @@ strategies:
   #             skip_strict_exist_check: false
   #             timestamp: 0
   #           # expected patterns of test status codes
-  #           expected_status_codes:
-  #             - ok
-  #             - already_exists
-  #             - not_found
+  #           expect:
+  #             status_codes:
+  #               - ok
+  #               - already_exists
+  #               - not_found
   #           # for kubernetes configurations
   #           kubernetes:
   #             kind: "statefulset"

--- a/tests/v2/e2e/assets/stream_crud.yaml
+++ b/tests/v2/e2e/assets/stream_crud.yaml
@@ -199,9 +199,8 @@ strategies:
             name: IndexInfo
             type: index_info
             expect:
-              - path: "$.length()"
-                op: eq
-                value: 0
+              - path: "$"
+                value: {}
           - name: Insert
             type: insert
             mode: unary

--- a/tests/v2/e2e/assets/stream_crud.yaml
+++ b/tests/v2/e2e/assets/stream_crud.yaml
@@ -199,8 +199,7 @@ strategies:
             name: IndexInfo
             type: index_info
             expect:
-              - path: "$"
-                value: {}
+              - value: {}
           - name: Insert
             type: insert
             mode: unary

--- a/tests/v2/e2e/assets/unary_crud.yaml
+++ b/tests/v2/e2e/assets/unary_crud.yaml
@@ -199,8 +199,7 @@ strategies:
             name: IndexInfo
             type: index_info
             expect:
-              - path: $
-                value: {}
+              - value: {}
           - name: Insert
             type: insert
             mode: unary

--- a/tests/v2/e2e/assets/unary_crud.yaml
+++ b/tests/v2/e2e/assets/unary_crud.yaml
@@ -167,10 +167,11 @@ strategies:
   #             skip_strict_exist_check: false
   #             timestamp: 0
   #           # expected patterns of test status codes
-  #           expected_status_codes:
-  #             - ok
-  #             - already_exists
-  #             - not_found
+  #           expect:
+  #             status_codes:
+  #               - ok
+  #               - already_exists
+  #               - not_found
   #           # for kubernetes configurations
   #           kubernetes:
   #             kind: "statefulset"

--- a/tests/v2/e2e/assets/unary_crud.yaml
+++ b/tests/v2/e2e/assets/unary_crud.yaml
@@ -199,9 +199,8 @@ strategies:
             name: IndexInfo
             type: index_info
             expect:
-              - path: "$.length()"
-                op: eq
-                value: 0
+              - path: $
+                value: {}
           - name: Insert
             type: insert
             mode: unary

--- a/tests/v2/e2e/assets/unary_crud.yaml
+++ b/tests/v2/e2e/assets/unary_crud.yaml
@@ -168,10 +168,9 @@ strategies:
   #             timestamp: 0
   #           # expected patterns of test status codes
   #           expect:
-  #             status_codes:
-  #               - ok
-  #               - already_exists
-  #               - not_found
+  #             - status_code: ok
+  #             - status_code: already_exists
+  #             - status_code: not_found
   #           # for kubernetes configurations
   #           kubernetes:
   #             kind: "statefulset"
@@ -192,16 +191,32 @@ strategies:
     operations:
       - name: Insert -> IndexInfo
         executions:
+          - name: Flush
+            mode: unary
+            type: flush
+            wait: 2m
+          - mode: unary
+            name: IndexInfo
+            type: index_info
+            expect:
+              - path: "$.length()"
+                op: eq
+                value: 0
           - name: Insert
             type: insert
             mode: unary
             parallelism: 10
-            num: 30000
+            num: 60000
             qps: 3000
             wait: 2m
           - mode: unary
             name: IndexInfo
             type: index_info
+            expect:
+              - status_code: ok
+                path: $.stored
+                op: gt
+                value: 30000
   - concurrency: 4
     name: Parallel Search Opeation (Search, SearchByID, LinearSearch, LinearSearchByID) x (ConcurrentQueue, SortSlice, SortPoolSlice, PairingHeap) = 16
     operations:

--- a/tests/v2/e2e/config/config.go
+++ b/tests/v2/e2e/config/config.go
@@ -22,6 +22,7 @@
 package config
 
 import (
+	"encoding/json"
 	"strconv"
 
 	"github.com/vdaas/vald/apis/grpc/v1/payload"
@@ -68,15 +69,15 @@ type Operation struct {
 
 // Execution represents the execution details for a given operation.
 type Execution struct {
-	*BaseConfig         `                    yaml:",inline,omitempty"               json:",inline,omitempty"`
-	TimeConfig          `                    yaml:",inline,omitempty"               json:",inline,omitempty"`
-	Name                string              `yaml:"name"                            json:"name,omitempty"`
-	Type                OperationType       `yaml:"type"                            json:"type,omitempty"`
-	Mode                OperationMode       `yaml:"mode"                            json:"mode,omitempty"`
-	Search              *SearchQuery        `yaml:"search,omitempty"                json:"search,omitempty"`
-	Kubernetes          *KubernetesConfig   `yaml:"kubernetes,omitempty"            json:"kubernetes,omitempty"`
-	Modification        *ModificationConfig `yaml:"modification,omitempty"          json:"modification,omitempty"`
-	ExpectedStatusCodes StatusCodes         `yaml:"expected_status_codes,omitempty" json:"expected_status_codes,omitempty"`
+	*BaseConfig  `                    yaml:",inline,omitempty"      json:",inline,omitempty"`
+	TimeConfig   `                    yaml:",inline,omitempty"      json:",inline,omitempty"`
+	Name         string              `yaml:"name"                   json:"name,omitempty"`
+	Type         OperationType       `yaml:"type"                   json:"type,omitempty"`
+	Mode         OperationMode       `yaml:"mode"                   json:"mode,omitempty"`
+	Search       *SearchQuery        `yaml:"search,omitempty"       json:"search,omitempty"`
+	Kubernetes   *KubernetesConfig   `yaml:"kubernetes,omitempty"   json:"kubernetes,omitempty"`
+	Modification *ModificationConfig `yaml:"modification,omitempty" json:"modification,omitempty"`
+	Expect       *Expect             `yaml:"expect,omitempty"       json:"expect,omitempty"`
 }
 
 // TimeConfig holds time-related configuration values.
@@ -145,6 +146,12 @@ type Port string
 // Dataset holds dataset-related configuration.
 type Dataset struct {
 	Name string `yaml:"name" json:"name,omitempty"`
+}
+
+// Expect holds expected results for executions.
+type Expect struct {
+	StatusCodes StatusCodes       `yaml:"status_codes,omitempty" json:"status_codes,omitempty"`
+	Results     []json.RawMessage `yaml:"results,omitempty"      json:"results,omitempty"`
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -300,8 +307,8 @@ func (e *Execution) Bind() (bound *Execution, err error) {
 				}
 			}
 		}
-		if e.ExpectedStatusCodes != nil {
-			if e.ExpectedStatusCodes, err = e.ExpectedStatusCodes.Bind(); err != nil {
+		if e.Expect != nil {
+			if e.Expect.StatusCodes, err = e.Expect.StatusCodes.Bind(); err != nil {
 				return nil, errors.Wrapf(err, "failed to bind StatusCodes for Execution %s of type %s", e.Name, e.Type)
 			}
 		}

--- a/tests/v2/e2e/config/config.go
+++ b/tests/v2/e2e/config/config.go
@@ -466,11 +466,9 @@ func (om OperationMode) Bind() (bound OperationMode, err error) {
 // Bind expands environment variables for StatusCode.
 func (op Operator) Bind() (bound Operator, err error) {
 	switch trimStringForCompare(config.GetActualValue(op)) {
-	case Lt:
-		return Lt, nil
-	case Gt:
-		return Gt, nil
-	case Eq, "":
+	case Le, Lt, Ge, Gt, Eq, Ne:
+		return op, nil
+	case "":
 		return Eq, nil
 	}
 	return op, errors.New("Unsupported operator: " + string(op))

--- a/tests/v2/e2e/config/enums.go
+++ b/tests/v2/e2e/config/enums.go
@@ -53,8 +53,6 @@ const (
 
 type StatusCode string
 
-type StatusCodes []StatusCode
-
 const (
 	StatusCodeOK                 StatusCode = "ok"
 	StatusCodeCanceled           StatusCode = "canceled"
@@ -129,4 +127,12 @@ const (
 	KubernetesStatusNotReady      KubernetesStatus = "notready"
 	KubernetesStatusBound         KubernetesStatus = "bound"
 	KubernetesStatusLoadBalancing KubernetesStatus = "loadbalancing"
+)
+
+type Operator string
+
+const (
+	Eq Operator = "eq"
+	Gt Operator = "gt"
+	Lt Operator = "lt"
 )

--- a/tests/v2/e2e/config/enums.go
+++ b/tests/v2/e2e/config/enums.go
@@ -133,6 +133,9 @@ type Operator string
 
 const (
 	Eq Operator = "eq"
+	Ne Operator = "ne"
+	Ge Operator = "ge"
 	Gt Operator = "gt"
+	Le Operator = "le"
 	Lt Operator = "lt"
 )

--- a/tests/v2/e2e/crud/grpc_test.go
+++ b/tests/v2/e2e/crud/grpc_test.go
@@ -130,6 +130,9 @@ func handleGRPCWithStatusCode(
 					errs = append(errs, fmt.Errorf("expected %v < %v at %s", val, expect.Value, expect.Path))
 					continue
 				}
+			default:
+				errs = append(errs, fmt.Errorf("unsupported operator '%s' for JSONPath %s", expect.Op, expect.Path))
+				continue
 			}
 			fmt.Fprintf(os.Stderr, "✅ assert_%v passed, expected: %v actual: %v\n", expect.Op, expect.Value, val)
 		}

--- a/tests/v2/e2e/crud/object_test.go
+++ b/tests/v2/e2e/crud/object_test.go
@@ -105,9 +105,9 @@ func (r *runner) processObject(
 						return
 					}
 					if res != nil && res.GetStatus() != nil {
-						_ = handleGRPCStatusCodeError(t, err, codes.Code(res.GetStatus().GetCode()), plan)
+						_ = handleGRPCWithStatusCode(t, err, codes.Code(res.GetStatus().GetCode()), res, plan)
 					} else {
-						handleGRPCCallError(t, err, plan)
+						handleGRPCCall(t, err, res, plan)
 					}
 					break
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

To assert API results like index count

Failure example
```
--- FAIL: TestE2EStrategy (15.40s)
    strategy_test.go:126: connected addrs: [127.0.0.1:8082]
    --- FAIL: TestE2EStrategy/#0:_strategy=check_Index_Property (3.09s)
        strategy_test.go:144: concurrency is set to 1, the operations will execute concurrently with limit (1)
        --- FAIL: TestE2EStrategy/#0:_strategy=check_Index_Property/#0:_operation=IndexProperty (3.08s)
            --- FAIL: TestE2EStrategy/#0:_strategy=check_Index_Property/#0:_operation=IndexProperty/#0:_execution=IndexProperty_type=index_property_mode=unary (3.08s)
                strategy_test.go:250: unexpected value for JSONPath $.details.length(): expected 4, got 3
FAIL
FAIL    github.com/vdaas/vald/tests/v2/e2e/crud 16.956s
FAIL
make: *** [Makefile.d/e2e.mk:25: e2e/v2] Error 1
```

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

VALD-336

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.16
- Go Version: v1.24.2
- Rust Version: v1.86.0
- Docker Version: v28.0.4
- Kubernetes Version: v1.32.3
- Helm Version: v3.17.2
- NGT Version: v2.3.14
- Faiss Version: v1.10.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Updated test configurations to nest expected status codes and results under a new structured format for consistency.
  - Enhanced test error handling to validate gRPC responses against detailed expected conditions, including JSONPath-based assertions.
  - Improved formatting consistency in configuration files.
  - Added a flush step and increased insert volumes in test flows for more robust validation.

- **New Features**
  - Added support for evaluating JSONPath expressions in test validations to enable more precise response checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->