### PR TITLE
check port-forward enabled/disabled

### DIFF
--- a/tests/v2/e2e/config/config.go
+++ b/tests/v2/e2e/config/config.go
@@ -669,27 +669,28 @@ func (pf *PortForward) Bind() (bound *PortForward, err error) {
 	if pf == nil {
 		return nil, errors.Wrap(errors.ErrInvalidConfig, "missing required fields on PortForward")
 	}
-	if pf.Enabled {
-		pf.ServiceName = config.GetActualValue(pf.ServiceName)
-		pf.Namespace = config.GetActualValue(pf.Namespace)
-		if pf.ServiceName == "" {
-			return nil, errors.New("portforward: service name cannot be empty")
-		}
-		if pf.Namespace == "" {
-			return nil, errors.New("portforward: namespace cannot be empty")
-		}
-		if _, err = pf.TargetPort.Bind(); err != nil {
-			return nil, err
-		}
-		if _, err = pf.LocalPort.Bind(); err != nil {
-			return nil, err
-		}
-		if pf.TargetPort.Port() == 0 {
-			pf.TargetPort = localPort
-		}
-		if pf.LocalPort.Port() == 0 {
-			pf.LocalPort = localPort
-		}
+	if !pf.Enabled {
+		return pf, nil
+	}
+	pf.ServiceName = config.GetActualValue(pf.ServiceName)
+	pf.Namespace = config.GetActualValue(pf.Namespace)
+	if pf.ServiceName == "" {
+		return nil, errors.New("portforward: service name cannot be empty")
+	}
+	if pf.Namespace == "" {
+		return nil, errors.New("portforward: namespace cannot be empty")
+	}
+	if _, err = pf.TargetPort.Bind(); err != nil {
+		return nil, err
+	}
+	if _, err = pf.LocalPort.Bind(); err != nil {
+		return nil, err
+	}
+	if pf.TargetPort.Port() == 0 {
+		pf.TargetPort = localPort
+	}
+	if pf.LocalPort.Port() == 0 {
+		pf.LocalPort = localPort
 	}
 	return pf, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

- Add checking port-forward enabled or not
<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.16
- Go Version: v1.24.4
- Rust Version: v1.88.0
- Docker Version: v28.3.0
- Kubernetes Version: v1.33.2
- Helm Version: v3.18.3
- NGT Version: v2.4.3
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of port forwarding settings by ensuring that validation and binding steps are only performed when port forwarding is enabled, preventing unnecessary errors when it is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->