### PR TITLE
[Bugfix] Do not bind when object is nil

### DIFF
--- a/internal/config/corrector.go
+++ b/internal/config/corrector.go
@@ -62,17 +62,11 @@ func (c *Corrector) Bind() *Corrector {
 	c.KVSBackgroundCompactionInterval = GetActualValue(c.KVSBackgroundCompactionInterval)
 	c.KVSBackgroundSyncInterval = GetActualValue(c.KVSBackgroundSyncInterval)
 
-	if c.Discoverer == nil {
-		c.Discoverer = new(DiscovererClient)
+	if c.Discoverer != nil {
+		c.Discoverer = c.Discoverer.Bind()
 	}
-	// Assuming DiscovererClient.Bind() is compliant and c.Discoverer is now non-nil
-	c.Discoverer.Bind()
-
-	if c.Gateway == nil {
-		c.Gateway = new(GRPCClient) // Using new() for consistency here as per re-evaluation.
+	if c.Gateway != nil {
+		c.Gateway = c.Gateway.Bind()
 	}
-	// Assuming GRPCClient.Bind() is compliant and c.Gateway is now non-nil
-	c.Gateway.Bind()
-
 	return c
 }

--- a/internal/config/index_creation.go
+++ b/internal/config/index_creation.go
@@ -50,11 +50,8 @@ func (ic *IndexCreation) Bind() *IndexCreation {
 	ic.NodeName = GetActualValue(ic.NodeName)
 	ic.TargetAddrs = GetActualValues(ic.TargetAddrs)
 
-	if ic.Discoverer == nil {
-		ic.Discoverer = new(DiscovererClient)
+	if ic.Discoverer != nil {
+		ic.Discoverer.Bind()
 	}
-	// Assuming DiscovererClient.Bind() is compliant and ic.Discoverer is now non-nil
-	ic.Discoverer.Bind()
-
 	return ic
 }

--- a/internal/config/index_deleter.go
+++ b/internal/config/index_deleter.go
@@ -54,11 +54,8 @@ func (ic *IndexDeleter) Bind() *IndexDeleter {
 	ic.NodeName = GetActualValue(ic.NodeName)
 	ic.TargetAddrs = GetActualValues(ic.TargetAddrs)
 
-	if ic.Discoverer == nil {
-		ic.Discoverer = new(DiscovererClient)
+	if ic.Discoverer != nil {
+		ic.Discoverer.Bind()
 	}
-	// Assuming DiscovererClient.Bind() is compliant and ic.Discoverer is now non-nil
-	ic.Discoverer.Bind()
-
 	return ic
 }

--- a/internal/config/lb.go
+++ b/internal/config/lb.go
@@ -56,15 +56,9 @@ func (g *LB) Bind() *LB {
 	g.AgentDNS = GetActualValue(g.AgentDNS)
 	g.NodeName = GetActualValue(g.NodeName)
 
-	// Bind for the value struct field. Its Bind method has a pointer receiver.
-	g.ReadReplicaClient.Bind()
-
-	if g.Discoverer == nil {
-		g.Discoverer = new(DiscovererClient)
+	if g.Discoverer != nil {
+		g.Discoverer = g.Discoverer.Bind()
 	}
-	// Assuming DiscovererClient.Bind() is compliant and g.Discoverer is now non-nil
-	g.Discoverer.Bind()
-
 	return g
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

- Reverts the part of #2938 
- nil and default object are different settings
  - we need to investigate the diff later

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.16
- Go Version: v1.24.4
- Rust Version: v1.87.0
- Docker Version: v28.2.2
- Kubernetes Version: v1.33.1
- Helm Version: v3.18.2
- NGT Version: v2.4.2
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->
