### PR TITLE
Added Loop test case for E2E V2

### DIFF
--- a/tests/v2/e2e/assets/unary_crud.yaml
+++ b/tests/v2/e2e/assets/unary_crud.yaml
@@ -179,15 +179,19 @@ strategies:
   #             action: rollout
   - concurrency: 1
     name: check Index Property
+    repeats: 0
     operations:
       - name: IndexProperty
+        repeats: 0
         executions:
           - mode: unary
             name: IndexProperty
+            repeats: 0
             type: index_property
             wait: 3s
   - concurrency: 1
     name: Initial Insert and Wait
+    repeats: 0
     operations:
       - name: Insert -> IndexInfo
         executions:

--- a/tests/v2/e2e/config/config.go
+++ b/tests/v2/e2e/config/config.go
@@ -57,6 +57,7 @@ type Data struct {
 type Strategy struct {
 	TimeConfig  `             yaml:",inline"              json:",inline"`
 	Name        string       `yaml:"name"                 json:"name,omitempty"`
+	Repeats     uint64       `yaml:"repeats"              json:"repeats,omitempty"`
 	Concurrency uint64       `yaml:"concurrency"          json:"concurrency,omitempty"`
 	Operations  []*Operation `yaml:"operations,omitempty" json:"operations,omitempty"`
 }
@@ -65,6 +66,7 @@ type Strategy struct {
 type Operation struct {
 	TimeConfig `             yaml:",inline"              json:",inline"`
 	Name       string       `yaml:"name,omitempty"       json:"name,omitempty"`
+	Repeats    uint64       `yaml:"repeats"              json:"repeats,omitempty"`
 	Executions []*Execution `yaml:"executions,omitempty" json:"executions,omitempty"`
 }
 
@@ -73,6 +75,7 @@ type Execution struct {
 	*BaseConfig  `                    yaml:",inline,omitempty"      json:",inline,omitempty"`
 	TimeConfig   `                    yaml:",inline"                json:",inline"`
 	Name         string              `yaml:"name"                   json:"name,omitempty"`
+	Repeats      uint64              `yaml:"repeats"                json:"repeats,omitempty"`
 	Type         OperationType       `yaml:"type"                   json:"type,omitempty"`
 	Mode         OperationMode       `yaml:"mode"                   json:"mode,omitempty"`
 	Search       *SearchQuery        `yaml:"search,omitempty"       json:"search,omitempty"`
@@ -746,6 +749,26 @@ func (t *TimeConfig) GetTimeout() timeutil.DurationString {
 		return ""
 	}
 	return t.Timeout
+}
+
+type Repeats interface {
+	GetRepeats() uint64
+}
+
+func (d Data) GetRepeats() uint64 {
+	return 0 // Data level repetition is not supported. Use Strategy, Operation, or Execution level repetition instead, as these levels are designed to handle repeated operations.
+}
+
+func (s Strategy) GetRepeats() uint64 {
+	return s.Repeats
+}
+
+func (o Operation) GetRepeats() uint64 {
+	return o.Repeats
+}
+
+func (e Execution) GetRepeats() uint64 {
+	return e.Repeats
 }
 
 // Equals compares StatusCode with a given string ignoring case.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
* **New Features**
  * Added support for specifying repetition counts in test strategies, operations, and executions via configuration.
* **Tests**
  * Enhanced test execution to support repeated runs based on configuration, with error aggregation for repeated attempts.

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.16
- Go Version: v1.24.4
- Rust Version: v1.88.0
- Docker Version: v28.3.0
- Kubernetes Version: v1.33.2
- Helm Version: v3.18.3
- NGT Version: v2.4.3
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying repeat counts in test strategies, operations, and executions.
  * Tests can now be configured to run multiple times automatically based on the new repeat count setting.

* **Tests**
  * Enhanced test execution to allow repeated runs and error aggregation when a repeat count is set in the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->