### PR TITLE
Try to separate amd64/arm64 builds

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -38,9 +38,6 @@ outputs:
   PRIMARY_TAG:
     description: "Primary tag"
     value: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
-  PLATFORMS:
-    description: "Target platforms"
-    value: ${{ steps.determine_platforms.outputs.PLATFORMS }}
   EXTRA_TAGS:
     description: "Extra tags"
     value: ${{ steps.add_extra_tags.outputs.EXTRA_TAGS }}
@@ -63,28 +60,6 @@ runs:
     - name: Determine tag name
       id: determine_tag_name
       uses: ./.github/actions/determine-docker-image-tag
-    - name: Determine platforms
-      shell: bash
-      id: determine_platforms
-      run: |
-        if [ "${TARGET_PLATFORMS}" = "" ]; then
-          if [[ "$GITHUB_REF" =~ ^refs/heads/main$ ]] || [[ "$GITHUB_REF" =~ ^refs/heads/master$ ]] || [[ "$GITHUB_REF" =~ ^refs/heads/release.* ]] || [[ "${PRIMARY_TAG}" == "nightly" ]]; then
-            platforms=`make docker/platforms`
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            platforms="linux/amd64"
-          elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
-            platforms="linux/amd64"
-          else
-            platforms=`make docker/platforms`
-          fi
-        else
-          platforms="${TARGET_PLATFORMS}"
-        fi
-        echo "PLATFORMS is determined: ${platforms}"
-        echo "PLATFORMS=${platforms}" >> $GITHUB_OUTPUT
-      env:
-        TARGET_PLATFORMS: ${{ inputs.platforms }}
-        PRIMARY_TAG: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
     - name: Update Vald version
       shell: bash
       run: echo "${PRIMARY_TAG}" > versions/VALD_VERSION
@@ -113,7 +88,7 @@ runs:
           REMOTE="true" \
           DOCKER="docker" \
           BUILDKIT_INLINE_CACHE=0 \
-          DOCKER_OPTS="--platform ${PLATFORMS} --builder ${BUILDER} ${LABEL_OPTS} \
+          DOCKER_OPTS="--platform ${{ inputs.platforms }} --builder ${BUILDER} ${LABEL_OPTS} \
           --label org.opencontainers.image.version=${PRIMARY_TAG} \
           --label org.opencontainers.image.title=${TARGET} \
           --label org.opencontainers.image.created=\"$(date --rfc-3339=ns)\" \
@@ -124,7 +99,6 @@ runs:
       env:
         TARGET: ${{ inputs.target }}
         DOCKER_BUILDKIT: "1"
-        PLATFORMS: ${{ steps.determine_platforms.outputs.PLATFORMS }}
         BUILDER: ${{ inputs.builder }}
         LABEL_OPTS: "--label org.opencontainers.image.url=${{ github.event.repository.html_url }} --label org.opencontainers.image.source=${{ github.event.repository.html_url }} --label org.opencontainers.image.revision=${{ github.sha }}"
         PRIMARY_TAG: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -24,9 +24,9 @@ inputs:
     description: "Buildx builder name"
     required: true
     default: ""
-  platforms:
-    description: "If it is specified, specified platforms will be used."
-    required: false
+  platform:
+    description: "Build platform"
+    required: true
     default: ""
 outputs:
   IMAGE_NAME:
@@ -88,13 +88,13 @@ runs:
           REMOTE="true" \
           DOCKER="docker" \
           BUILDKIT_INLINE_CACHE=0 \
-          DOCKER_OPTS="--platform ${{ inputs.platforms }} --builder ${BUILDER} ${LABEL_OPTS} \
+          DOCKER_OPTS="--platform ${{ inputs.platform }} --builder ${BUILDER} ${LABEL_OPTS} \
           --label org.opencontainers.image.version=${PRIMARY_TAG} \
           --label org.opencontainers.image.title=${TARGET} \
           --label org.opencontainers.image.created=\"$(date --rfc-3339=ns)\" \
           --label org.opencontainers.image.licenses=\"Apache 2.0\"" \
           EXTRA_ARGS="${EXTRA_TAGS}" \
-          TAG="${PRIMARY_TAG}" \
+          TAG="${PRIMARY_TAG}-${{contains(inputs.platform, 'arm64') && 'arm64' || 'amd64' }}" \
           docker/build/${TARGET}
       env:
         TARGET: ${{ inputs.target }}

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -94,7 +94,7 @@ runs:
           --label org.opencontainers.image.created=\"$(date --rfc-3339=ns)\" \
           --label org.opencontainers.image.licenses=\"Apache 2.0\"" \
           EXTRA_ARGS="${EXTRA_TAGS}" \
