### PR TITLE
docs: Fix a typo in the value that specified the service name

### DIFF
--- a/docs/tutorial/vald-agent-standalone-on-k8s.md
+++ b/docs/tutorial/vald-agent-standalone-on-k8s.md
@@ -100,10 +100,10 @@ This chapter uses [NGT](https://github.com/yahoojapan/ngt) as Vald Agent to perf
 
    ```bash
    NAME               READY   STATUS    RESTARTS   AGE
-   vald-agent-ngt-0   1/1     Running   0          20m
-   vald-agent-ngt-1   1/1     Running   0          20m
-   vald-agent-ngt-2   1/1     Running   0          20m
-   vald-agent-ngt-3   1/1     Running   0          20m
+   vald-agent-0   1/1     Running   0          20m
+   vald-agent-1   1/1     Running   0          20m
+   vald-agent-2   1/1     Running   0          20m
+   vald-agent-3   1/1     Running   0          20m
    ```
 
    </details>
@@ -115,7 +115,7 @@ This chapter uses [NGT](https://github.com/yahoojapan/ngt) as Vald Agent to perf
     At first, port-forward the vald-lb-gateway is required to make request from your local environment possible.
 
     ```bash
-    kubectl port-forward service/vald-agent-ngt 8081:8081
+    kubectl port-forward service/vald-agent 8081:8081
     ```
 
 1.  Download dataset


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

I followed this [tutorial](https://github.com/vdaas/vald/blob/main/docs/tutorial/vald-agent-standalone-on-k8s.md
).
The service name specification seems to be out of date, so please fix it.


I ran the tutorial and got the following:
```
❯ kubectl get pods
NAME           READY   STATUS    RESTARTS   AGE
vald-agent-0   1/1     Running   0          23m
vald-agent-1   1/1     Running   0          23m
vald-agent-2   1/1     Running   0          23m
vald-agent-3   1/1     Running   0          23m
```

```
❯ kubectl get services -n default
NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)             AGE
kubernetes   ClusterIP   10.96.0.1    <none>        443/TCP             55d
vald-agent   ClusterIP   None         <none>        8081/TCP,3001/TCP   24m
```

The correction is here.
>1.Port Forward

 >   At first, port-forward the vald-lb-gateway is required to make request from your local environment possible.

As is:
```
❯ kubectl port-forward service/vald-agent-ngt 8081:8081
Error from server (NotFound): services "vald-agent-ngt" not found
```

To be:
```
❯ kubectl port-forward service/vald-agent 8081:8081 
Forwarding from 127.0.0.1:8081 -> 8081
Forwarding from [::1]:8081 -> 8081
```

It's `service/vald-agent`, not `service/vald-agent-ngt`

P.S. Thanks for the kind tutorial, it's a fascinating project.

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.16
- Go Version: v1.24.2
- Rust Version: v1.86.0
- Docker Version: v28.0.4
- Kubernetes Version: v1.32.3
- Helm Version: v3.17.2
- NGT Version: v2.3.14
- Faiss Version: v1.10.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved the structure of the Vald Agent Standalone on Kubernetes tutorial with a nested table of contents, overview, and a "Recommended Documents" section.
  - Updated example pod names and service references to match current naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->