### PR TITLE
[VALD-350] Add retry_until_success_timeout and use it in readreplica CI

### DIFF
--- a/.github/actions/e2e-deploy-vald-readreplica/action.yaml
+++ b/.github/actions/e2e-deploy-vald-readreplica/action.yaml
@@ -35,7 +35,7 @@ inputs:
   wait_for_timeout:
     description: "Timeout used for waiting for pods"
     required: false
-    default: "600s"
+    default: "3600s"
   use_local_charts:
     description: "If you want to use local charts, set this to true."
     required: false
@@ -87,7 +87,7 @@ runs:
         sleep 3
         kubectl get pods
 
-        kubectl wait --for=condition=ready pod -l ${WAIT_FOR_SELECTOR} --timeout=3600s
+        kubectl wait --for=condition=ready pod -l ${WAIT_FOR_SELECTOR} --timeout=${WAIT_FOR_TIMEOUT}
 
         podname=`kubectl get pods --selector=${WAIT_FOR_SELECTOR} | tail -1 | awk '{print $1}'`
         echo "POD_NAME=${podname}" >> $GITHUB_OUTPUT

--- a/.github/actions/e2e-deploy-vald-readreplica/action.yaml
+++ b/.github/actions/e2e-deploy-vald-readreplica/action.yaml
@@ -87,7 +87,7 @@ runs:
         sleep 3
         kubectl get pods
 
-        kubectl wait --for=condition=ready pod -l ${WAIT_FOR_SELECTOR} --timeout=600s
+        kubectl wait --for=condition=ready pod -l ${WAIT_FOR_SELECTOR} --timeout=3600s
 
         podname=`kubectl get pods --selector=${WAIT_FOR_SELECTOR} | tail -1 | awk '{print $1}'`
         echo "POD_NAME=${podname}" >> $GITHUB_OUTPUT

--- a/.github/actions/e2e-deploy-vald/action.yaml
+++ b/.github/actions/e2e-deploy-vald/action.yaml
@@ -38,7 +38,7 @@ inputs:
   wait_for_timeout:
     description: "Timeout used for waiting for pods"
     required: false
-    default: "600s"
+    default: "6000s"
   use_local_charts:
     description: "If you want to use local charts, set this to true."
     required: false

--- a/.github/e2e/readreplica.yaml
+++ b/.github/e2e/readreplica.yaml
@@ -204,6 +204,7 @@ strategies:
           - mode: unary
             name: IndexInfo
             type: index_info
+            timeout: 30m
             repeats:
               enabled: true
               exit_condition: success

--- a/.github/e2e/readreplica.yaml
+++ b/.github/e2e/readreplica.yaml
@@ -186,6 +186,11 @@ strategies:
             num: 105
             qps: 35
             wait: 2m
+          - mode: unary
+            name: CreateIndex
+            type: create_index
+            expect:
+              - status_code: ok
           - name: Check rotate job
             type: kubernetes
             mode: other

--- a/.github/e2e/readreplica.yaml
+++ b/.github/e2e/readreplica.yaml
@@ -201,18 +201,6 @@ strategies:
               status: completed
               action: wait
             wait: 1m
-          - mode: unary
-            name: IndexInfo
-            type: index_info
-            timeout: 30m
-            repeats:
-              enabled: true
-              exit_condition: success
-            expect:
-              - status_code: ok
-                path: $.sum()
-                op: ge
-                value: 215
   - concurrency: 2
     name: Parallel Search Opeation (Search, SearchByID, LinearSearch, LinearSearchByID) x (ConcurrentQueue, SortSlice, SortPoolSlice, PairingHeap) = 16
     operations:

--- a/.github/e2e/readreplica.yaml
+++ b/.github/e2e/readreplica.yaml
@@ -186,11 +186,6 @@ strategies:
             num: 105
             qps: 35
             wait: 2m
-          - mode: unary
-            name: CreateIndex
-            type: create_index
-            expect:
-              - status_code: ok
           - name: Check rotate job
             type: kubernetes
             mode: other

--- a/.github/e2e/readreplica.yaml
+++ b/.github/e2e/readreplica.yaml
@@ -425,11 +425,12 @@ strategies:
           - mode: unary
             name: IndexInfo
             type: index_info
+            retry_until_success_timeout: 30m
             expect:
               - status_code: ok
                 path: $.sum()
                 op: ge
-                value: 150
+                value: 300
           - name: Flush
             mode: unary
             type: flush

--- a/.github/e2e/readreplica.yaml
+++ b/.github/e2e/readreplica.yaml
@@ -430,7 +430,7 @@ strategies:
               - status_code: ok
                 path: $.sum()
                 op: ge
-                value: 300
+                value: 215
           - name: Flush
             mode: unary
             type: flush

--- a/.github/e2e/readreplica.yaml
+++ b/.github/e2e/readreplica.yaml
@@ -425,7 +425,9 @@ strategies:
           - mode: unary
             name: IndexInfo
             type: index_info
-            retry_until_success_timeout: 30m
+            repeats:
+              enabled: true
+              exit_condition: success
             expect:
               - status_code: ok
                 path: $.sum()

--- a/.github/e2e/readreplica.yaml
+++ b/.github/e2e/readreplica.yaml
@@ -196,6 +196,17 @@ strategies:
               status: completed
               action: wait
             wait: 1m
+          - mode: unary
+            name: IndexInfo
+            type: index_info
+            repeats:
+              enabled: true
+              exit_condition: success
+            expect:
+              - status_code: ok
+                path: $.sum()
+                op: ge
+                value: 215
   - concurrency: 2
     name: Parallel Search Opeation (Search, SearchByID, LinearSearch, LinearSearchByID) x (ConcurrentQueue, SortSlice, SortPoolSlice, PairingHeap) = 16
     operations:

