### PR TITLE
[VALD-361] Backport changes into release v1.7 by default

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -83,7 +83,7 @@ jobs:
             data="{\"labels\": [$str]}"
             # If target branch is main, add "actions/backport/release/v1.7" label
             base_name=`cat $GITHUB_EVENT_PATH | jq -r ".pull_request.base.ref"`
-            if [[ "${base_name}" == "main" ]]; then
+            if [[ "${base_name}" == "main" && "${branch_name}" != backport/* ]]; then
               data="{\"labels\": [$str, \"actions/backport/release/v1.7\"]}"
             fi
             echo "send data: " $data

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           pr_num=`cat $GITHUB_EVENT_PATH | jq -r ".number"`
           branch_name=`cat $GITHUB_EVENT_PATH | jq -r ".pull_request.head.ref"`
-          type_labels=($(curl -s "https://api.github.com/repos/${REPOSITORY}/labels?per_page=5000" | jq -r ".[].name" | grep -e "^type/"))
+          type_labels=($(gh api "repos/${REPOSITORY}/labels?per_page=5000" | jq -r ".[].name" | grep -e "^type/"))
           send_labels=()
 
           git fetch origin main
@@ -121,7 +121,7 @@ jobs:
           )
 
           pr_num=`cat $GITHUB_EVENT_PATH | jq -r ".number"`
-          existing_labels=($(curl -s "https://api.github.com/repos/${REPOSITORY}/issues/${pr_num}/labels" | jq -r ".[].name"))
+          existing_labels=($(gh api "repos/${REPOSITORY}/issues/${pr_num}/labels" | jq -r ".[].name"))
           send_labels=()
           size_label="size/S"
           priority_label="priority/low"

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -81,6 +81,11 @@ jobs:
           if [ ${#send_labels[@]} -gt 0 ]; then
             str="$(IFS=,; echo "${send_labels[*]}")"
             data="{\"labels\": [$str]}"
+            # If target branch is main, add "actions/backport/release/v1.7" label
+            base_name=`cat $GITHUB_EVENT_PATH | jq -r ".pull_request.base.ref"`
+            if [[ "${base_name}" == "main" ]]; then
+              data="{\"labels\": [$str, \"actions/backport/release/v1.7\"]}"
+            fi
             echo "send data: " $data
             curl --request POST \
                  --url "https://api.github.com/repos/${REPOSITORY}/issues/${pr_num}/labels" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

- Backport changes into release v1.7
- Let's update the version after v1.8 release

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

VALD-361

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.16
- Go Version: v1.24.4
- Rust Version: v1.88.0
- Docker Version: v28.3.0
- Kubernetes Version: v1.33.2
- Helm Version: v3.18.3
- NGT Version: v2.4.3
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated labeling to add "actions/backport/release/v1.7" to pull requests targeting the "main" branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->