### PR TITLE
hotfix: separated unification job

### DIFF
--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -246,6 +246,8 @@ jobs:
           username: ${{ secrets.PACKAGE_USER }}
           password: ${{ secrets.PACKAGE_TOKEN }}
       - name: Unify multiple platforms
+        env:
+          TARGET: ${{ inputs.target }}
         run: |
           image_name=`make docker/name/${TARGET}`
           alter_org=`make docker/name/org/alter`

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -234,6 +234,7 @@ jobs:
     if: ${{ always() && (needs.build-amd64.result == 'success' || needs.build-arm64.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -160,8 +160,7 @@ jobs:
       - id: set-digest
         run: |
           REF="${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-amd64"
-          digest=$(docker buildx imagetools inspect --raw "$REF" \
- | jq -r '.manifests[]? | select(.platform.os=="linux" and .platform.architecture=="amd64") | .digest')
+          digest=$(docker buildx imagetools inspect --raw "$REF" | jq -r '.manifests[]? | select(.platform.os=="linux" and .platform.architecture=="amd64") | .digest')
           echo "digest=${digest}" >> $GITHUB_OUTPUT
   build-arm64:
     runs-on: ubuntu-latest
@@ -227,8 +226,7 @@ jobs:
       - id: set-digest
         run: |
           REF="${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-arm64"
-          digest=$(docker buildx imagetools inspect --raw "$REF" \
- | jq -r '.manifests[]? | select(.platform.os=="linux" and .platform.architecture=="arm64") | .digest')
+          digest=$(docker buildx imagetools inspect --raw "$REF" | jq -r '.manifests[]? | select(.platform.os=="linux" and .platform.architecture=="arm64") | .digest')
           echo "digest=${digest}" >> $GITHUB_OUTPUT
 
   unify:

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -41,6 +41,22 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       platforms: ${{ steps.determine_platforms.outputs.result }}
+    if: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.fork == false) ||
+        (github.event.pull_request.head.repo.fork == true &&
+         github.event_name == 'pull_request_target' &&
+         (
+           (github.event.action == 'labeled' && github.event.label.name == 'ci/approved') ||
+           contains(github.event.pull_request.labels.*.name, 'ci/approved')
+         )
+        ) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/v')) ||
+        startsWith(github.ref, 'refs/tags/') ||
+        (github.event_name == 'schedule')
+      }}
     steps:
       - name: Get ref
         id: ref
@@ -79,31 +95,15 @@ jobs:
         env:
           TARGET_PLATFORMS: ${{ inputs.platforms }}
           PRIMARY_TAG: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
-  build:
+  build-amd64:
     runs-on: ubuntu-latest
     needs: setup-matrix
+    if: ${{ contains(fromJson(needs.setup-matrix.outputs.platforms), 'linux/amd64') }}
     permissions:
       packages: write
-    strategy:
-      max-parallel: 1
-      matrix:
-        platform: ${{ fromJson(needs.setup-matrix.outputs.platforms) }}
-    if: >-
-      ${{
-        (github.event_name == 'pull_request' &&
-         github.event.pull_request.head.repo.fork == false) ||
-        (github.event.pull_request.head.repo.fork == true &&
-         github.event_name == 'pull_request_target' &&
-         (
-           (github.event.action == 'labeled' && github.event.label.name == 'ci/approved') ||
-           contains(github.event.pull_request.labels.*.name, 'ci/approved')
-         )
-        ) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/v')) ||
-        startsWith(github.ref, 'refs/tags/') ||
-        (github.event_name == 'schedule')
-      }}
+    outputs:
+      digest: ${{ steps.set-digest.outputs.digest }}
+      primary_tag: ${{ steps.build_and_publish.outputs.PRIMARY_TAG }}
     steps:
       - name: Get ref
         id: ref
@@ -134,13 +134,13 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           image: ghcr.io/vdaas/vald/vald-binfmt:nightly
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
         with:
           version: latest
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           driver-opts: |
             image=ghcr.io/vdaas/vald/vald-buildkit:nightly
             network=host
@@ -150,30 +150,130 @@ jobs:
         uses: ./.github/actions/docker-build
         with:
           target: ${{ inputs.target }}
-          platform: ${{ matrix.platform }}
+          platform: linux/amd64
           builder: ${{ steps.buildx.outputs.name }}
       - name: Scan the Docker image
         if: startsWith(github.ref, 'refs/tags/')
         uses: ./.github/actions/scan-docker-image
         with:
-          image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
+          image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-amd64"
+      - id: set-digest
+        run: |
+          REF="${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-amd64"
+          digest=$(docker buildx imagetools inspect --raw "$REF" \
+ | jq -r '.manifests[]? | select(.platform.os=="linux" and .platform.architecture=="amd64") | .digest')
+          echo "digest=${digest}" >> $GITHUB_OUTPUT
+  build-arm64:
+    runs-on: ubuntu-latest
+    needs: setup-matrix
+    if: ${{ contains(fromJson(needs.setup-matrix.outputs.platforms), 'linux/arm64') }}
+    permissions:
+      packages: write
+    outputs:
+      digest: ${{ steps.set-digest.outputs.digest }}
+    steps:
+      - name: Get ref
+        id: ref
+        run: |
+          if [ "${{ github.event.pull_request.head.sha }}" != "" ]; then
+            echo ref=${{ github.event.pull_request.head.sha }} >> $GITHUB_OUTPUT
+          else
+            echo ref=${{ github.sha }} >> $GITHUB_OUTPUT
+          fi
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+      - name: Set Git config
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASS }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.PACKAGE_USER }}
+          password: ${{ secrets.PACKAGE_TOKEN }}
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: ghcr.io/vdaas/vald/vald-binfmt:nightly
+          platforms: linux/arm64
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+          platforms: linux/arm64
+          driver-opts: |
+            image=ghcr.io/vdaas/vald/vald-buildkit:nightly
+            network=host
+          buildkitd-flags: "--debug --oci-worker-gc=false --oci-worker-snapshotter=stargz"
+      - name: Build and Publish
+        id: build_and_publish
+        uses: ./.github/actions/docker-build
+        with:
+          target: ${{ inputs.target }}
+          platform: linux/arm64
+          builder: ${{ steps.buildx.outputs.name }}
+      - name: Scan the Docker image
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: ./.github/actions/scan-docker-image
+        with:
+          image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-arm64"
+      - id: set-digest
+        run: |
+          REF="${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-arm64"
+          digest=$(docker buildx imagetools inspect --raw "$REF" \
+ | jq -r '.manifests[]? | select(.platform.os=="linux" and .platform.architecture=="arm64") | .digest')
+          echo "digest=${digest}" >> $GITHUB_OUTPUT
+
+  unify:
+    needs: [build-amd64, build-arm64]
+    if: ${{ always() && (needs.build-amd64.result == 'success' || needs.build-arm64.result == 'success') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASS }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.PACKAGE_USER }}
+          password: ${{ secrets.PACKAGE_TOKEN }}
       - name: Unify multiple platforms
         run: |
+          image_name=`make docker/name/${TARGET}`
           alter_org=`make docker/name/org/alter`
-          alter_image_name=`make ORG="${alter_org}" docker/name/${{ inputs.target }}`
-          # Append images to the unified tag, create a new one if not exists
-          (docker buildx imagetools create --append \
-            --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
-            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
-          docker buildx imagetools create --append \
-            --tag "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
-            "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}") || \
-          (docker buildx imagetools create \
-            --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
-            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
+          alter_image_name=`make ORG="${alter_org}" docker/name/${TARGET}`
+          echo "IMAGE_NAME is: ${image_name}"
+          echo "ALTER_IMAGE_NAME is: ${alter_image_name}"
+          echo "IMAGE_NAME=${image_name}" >> $GITHUB_OUTPUT
+          echo "ALTER_IMAGE_NAME=${alter_image_name}" >> $GITHUB_OUTPUT
+
+          AMD="${{ needs.build-amd64.outputs.digest }}"
+          ARM="${{ needs.build-arm64.outputs.digest }}"
+          refs=""
+          alter_refs=""
+          [ -n "$AMD" ] && \
+            refs="$image_name@$AMD" && \
+            alter_refs="$alter_image_name@$AMD"
+          [ -n "$ARM" ] && \
+            refs="$refs $image_name@$ARM" && \
+            alter_refs="$alter_refs $alter_image_name@$ARM"
+
           docker buildx imagetools create \
-            --tag "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
-            "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}")
+            --tag "$image_name:${{ needs.build-amd64.outputs.primary_tag }}" \
+            $refs
+          docker buildx imagetools create \
+            --tag "$alter_image_name:${{ needs.build-amd64.outputs.primary_tag }}" \
+            $alter_refs
 
   slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -275,7 +275,7 @@ jobs:
 
   slack:
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [unify]
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4

--- a/Makefile.d/docker.mk
+++ b/Makefile.d/docker.mk
@@ -101,6 +101,7 @@ ifeq ($(REMOTE),true)
 		--build-arg GO_VERSION=$(GO_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg MAINTAINER=$(MAINTAINER) \
+		--attest type=sbom,generator=$(DEFAULT_BUILDKIT_SYFT_SCANNER_IMAGE) \
 		--provenance=mode=max \
 		-t $(CRORG)/$(IMAGE):$(TAG) \
 		-t $(GHCRORG)/$(IMAGE):$(TAG) \

--- a/Makefile.d/docker.mk
+++ b/Makefile.d/docker.mk
@@ -101,7 +101,6 @@ ifeq ($(REMOTE),true)
 		--build-arg GO_VERSION=$(GO_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg MAINTAINER=$(MAINTAINER) \
-		--attest type=sbom,generator=$(DEFAULT_BUILDKIT_SYFT_SCANNER_IMAGE) \
 		--provenance=mode=max \
 		-t $(CRORG)/$(IMAGE):$(TAG) \
 		-t $(GHCRORG)/$(IMAGE):$(TAG) \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

Hotfix for the main CI

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.17
- Go Version: v1.24.5
- Rust Version: v1.88.0
- Docker Version: v28.3.2
- Kubernetes Version: v1.33.3
- Helm Version: v3.18.4
- NGT Version: v2.4.3
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Split image build into separate amd64 and arm64 jobs, then unify per-arch outputs into a single multi-arch manifest for consistent tags and pulls.

* **Chores**
  * Tightened CI gating to approved events and specific branches/tags/schedules.
  * Added per-architecture image scanning, digest export, and adjusted platform targeting.
  * Slack notifications now follow the unify step.
  * Disabled SBOM attestation for remote Docker builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->