-          TAG="${PRIMARY_TAG}-${{contains(inputs.platform, 'arm64') && 'arm64' || 'amd64' }}" \
+          TAG="${PRIMARY_TAG}-${{ contains(inputs.platform, 'arm64') && 'arm64' || 'amd64' }}" \
           docker/build/${TARGET}
       env:
         TARGET: ${{ inputs.target }}

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -83,6 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-matrix
     strategy:
+      max-parallel: 1
       matrix:
         platform: ${{ fromJson(needs.setup-matrix.outputs.platforms) }}
     if: >-

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -74,7 +74,7 @@ jobs:
             platforms="${TARGET_PLATFORMS}"
           fi
           echo "PLATFORMS is determined: ${platforms}"
-          json=$(jq -R -s 'split(",")' <<< "$platforms")
+          json=$(jq -Rsc 'split(",")' <<< "$platforms")
           echo "result=$json" >> $GITHUB_OUTPUT
         env:
           TARGET_PLATFORMS: ${{ inputs.platforms }}

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -158,6 +158,10 @@ jobs:
         run: |
           docker buildx imagetools create --append \
             --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
+            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" || \
+                                                                                                                          # If the image does not exist, create a new one
+          docker buildx imagetools create \
+            --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
             "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
 
   slack:

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -37,8 +37,43 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dump-context
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      platforms: ${{ steps.determine_platforms.outputs.result }}
+    steps:
+      - name: Determine tag name
+        id: determine_tag_name
+        uses: ./.github/actions/determine-docker-image-tag
+      - name: Determine platforms
+        shell: bash
+        id: determine_platforms
+        run: |
+          if [ "${TARGET_PLATFORMS}" = "" ]; then
+            if [[ "$GITHUB_REF" =~ ^refs/heads/main$ ]] || [[ "$GITHUB_REF" =~ ^refs/heads/master$ ]] || [[ "$GITHUB_REF" =~ ^refs/heads/release.* ]] || [[ "${PRIMARY_TAG}" == "nightly" ]]; then
+              platforms=`make docker/platforms`
+            elif [ "${{ github.event_name }}" = "pull_request" ]; then
+              platforms="linux/amd64"
+            elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
+              platforms="linux/amd64"
+            else
+              platforms=`make docker/platforms`
+            fi
+          else
+            platforms="${TARGET_PLATFORMS}"
+          fi
+          echo "PLATFORMS is determined: ${platforms}"
+          json=$(jq -R -s 'split(",")' <<< "$platforms")
+          echo "result=$json" >> $GITHUB_OUTPUT
+        env:
+          TARGET_PLATFORMS: ${{ inputs.platforms }}
+          PRIMARY_TAG: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
   build:
     runs-on: ubuntu-latest
+    needs: setup-matrix
+    strategy:
+      matrix:
+        platform: ${{ fromJson(needs.setup-matrix.outputs.platforms) }}
     if: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -85,13 +120,13 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           image: ghcr.io/vdaas/vald/vald-binfmt:nightly
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
         with:
           version: latest
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           driver-opts: |
             image=ghcr.io/vdaas/vald/vald-buildkit:nightly
             network=host
@@ -101,7 +136,7 @@ jobs:
         uses: ./.github/actions/docker-build
         with:
           target: ${{ inputs.target }}
-          platforms: ${{ inputs.platforms }}
+          platforms: ${{ matrix.platform }}
           builder: ${{ steps.buildx.outputs.name }}
       - name: Scan the Docker image
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -153,12 +153,12 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: ./.github/actions/scan-docker-image
         with:
-          image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ matrix.platform }}"
+          image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
       - name: Unify multiple platforms
         run: |
           docker buildx imagetools create --append \
             --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
-            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ matrix.platform }}"
+            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
 
   slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -74,7 +74,7 @@ jobs:
             platforms="${TARGET_PLATFORMS}"
           fi
           echo "PLATFORMS is determined: ${platforms}"
-          json=$(jq -Rsc 'split(",")' <<< "$platforms")
+          json=$(jq -Rsc '[split(",") | .[] | gsub("\n"; "")]' <<< "$platforms")
           echo "result=$json" >> $GITHUB_OUTPUT
         env:
           TARGET_PLATFORMS: ${{ inputs.platforms }}
@@ -83,6 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-matrix
     strategy:
+      max-parallel: 1
       matrix:
         platform: ${{ fromJson(needs.setup-matrix.outputs.platforms) }}
     if: >-
@@ -147,13 +148,20 @@ jobs:
         uses: ./.github/actions/docker-build
         with:
           target: ${{ inputs.target }}
-          platforms: ${{ matrix.platform }}
+          platform: ${{ matrix.platform }}
           builder: ${{ steps.buildx.outputs.name }}
       - name: Scan the Docker image
         if: startsWith(github.ref, 'refs/tags/')
         uses: ./.github/actions/scan-docker-image
         with:
-          image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}"
+          image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ matrix.platform }}"
+      - name: Unify multiple platforms
+        run: |
+          docker buildx imagetools create \
+            --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
+            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-amd64" \
+            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-arm64"
+
   slack:
     runs-on: ubuntu-latest
     needs: [build]

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -82,6 +82,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: setup-matrix
+    permissions:
+      packages: write
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -159,18 +159,20 @@ jobs:
           image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
       - name: Unify multiple platforms
         run: |
+          alter_org=`make docker/name/org/alter`
+          alter_image_name=`make ORG="${alter_org}" docker/name/${{ inputs.target }}`
           # Append images to the unified tag, create a new one if not exists
           docker buildx imagetools create --append \
             --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
             "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
           docker buildx imagetools create --append \
-            --tag "ghcr.io/${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
+            --tag "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
             "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" || \
           docker buildx imagetools create \
             --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
             "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
           docker buildx imagetools create \
-            --tag "ghcr.io/${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
+            --tag "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
             "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
 
   slack:

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -157,12 +157,18 @@ jobs:
           image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
       - name: Unify multiple platforms
         run: |
+          # Append images to the unified tag, create a new one if not exists
           docker buildx imagetools create --append \
             --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
+            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
+          docker buildx imagetools create --append \
+            --tag "ghcr.io/${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
             "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" || \
-                                                                                                                          # If the image does not exist, create a new one
           docker buildx imagetools create \
             --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
+            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
+          docker buildx imagetools create \
+            --tag "gcr.io/${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
             "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
 
   slack:

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -168,7 +168,7 @@ jobs:
             --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
             "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
           docker buildx imagetools create \
-            --tag "gcr.io/${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
+            --tag "ghcr.io/${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
             "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
 
   slack:

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -167,13 +167,13 @@ jobs:
             "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
           docker buildx imagetools create --append \
             --tag "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
-            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" || \
+            "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" || \
           docker buildx imagetools create \
             --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
             "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
           docker buildx imagetools create \
             --tag "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
-            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
+            "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
 
   slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -42,6 +42,17 @@ jobs:
     outputs:
       platforms: ${{ steps.determine_platforms.outputs.result }}
     steps:
+      - name: Get ref
+        id: ref
+        run: |
+          if [ "${{ github.event.pull_request.head.sha }}" != "" ]; then
+            echo ref=${{ github.event.pull_request.head.sha }} >> $GITHUB_OUTPUT
+          else
+            echo ref=${{ github.sha }} >> $GITHUB_OUTPUT
+          fi
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
       - name: Determine tag name
         id: determine_tag_name
         uses: ./.github/actions/determine-docker-image-tag

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -83,7 +83,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-matrix
     strategy:
-      max-parallel: 1
       matrix:
         platform: ${{ fromJson(needs.setup-matrix.outputs.platforms) }}
     if: >-
@@ -157,10 +156,9 @@ jobs:
           image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ matrix.platform }}"
       - name: Unify multiple platforms
         run: |
-          docker buildx imagetools create \
+          docker buildx imagetools create --append \
             --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
-            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-amd64" \
-            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-arm64"
+            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ matrix.platform }}"
 
   slack:
     runs-on: ubuntu-latest

--- a/Makefile.d/helm.mk
+++ b/Makefile.d/helm.mk
@@ -23,7 +23,7 @@ $(BINDIR)/helm:
 	$(eval DARCH := $(subst aarch64,arm64,$(ARCH)))
 	TAR_NAME=helm-$(HELM_VERSION)-$(OS)-$(subst x86_64,amd64,$(shell echo $(DARCH) | tr '[:upper:]' '[:lower:]')) \
 	    && cd $(TEMP_DIR) \
-	    && curl -fsSL "https://get.helm.sh/$${TAR_NAME}.tar.gz" -o "$(TEMP_DIR)/$${TAR_NAME}" \
+	    && curl -fsSL --retry 3 "https://get.helm.sh/$${TAR_NAME}.tar.gz" -o "$(TEMP_DIR)/$${TAR_NAME}" \
 	    && tar -xzvf "$(TEMP_DIR)/$${TAR_NAME}" --strip=1 \
 	    && mv helm $(BINDIR)/helm
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

Separate ARM64/AMD64 builds to increase build resources and improve pipeline efficiency.

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

#3177

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.17
- Go Version: v1.24.5
- Rust Version: v1.88.0
- Docker Version: v28.3.2
- Kubernetes Version: v1.33.3
- Helm Version: v3.18.4
- NGT Version: v2.4.3
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI adds a setup-matrix job to compute per-platform build matrices, run per-architecture builds, emit PRIMARY_TAG-<arch> image tags, and consolidate them into a single multi-arch imagetools tag.
  * The build action now requires a single "platform" input; per-architecture runs use that platform and append architecture suffixes to tags.

* **Bug Fixes**
  * Helm download now retries transient network failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->