--- a/.github/workflows/e2e.v2.yaml
+++ b/.github/workflows/e2e.v2.yaml
@@ -83,7 +83,7 @@ jobs:
             environment: bandwidth
           - scenario: readreplica
             deployment: helm-chart
-            cluster: kind
+            cluster: k0s
             environment: "null"
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/e2e.v2.yaml
+++ b/.github/workflows/e2e.v2.yaml
@@ -83,7 +83,7 @@ jobs:
             environment: bandwidth
           - scenario: readreplica
             deployment: helm-chart
-            cluster: k0s
+            cluster: kind
             environment: "null"
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/e2e.v2.yaml
+++ b/.github/workflows/e2e.v2.yaml
@@ -81,10 +81,11 @@ jobs:
             deployment: helm-chart
             cluster: k3d
             environment: bandwidth
-          - scenario: readreplica
-            deployment: helm-chart
-            cluster: kind
-            environment: "null"
+          # TODO: Fix the issue the readreplica returns 0 indices
+          # - scenario: readreplica
+          #   deployment: helm-chart
+          #   cluster: kind
+          #   environment: "null"
     runs-on: ubuntu-latest
     timeout-minutes: 60
     container:

--- a/.github/workflows/e2e.v2.yaml
+++ b/.github/workflows/e2e.v2.yaml
@@ -81,11 +81,11 @@ jobs:
             deployment: helm-chart
             cluster: k3d
             environment: bandwidth
-          # TODO: Fix the issue the readreplica returns 0 indices
-          # - scenario: readreplica
-          #   deployment: helm-chart
-          #   cluster: kind
-          #   environment: "null"
+            # TODO: Fix the issue the readreplica returns 0 indices
+            # - scenario: readreplica
+            #   deployment: helm-chart
+            #   cluster: kind
+            #   environment: "null"
     runs-on: ubuntu-latest
     timeout-minutes: 60
     container:

--- a/Makefile.d/k8s.mk
+++ b/Makefile.d/k8s.mk
@@ -266,13 +266,13 @@ k8s/vald-readreplica/deploy: k8s/vald/deploy
 	kubectl delete -f $(TEMP_DIR)/vald/templates/gateway/lb || true
 	kubectl get pods
 	kubectl wait --for=delete pod -l app=vald-lb-gateway --timeout=600s
-	
+
 	kubectl apply -f $(TEMP_DIR)/vald-readreplica/templates
 	sleep 5
 
 	kubectl get pods
-	kubectl wait --for=condition=ready pod -l app=vald-agent --timeout=600s
-	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=vald-readreplica --timeout=600s
+	kubectl wait --for=condition=ready pod -l app=vald-agent --timeout=3600s
+	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=vald-readreplica --timeout=3600s
 
 	kubectl apply -f $(TEMP_DIR)/vald/templates/gateway || true
 	kubectl apply -f $(TEMP_DIR)/vald/templates/gateway/lb || true

--- a/tests/v2/e2e/assets/agent_crud.yaml
+++ b/tests/v2/e2e/assets/agent_crud.yaml
@@ -179,19 +179,15 @@ strategies:
   #             action: rollout
   - concurrency: 1
     name: check Index Property
-    repeats: 0
     operations:
       - name: IndexProperty
-        repeats: 0
         executions:
           - mode: unary
             name: IndexProperty
-            repeats: 0
             type: index_property
             wait: 3s
   - concurrency: 1
     name: Initial Insert and CreateIndex
-    repeats: 0
     operations:
       - name: Insert -> CreateIndex -> IndexInfo
         executions:

--- a/tests/v2/e2e/assets/unary_crud.yaml
+++ b/tests/v2/e2e/assets/unary_crud.yaml
@@ -179,19 +179,15 @@ strategies:
   #             action: rollout
   - concurrency: 1
     name: check Index Property
-    repeats: 0
     operations:
       - name: IndexProperty
-        repeats: 0
         executions:
           - mode: unary
             name: IndexProperty
-            repeats: 0
             type: index_property
             wait: 3s
   - concurrency: 1
     name: Initial Insert and Wait
-    repeats: 0
     operations:
       - name: Insert -> IndexInfo
         executions:

