### PR TITLE
Add RBAC permissions for DaemonSet access

### DIFF
--- a/charts/vald-helm-operator/templates/clusterrole.yaml
+++ b/charts/vald-helm-operator/templates/clusterrole.yaml
@@ -100,6 +100,7 @@ rules:
       - replicasets
       - deployments
       - statefulsets
+      - daemonsets
     verbs:
       - create
       - delete


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Added DaemonSet permissions to ClusterRole to allow VHO to manage those components.

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.16
- Go Version: v1.24.4
- Rust Version: v1.88.0
- Docker Version: v28.3.0
- Kubernetes Version: v1.33.2
- Helm Version: v3.18.3
- NGT Version: v2.4.3
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded permissions to include management of DaemonSets, allowing for create, delete, get, list, patch, update, and watch actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->