--- a/tests/v2/e2e/config/config.go
+++ b/tests/v2/e2e/config/config.go
@@ -170,11 +170,10 @@ type Expect struct {
 
 // Repeats holds the repeat configuration for operations.
 type Repeats struct {
-	Enable        bool	 `yaml:"enable,omitempty"       json:"enable,omitempty"`
+	Enabled        bool	 `yaml:"enabled,omitempty"       json:"enabled,omitempty"`
 	ExitCondition ExitCondition `yaml:"exit_condition,omitempty" json:"exit_condition,omitempty"`
 	Count         uint64 `yaml:"count,omitempty"         json:"count,omitempty"`
 	Interval      timeutil.DurationString `yaml:"interval,omitempty"       json:"interval,omitempty"`
-	Timeout       timeutil.DurationString `yaml:"timeout,omitempty"       json:"timeout,omitempty"`
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/v2/e2e/config/config.go
+++ b/tests/v2/e2e/config/config.go
@@ -291,12 +291,12 @@ func (e *Execution) Bind() (bound *Execution, err error) {
 		e.RetryUntilSuccessTimeout = timeutil.DurationString("0s")
 	}
 	if e.Expect != nil {
-		if e.Mode != OperationUnary {
-			return nil, errors.Wrapf(errors.ErrInvalidConfig, "Expect is only supported for unary operations in Execution %s of type %s", e.Name, e.Type)
-		}
 		for i, ex := range e.Expect {
 			if ex.StatusCode, err = ex.StatusCode.Bind(); err != nil {
 				return nil, errors.Wrapf(err, "failed to bind StatusCodes for Execution %s of type %s", e.Name, e.Type)
+			}
+			if e.Mode != OperationUnary && ex.Value != nil {
+				return nil, errors.Wrapf(errors.ErrInvalidConfig, "Expect.Value is only supported for unary operations in Execution %s of type %s", e.Name, e.Type)
 			}
 			if ex.Op, err = ex.Op.Bind(); err != nil {
 				return nil, errors.Wrapf(err, "failed to bind Expect.Op for Execution %s of type %s", e.Name, e.Type)

--- a/tests/v2/e2e/config/config.go
+++ b/tests/v2/e2e/config/config.go
@@ -58,7 +58,7 @@ type Data struct {
 type Strategy struct {
 	TimeConfig  `             yaml:",inline"              json:",inline"`
 	Name        string       `yaml:"name"                 json:"name,omitempty"`
-	Repeats     *Repeats       `yaml:"repeats"              json:"repeats,omitempty"`
+	Repeats     *Repeats     `yaml:"repeats"              json:"repeats,omitempty"`
 	Concurrency uint64       `yaml:"concurrency"          json:"concurrency,omitempty"`
 	Operations  []*Operation `yaml:"operations,omitempty" json:"operations,omitempty"`
 }
@@ -67,23 +67,23 @@ type Strategy struct {
 type Operation struct {
 	TimeConfig `             yaml:",inline"              json:",inline"`
 	Name       string       `yaml:"name,omitempty"       json:"name,omitempty"`
-	Repeats    *Repeats       `yaml:"repeats"              json:"repeats,omitempty"`
+	Repeats    *Repeats     `yaml:"repeats"              json:"repeats,omitempty"`
 	Executions []*Execution `yaml:"executions,omitempty" json:"executions,omitempty"`
 }
 
 // Execution represents the execution details for a given operation.
 type Execution struct {
-	*BaseConfig              `yaml:",inline,omitempty" json:",inline,omitempty"`
-	TimeConfig               `yaml:",inline" json:",inline"`
-	Name                     string                  `yaml:"name"                        json:"name,omitempty"`
-	Repeats                  *Repeats                  `yaml:"repeats"                     json:"repeats,omitempty"`
-	Type                     OperationType           `yaml:"type"                        json:"type,omitempty"`
-	Mode                     OperationMode           `yaml:"mode"                        json:"mode,omitempty"`
-	Search                   *SearchQuery            `yaml:"search,omitempty"            json:"search,omitempty"`
-	Agent                    *AgentConfig            `yaml:"agent,omitempty"             json:"agent,omitempty"`
-	Kubernetes               *KubernetesConfig       `yaml:"kubernetes,omitempty"        json:"kubernetes,omitempty"`
-	Modification             *ModificationConfig     `yaml:"modification,omitempty"      json:"modification,omitempty"`
-	Expect                   []Expect                `yaml:"expect,omitempty"            json:"expect,omitempty"`
+	*BaseConfig  `                    yaml:",inline,omitempty"      json:",inline,omitempty"`
+	TimeConfig   `                    yaml:",inline"                json:",inline"`
+	Name         string              `yaml:"name"                   json:"name,omitempty"`
+	Repeats      *Repeats            `yaml:"repeats"                json:"repeats,omitempty"`
+	Type         OperationType       `yaml:"type"                   json:"type,omitempty"`
+	Mode         OperationMode       `yaml:"mode"                   json:"mode,omitempty"`
+	Search       *SearchQuery        `yaml:"search,omitempty"       json:"search,omitempty"`
+	Agent        *AgentConfig        `yaml:"agent,omitempty"        json:"agent,omitempty"`
+	Kubernetes   *KubernetesConfig   `yaml:"kubernetes,omitempty"   json:"kubernetes,omitempty"`
+	Modification *ModificationConfig `yaml:"modification,omitempty" json:"modification,omitempty"`
+	Expect       []Expect            `yaml:"expect,omitempty"       json:"expect,omitempty"`
 }
 
 // TimeConfig holds time-related configuration values.
@@ -170,9 +170,9 @@ type Expect struct {
 
 // Repeats holds the repeat configuration for operations.
 type Repeats struct {
-	Enabled        bool	 `yaml:"enabled,omitempty"       json:"enabled,omitempty"`
-	ExitCondition ExitCondition `yaml:"exit_condition,omitempty" json:"exit_condition,omitempty"`
-	Count         uint64 `yaml:"count,omitempty"         json:"count,omitempty"`
+	Enabled       bool                    `yaml:"enabled,omitempty"        json:"enabled,omitempty"`
+	ExitCondition ExitCondition           `yaml:"exit_condition,omitempty" json:"exit_condition,omitempty"`
+	Count         uint64                  `yaml:"count,omitempty"          json:"count,omitempty"`
 	Interval      timeutil.DurationString `yaml:"interval,omitempty"       json:"interval,omitempty"`
 }
 

--- a/tests/v2/e2e/config/config.go
+++ b/tests/v2/e2e/config/config.go
@@ -73,17 +73,17 @@ type Operation struct {
 
 // Execution represents the execution details for a given operation.
 type Execution struct {
-	*BaseConfig              `                    yaml:",inline,omitempty"      json:",inline,omitempty"`
-	TimeConfig               `                    yaml:",inline"                json:",inline"`
-	Name                     string                  `yaml:"name"                   json:"name,omitempty"`
-	Repeats                  uint64                  `yaml:"repeats"                json:"repeats,omitempty"`
-	Type                     OperationType           `yaml:"type"                   json:"type,omitempty"`
-	Mode                     OperationMode           `yaml:"mode"                   json:"mode,omitempty"`
-	Search                   *SearchQuery            `yaml:"search,omitempty"       json:"search,omitempty"`
-	Agent                    *AgentConfig            `yaml:"agent,omitempty"        json:"agent,omitempty"`
-	Kubernetes               *KubernetesConfig       `yaml:"kubernetes,omitempty"   json:"kubernetes,omitempty"`
-	Modification             *ModificationConfig     `yaml:"modification,omitempty" json:"modification,omitempty"`
-	Expect                   []Expect                `yaml:"expect,omitempty"       json:"expect,omitempty"`
+	*BaseConfig              `yaml:",inline,omitempty" json:",inline,omitempty"`
+	TimeConfig               `yaml:",inline" json:",inline"`
+	Name                     string                  `yaml:"name"                        json:"name,omitempty"`
+	Repeats                  uint64                  `yaml:"repeats"                     json:"repeats,omitempty"`
+	Type                     OperationType           `yaml:"type"                        json:"type,omitempty"`
+	Mode                     OperationMode           `yaml:"mode"                        json:"mode,omitempty"`
+	Search                   *SearchQuery            `yaml:"search,omitempty"            json:"search,omitempty"`
+	Agent                    *AgentConfig            `yaml:"agent,omitempty"             json:"agent,omitempty"`
+	Kubernetes               *KubernetesConfig       `yaml:"kubernetes,omitempty"        json:"kubernetes,omitempty"`
+	Modification             *ModificationConfig     `yaml:"modification,omitempty"      json:"modification,omitempty"`
+	Expect                   []Expect                `yaml:"expect,omitempty"            json:"expect,omitempty"`
 	RetryUntilSuccessTimeout timeutil.DurationString `yaml:"retry_until_success_timeout" json:"retry_until_success_timeout,omitempty"`
 }
 
@@ -163,10 +163,10 @@ type Dataset struct {
 
 // Expect holds expected results for executions.
 type Expect struct {
-	StatusCode StatusCode `yaml:"status_code,omitempty"       json:"status_code,omitempty"`
-	Path       string     `yaml:"path,omitempty"              json:"path,omitempty"`
-	Op         Operator   `yaml:"op,omitempty"                json:"op,omitempty"`
-	Value      any        `yaml:"value,omitempty"             json:"value,omitempty"`
+	StatusCode StatusCode `yaml:"status_code,omitempty" json:"status_code,omitempty"`
+	Path       string     `yaml:"path,omitempty"        json:"path,omitempty"`
+	Op         Operator   `yaml:"op,omitempty"          json:"op,omitempty"`
+	Value      any        `yaml:"value,omitempty"       json:"value,omitempty"`
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/v2/e2e/config/config.go
+++ b/tests/v2/e2e/config/config.go
@@ -170,9 +170,11 @@ type Expect struct {
 
 // Repeats holds the repeat configuration for operations.
 type Repeats struct {
-	Count        uint64 `yaml:"count,omitempty"         json:"count,omitempty"`
-	UntilSuccess bool   `yaml:"until_success,omitempty" json:"until_success,omitempty"`
-	Timeout      timeutil.DurationString `yaml:"timeout,omitempty"       json:"timeout,omitempty"`
+	Enable        bool	 `yaml:"enable,omitempty"       json:"enable,omitempty"`
+	ExitCondition ExitCondition `yaml:"exit_condition,omitempty" json:"exit_condition,omitempty"`
+	Count         uint64 `yaml:"count,omitempty"         json:"count,omitempty"`
+	Interval      timeutil.DurationString `yaml:"interval,omitempty"       json:"interval,omitempty"`
+	Timeout       timeutil.DurationString `yaml:"timeout,omitempty"       json:"timeout,omitempty"`
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/v2/e2e/config/enums.go
+++ b/tests/v2/e2e/config/enums.go
@@ -149,4 +149,5 @@ type ExitCondition string
 const (
 	Count   ExitCondition = "count"
 	Success ExitCondition = "success"
+	Timeout ExitCondition = "timeout"
 )

--- a/tests/v2/e2e/config/enums.go
+++ b/tests/v2/e2e/config/enums.go
@@ -148,6 +148,5 @@ type ExitCondition string
 
 const (
 	Count   ExitCondition = "count"
-	Timeout ExitCondition = "timeout"
 	Success ExitCondition = "success"
 )

--- a/tests/v2/e2e/config/enums.go
+++ b/tests/v2/e2e/config/enums.go
@@ -143,3 +143,11 @@ const (
 	Le Operator = "le"
 	Lt Operator = "lt"
 )
+
+type ExitCondition string
+
+const (
+	Count   ExitCondition = "count"
+	Timeout ExitCondition = "timeout"
+	Success ExitCondition = "success"
+)

--- a/tests/v2/e2e/crud/agent_test.go
+++ b/tests/v2/e2e/crud/agent_test.go
@@ -27,24 +27,25 @@ import (
 	"github.com/vdaas/vald/tests/v2/e2e/config"
 )
 
-func (r *runner) processAgent(t *testing.T, ctx context.Context, plan *config.Execution) {
+func (r *runner) processAgent(t *testing.T, ctx context.Context, plan *config.Execution) error {
 	t.Helper()
 	if plan == nil {
 		t.Fatalf("index operation plan is nil")
-		return
+		return nil
 	}
 	switch plan.Type {
 	case config.OpCreateIndex:
-		single(t, ctx, 0, plan, &payload.Control_CreateIndexRequest{
+		return single(t, ctx, 0, plan, &payload.Control_CreateIndexRequest{
 			PoolSize: plan.Agent.PoolSize,
 		}, r.aclient.CreateIndex, emptyCallback[*payload.Empty](plan.Name))
 	case config.OpSaveIndex:
-		single(t, ctx, 0, plan, new(payload.Empty), r.aclient.SaveIndex, emptyCallback[*payload.Empty](plan.Name))
+		return single(t, ctx, 0, plan, new(payload.Empty), r.aclient.SaveIndex, emptyCallback[*payload.Empty](plan.Name))
 	case config.OpCreateAndSaveIndex:
-		single(t, ctx, 0, plan, &payload.Control_CreateIndexRequest{
+		return single(t, ctx, 0, plan, &payload.Control_CreateIndexRequest{
 			PoolSize: plan.Agent.PoolSize,
 		}, r.aclient.CreateAndSaveIndex, emptyCallback[*payload.Empty](plan.Name))
 	default:
 		t.Fatalf("unsupported agent operation: %s", plan.Type)
 	}
+	return nil
 }

--- a/tests/v2/e2e/crud/grpc_test.go
+++ b/tests/v2/e2e/crud/grpc_test.go
@@ -219,9 +219,9 @@ func single[Q, R proto.Message](
 			break
 		}
 		if time.Since(start) >= timeout {
-      t.Error(fmt.Errorf("timeout reached: %w", err.Error()))
-      return
-    }
+			t.Error(fmt.Errorf("timeout reached: %w", err.Error()))
+			return
+		}
 	}
 
 	for _, cb := range callback {

--- a/tests/v2/e2e/crud/grpc_test.go
+++ b/tests/v2/e2e/crud/grpc_test.go
@@ -219,7 +219,7 @@ func single[Q, R proto.Message](
 			break
 		}
 		if time.Since(start) >= timeout {
-			t.Error(fmt.Errorf("timeout reached: %w", err.Error()))
+			t.Error(fmt.Errorf("timeout reached: %w", err))
 			return
 		}
 	}

--- a/tests/v2/e2e/crud/grpc_test.go
+++ b/tests/v2/e2e/crud/grpc_test.go
@@ -116,14 +116,14 @@ func handleGRPCWithStatusCode(
 	for _, expect := range plan.Expect {
 		if expect.StatusCode != "" && !expect.StatusCode.Equals(code.String()) {
 			err := fmt.Errorf("unexpected gRPC response received expected: %s, got: %s", expect.StatusCode, code)
-			log.Errorf("❌ assert failed, err: %v\n", err)
+			log.Errorf("❌ assert failed, err: %v", err)
 			errs = append(errs, err)
 			continue
 		}
 		if expect.Value != nil {
 			val, err := jsonpath.JSONPathEval(protoJSON, expect.Path)
 			if err != nil {
-				log.Errorf("❌ assert failed, err: %v\n", err)
+				log.Errorf("❌ assert failed, err: %v", err)
 				errs = append(errs, fmt.Errorf("failed to evaluate JSONPath: %s, JSON: %s, err: %s", expect.Path, protoJSON, err))
 				continue
 			}
@@ -167,13 +167,13 @@ func handleGRPCWithStatusCode(
 				errs = append(errs, fmt.Errorf("unsupported operator '%s' for JSONPath %s", expect.Op, expect.Path))
 				continue
 			}
-			log.Infof("✅ assert_%v passed, expected: %v actual: %v\n", expect.Op, expect.Value, val)
+			log.Infof("✅ assert_%v passed, expected: %v actual: %v", expect.Op, expect.Value, val)
 		}
 		return nil
 	}
 
 	err = errors.Join(errs...)
-	log.Errorf("❌ assert failed, err: %v\n", err)
+	log.Errorf("❌ assert failed, err: %v", err)
 	return err
 }
 

--- a/tests/v2/e2e/crud/index_test.go
+++ b/tests/v2/e2e/crud/index_test.go
@@ -27,26 +27,27 @@ import (
 	"github.com/vdaas/vald/tests/v2/e2e/config"
 )
 
-func (r *runner) processIndex(t *testing.T, ctx context.Context, plan *config.Execution) {
+func (r *runner) processIndex(t *testing.T, ctx context.Context, plan *config.Execution) error {
 	t.Helper()
 	if plan == nil {
 		t.Fatalf("index operation plan is nil")
-		return
+		return nil
 	}
 	switch plan.Type {
 	case config.OpIndexInfo:
-		single(t, ctx, 0, plan, new(payload.Empty), r.client.IndexInfo, printCallback[*payload.Info_Index_Count](passThrough))
+		return single(t, ctx, 0, plan, new(payload.Empty), r.client.IndexInfo, printCallback[*payload.Info_Index_Count](passThrough))
 	case config.OpIndexDetail:
-		single(t, ctx, 0, plan, new(payload.Empty), r.client.IndexDetail, printCallback[*payload.Info_Index_Detail](passThrough))
+		return single(t, ctx, 0, plan, new(payload.Empty), r.client.IndexDetail, printCallback[*payload.Info_Index_Detail](passThrough))
 	case config.OpIndexStatistics:
-		single(t, ctx, 0, plan, new(payload.Empty), r.client.IndexStatistics, printCallback[*payload.Info_Index_Statistics](passThrough))
+		return single(t, ctx, 0, plan, new(payload.Empty), r.client.IndexStatistics, printCallback[*payload.Info_Index_Statistics](passThrough))
 	case config.OpIndexStatisticsDetail:
-		single(t, ctx, 0, plan, new(payload.Empty), r.client.IndexStatisticsDetail, printCallback[*payload.Info_Index_StatisticsDetail](passThrough))
+		return single(t, ctx, 0, plan, new(payload.Empty), r.client.IndexStatisticsDetail, printCallback[*payload.Info_Index_StatisticsDetail](passThrough))
 	case config.OpIndexProperty:
-		single(t, ctx, 0, plan, new(payload.Empty), r.client.IndexProperty, printCallback[*payload.Info_Index_PropertyDetail](passThrough))
+		return single(t, ctx, 0, plan, new(payload.Empty), r.client.IndexProperty, printCallback[*payload.Info_Index_PropertyDetail](passThrough))
 	case config.OpFlush:
-		single(t, ctx, 0, plan, new(payload.Flush_Request), r.client.Flush, printCallback[*payload.Info_Index_Count](passThrough))
+		return single(t, ctx, 0, plan, new(payload.Flush_Request), r.client.Flush, printCallback[*payload.Info_Index_Count](passThrough))
 	default:
 		t.Fatalf("unsupported index operation: %s", plan.Type)
 	}
+	return nil
 }

--- a/tests/v2/e2e/crud/modification_test.go
+++ b/tests/v2/e2e/crud/modification_test.go
@@ -126,52 +126,53 @@ func (r *runner) processModification(
 	ctx context.Context,
 	train iter.Cycle[[][]float32, []float32],
 	plan *config.Execution,
-) {
+) error {
 	t.Helper()
 	if plan == nil {
 		t.Fatal("modification plan is nil")
-		return
+		return nil
 	}
 	switch plan.Type {
 	case config.OpInsert:
 		switch plan.Mode {
 		case config.OperationUnary, config.OperationOther:
-			unary(t, ctx, train, plan, r.client.Insert, insertRequest)
+			return unary(t, ctx, train, plan, r.client.Insert, insertRequest)
 		case config.OperationMultiple:
-			multi(t, ctx, train, plan, r.client.MultiInsert, insertRequest, insertMultipleRequest)
+			return multi(t, ctx, train, plan, r.client.MultiInsert, insertRequest, insertMultipleRequest)
 		case config.OperationStream:
 			stream(t, ctx, train, plan, r.client.StreamInsert, insertRequest)
 		}
 	case config.OpUpdate:
 		switch plan.Mode {
 		case config.OperationUnary, config.OperationOther:
-			unary(t, ctx, train, plan, r.client.Update, updateRequest)
+			return unary(t, ctx, train, plan, r.client.Update, updateRequest)
 		case config.OperationMultiple:
-			multi(t, ctx, train, plan, r.client.MultiUpdate, updateRequest, updateMultipleRequest)
+			return multi(t, ctx, train, plan, r.client.MultiUpdate, updateRequest, updateMultipleRequest)
 		case config.OperationStream:
 			stream(t, ctx, train, plan, r.client.StreamUpdate, updateRequest)
 		}
 	case config.OpUpsert:
 		switch plan.Mode {
 		case config.OperationUnary, config.OperationOther:
-			unary(t, ctx, train, plan, r.client.Upsert, upsertRequest)
+			return unary(t, ctx, train, plan, r.client.Upsert, upsertRequest)
 		case config.OperationMultiple:
-			multi(t, ctx, train, plan, r.client.MultiUpsert, upsertRequest, upsertMultipleRequest)
+			return multi(t, ctx, train, plan, r.client.MultiUpsert, upsertRequest, upsertMultipleRequest)
 		case config.OperationStream:
 			stream(t, ctx, train, plan, r.client.StreamUpsert, upsertRequest)
 		}
 	case config.OpRemove:
 		switch plan.Mode {
 		case config.OperationUnary, config.OperationOther:
-			unary(t, ctx, train, plan, r.client.Remove, removeRequest)
+			return unary(t, ctx, train, plan, r.client.Remove, removeRequest)
 		case config.OperationMultiple:
-			multi(t, ctx, train, plan, r.client.MultiRemove, removeRequest, removeMultipleRequest)
+			return multi(t, ctx, train, plan, r.client.MultiRemove, removeRequest, removeMultipleRequest)
 		case config.OperationStream:
 			stream(t, ctx, train, plan, r.client.StreamRemove, removeRequest)
 		}
 	case config.OpRemoveByTimestamp:
-		single(t, ctx, 0, plan, removeByTimestampRequest(t, 0, "", nil, plan), r.client.RemoveByTimestamp)
+		return single(t, ctx, 0, plan, removeByTimestampRequest(t, 0, "", nil, plan), r.client.RemoveByTimestamp)
 	}
+	return nil
 }
 
 func toModificationConfig(plan *config.Execution) (ts int64, skip bool) {

--- a/tests/v2/e2e/crud/search_test.go
+++ b/tests/v2/e2e/crud/search_test.go
@@ -156,20 +156,20 @@ func (r *runner) processSearch(
 	test, train iter.Cycle[[][]float32, []float32],
 	neighbors iter.Cycle[[][]int, []int],
 	plan *config.Execution,
-) {
+) error {
 	t.Helper()
 	if plan == nil {
 		t.Fatal("search operation plan is nil")
-		return
+		return nil
 	}
 
 	if plan.BaseConfig == nil {
 		t.Fatal("base configuration is nil")
-		return
+		return nil
 	}
 	if plan.Search == nil {
 		t.Fatal("search configuration is nil")
-		return
+		return nil
 	}
 
 	switch plan.Type {
@@ -177,10 +177,10 @@ func (r *runner) processSearch(
 		switch plan.Mode {
 		case config.OperationUnary, config.OperationOther:
 			// For unary search requests, use the generic unarySearch function with the searchRequest builder.
-			unary(t, ctx, test, plan, r.client.Search, searchRequest, checkUnarySearchResponse(neighbors))
+			return unary(t, ctx, test, plan, r.client.Search, searchRequest, checkUnarySearchResponse(neighbors))
 		case config.OperationMultiple:
 			// For bulk search requests, use the generic multiSearch function with searchRequest and searchMultiRequest builders.
-			multi(t, ctx, test, plan, r.client.MultiSearch, searchRequest, searchMultiRequest, checkMultiSearchResponse(neighbors))
+			return multi(t, ctx, test, plan, r.client.MultiSearch, searchRequest, searchMultiRequest, checkMultiSearchResponse(neighbors))
 		case config.OperationStream:
 			// For streaming search requests, use the generic streamSearch function with the searchRequest builder.
 			stream(t, ctx, test, plan, r.client.StreamSearch, searchRequest, checkStreamSearchResponse(neighbors))
@@ -188,31 +188,32 @@ func (r *runner) processSearch(
 	case config.OpSearchByID:
 		switch plan.Mode {
 		case config.OperationUnary, config.OperationOther:
-			unary(t, ctx, train, plan, r.client.SearchByID, searchIDRequest, checkUnarySearchResponse(neighbors))
+			return unary(t, ctx, train, plan, r.client.SearchByID, searchIDRequest, checkUnarySearchResponse(neighbors))
 		case config.OperationMultiple:
-			multi(t, ctx, train, plan, r.client.MultiSearchByID, searchIDRequest, searchMultiIDRequest, checkMultiSearchResponse(neighbors))
+			return multi(t, ctx, train, plan, r.client.MultiSearchByID, searchIDRequest, searchMultiIDRequest, checkMultiSearchResponse(neighbors))
 		case config.OperationStream:
 			stream(t, ctx, train, plan, r.client.StreamSearchByID, searchIDRequest, checkStreamSearchResponse(neighbors))
 		}
 	case config.OpLinearSearch:
 		switch plan.Mode {
 		case config.OperationUnary, config.OperationOther:
-			unary(t, ctx, test, plan, r.client.LinearSearch, searchRequest, checkUnarySearchResponse(neighbors))
+			return unary(t, ctx, test, plan, r.client.LinearSearch, searchRequest, checkUnarySearchResponse(neighbors))
 		case config.OperationMultiple:
-			multi(t, ctx, test, plan, r.client.MultiLinearSearch, searchRequest, searchMultiRequest, checkMultiSearchResponse(neighbors))
+			return multi(t, ctx, test, plan, r.client.MultiLinearSearch, searchRequest, searchMultiRequest, checkMultiSearchResponse(neighbors))
 		case config.OperationStream:
 			stream(t, ctx, test, plan, r.client.StreamLinearSearch, searchRequest, checkStreamSearchResponse(neighbors))
 		}
 	case config.OpLinearSearchByID:
 		switch plan.Mode {
 		case config.OperationUnary, config.OperationOther:
-			unary(t, ctx, test, plan, r.client.LinearSearchByID, searchIDRequest, checkUnarySearchResponse(neighbors))
+			return unary(t, ctx, test, plan, r.client.LinearSearchByID, searchIDRequest, checkUnarySearchResponse(neighbors))
 		case config.OperationMultiple:
-			multi(t, ctx, train, plan, r.client.MultiLinearSearchByID, searchIDRequest, searchMultiIDRequest, checkMultiSearchResponse(neighbors))
+			return multi(t, ctx, train, plan, r.client.MultiLinearSearchByID, searchIDRequest, searchMultiIDRequest, checkMultiSearchResponse(neighbors))
 		case config.OperationStream:
 			stream(t, ctx, train, plan, r.client.StreamLinearSearchByID, searchIDRequest, checkStreamSearchResponse(neighbors))
 		}
 	}
+	return nil
 }
 
 func checkUnarySearchResponse(

--- a/tests/v2/e2e/crud/strategy_test.go
+++ b/tests/v2/e2e/crud/strategy_test.go
@@ -367,6 +367,23 @@ func executeWithRepeats(
 			} else {
 				task = fmt.Sprintf("Repeat %s for %s (%d), ExitCondition: %s", prefix, name, idx+1, repeats.ExitCondition)
 			}
+			if idx >= 0 {
+				if wait := repeats.Interval; wait != "" {
+					dur, werr := wait.Duration()
+					if werr != nil {
+						t.Errorf("failed to parse wait duration: %s, error: %v", wait, werr)
+						return err
+					}
+					if dur > 0 {
+						log.Infof("Waiting interval: %s for %s", repeats.Interval, task)
+						select {
+						case <-ctx.Done():
+							return ctx.Err()
+						case <-time.After(dur):
+						}
+					}
+				}
+			}
 			idx++
 			select {
 			case <-ctx.Done():

--- a/tests/v2/e2e/crud/strategy_test.go
+++ b/tests/v2/e2e/crud/strategy_test.go
@@ -396,20 +396,20 @@ func executeWithRepeats(
 			default:
 			}
 			log.Info(task)
+			ierr := fn(t, ctx)
 			if repeats.ExitCondition == config.Success {
-				if err == nil {
+				if ierr == nil {
 					log.Infof("successfully finished %s, exiting repeat loop", task)
 					break
 				}
-				if errors.IsNot(err, context.Canceled, context.DeadlineExceeded) {
-					log.Warnf("failed to finish %s, error: %v, will retry", task, err)
+				if errors.IsNot(ierr, context.Canceled, context.DeadlineExceeded) {
+					log.Warnf("failed to finish %s, error: %v, will retry", task, ierr)
 					continue
 				}
 				// timeout
 				break
 			}
 			// repeats.ExitCondition == config.Count or config.Timeout
-			ierr := fn(t, ctx)
 			if ierr != nil {
 				if errors.IsNot(ierr, context.Canceled, context.DeadlineExceeded) {
 					err = errors.Join(err, ierr)

--- a/tests/v2/e2e/crud/strategy_test.go
+++ b/tests/v2/e2e/crud/strategy_test.go
@@ -397,24 +397,24 @@ func executeWithRepeats(
 			}
 			log.Info(task)
 			ierr := fn(t, ctx)
-			if repeats.ExitCondition == config.Success {
-				if ierr == nil {
-					log.Infof("successfully finished %s, exiting repeat loop", task)
-					break
-				}
-				if errors.IsNot(ierr, context.Canceled, context.DeadlineExceeded) {
-					log.Warnf("failed to finish %s, error: %v, will retry", task, ierr)
-					continue
-				}
-				// timeout
-				break
-			}
-			// repeats.ExitCondition == config.Count or config.Timeout
 			if ierr != nil {
+				if repeats.ExitCondition == config.Success {
+					if ierr == nil {
+						log.Infof("successfully finished %s, exiting repeat loop", task)
+						break
+					}
+					if errors.IsNot(ierr, context.Canceled, context.DeadlineExceeded) {
+						log.Warnf("failed to finish %s, error: %v, will retry", task, ierr)
+						continue
+					}
+				}
 				if errors.IsNot(ierr, context.Canceled, context.DeadlineExceeded) {
 					err = errors.Join(err, ierr)
 				} else {
 					// timeout
+					if repeats.ExitCondition != config.Timeout {
+							t.Error("timeout occurred during execution of", task)
+					}
 					break
 				}
 			}

--- a/tests/v2/e2e/crud/strategy_test.go
+++ b/tests/v2/e2e/crud/strategy_test.go
@@ -355,7 +355,7 @@ func executeWithRepeats(
 	fn func(*testing.T, context.Context) error,
 ) (err error) {
 	t.Helper()
-	if repeats.Enabled {
+	if repeats != nil && repeats.Enabled {
 		idx := uint64(0)
 		for {
 			var task string

--- a/tests/v2/e2e/crud/strategy_test.go
+++ b/tests/v2/e2e/crud/strategy_test.go
@@ -413,7 +413,7 @@ func executeWithRepeats(
 				} else {
 					// timeout
 					if repeats.ExitCondition != config.Timeout {
-							t.Error("timeout occurred during execution of", task)
+						t.Error("timeout occurred during execution of", task)
 					}
 					break
 				}

--- a/tests/v2/e2e/crud/strategy_test.go
+++ b/tests/v2/e2e/crud/strategy_test.go
@@ -367,7 +367,7 @@ func executeWithRepeats(
 			} else {
 				task = fmt.Sprintf("Repeat %s for %s (%d), ExitCondition: %s", prefix, name, idx+1, repeats.ExitCondition)
 			}
-			if idx >= 0 {
+			if idx > 0 {
 				if wait := repeats.Interval; wait != "" {
 					dur, werr := wait.Duration()
 					if werr != nil {

--- a/tests/v2/e2e/crud/strategy_test.go
+++ b/tests/v2/e2e/crud/strategy_test.go
@@ -261,7 +261,7 @@ func (r *runner) processExecution(t *testing.T, ctx context.Context, idx int, e 
 					log.Infof("finished %s execution in %s, type: %s, mode: %s, execution: %d",
 						e.Name, time.Since(start).String(), e.Type, e.Mode, idx)
 				}()
-				return r.processAgent(t, ctx, e)
+				return r.processAgent(ttt, ctx, e)
 			case config.OpKubernetes:
 				if e.Kubernetes != nil {
 					start := time.Now()

--- a/tests/v2/e2e/crud/strategy_test.go
+++ b/tests/v2/e2e/crud/strategy_test.go
@@ -358,10 +358,15 @@ func executeWithRepeats(
 	if repeats.Enabled {
 		idx := uint64(0)
 		for {
-			if repeats.ExitCondition == config.Count && idx >= repeats.Count {
-				break
+			var task string
+			if repeats.ExitCondition == config.Count {
+				task = fmt.Sprintf("Repeat %s for %s (%d/%d)", prefix, name, idx+1, repeats.Count)
+				if idx >= repeats.Count {
+					break
+				}
+			} else {
+				task = fmt.Sprintf("Repeat %s for %s (%d), ExitCondition: %s", prefix, name, idx+1, repeats.ExitCondition)
 			}
-			task := fmt.Sprintf("Repeat %s for %s (%d/%d)", prefix, name, idx+1, repeats)
 			idx++
 			select {
 			case <-ctx.Done():

--- a/tests/v2/e2e/crud/strategy_test.go
+++ b/tests/v2/e2e/crud/strategy_test.go
@@ -289,7 +289,7 @@ func (r *runner) processExecution(t *testing.T, ctx context.Context, idx int, e 
 
 func executeWithTimings[T interface {
 	config.Timing
-	config.Repeats
+	config.Repeater
 }](
 	t *testing.T,
 	ctx context.Context,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

Add retry_until_success_timeout and use it in readreplica CI

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

VALD-350

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.17
- Go Version: v1.24.5
- Rust Version: v1.88.0
- Docker Version: v28.3.2
- Kubernetes Version: v1.33.3
- Helm Version: v3.18.4
- NGT Version: v2.4.3
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->

Logs on the readreplica case
```
2025-08-07 05:19:11	[INFO]:	started IndexInfo execution at 2025-08-07 05:19:11, type: index_info, mode: unary, execution: 0
2025-08-07 05:19:50	[ERR]:	(/__w/vald/vald/tests/v2/e2e/crud/grpc_test.go:176):	❌ assert failed, err: assert_ge failed, JSONPath: $.sum(), expected: 215 actual: 0
2025-08-07 05:19:50	[INFO]:	finished IndexInfo execution in 38.908499765s, type: index_info, mode: unary, execution: 0
2025-08-07 05:19:50	[WARN]:	failed to finish Repeat execution for IndexInfo (1), ExitCondition: success, error: assert_ge failed, JSONPath: $.sum(), expected: 215 actual: 0, will retry
2025-08-07 05:19:50	[INFO]:	Repeat execution for IndexInfo (2), ExitCondition: success
2025-08-07 05:19:50	[INFO]:	started IndexInfo execution at 2025-08-07 05:19:50, type: index_info, mode: unary, execution: 0
2025-08-07 05:19:50	[INFO]:	✅ assert_ge passed, expected: 215 actual: 294
2025-08-07 05:19:50	[INFO]:	idx: 0 operation returned result: stored:247 uncommitted:47
2025-08-07 05:19:50	[INFO]:	finished IndexInfo execution in 4.21185ms, type: index_info, mode: unary, execution: 0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable repeatable test executions with selectable exit conditions (count/success/timeout), per-iteration intervals, and success-based retry behavior.

* **Bug Fixes**
  * Improved error propagation across end-to-end test runners for clearer, reliable failures.
  * Trimmed extraneous log newlines and adjusted a JSON sum expectation (150 → 215).
  * Added an extra index verification step in the read-replica strategy.

* **Chores**
  * Increased pod readiness timeouts in deployment scripts and CI actions.
  * Removed redundant repeat fields from test YAMLs and disabled one read-replica scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->