### PR TITLE
hotfix: Use extra tags to push nightly

### DIFF
--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -263,7 +263,7 @@ jobs:
 
           docker buildx imagetools create \
             --tag "$image_name:${{ needs.build-amd64.outputs.primary_tag }}" \
-            ${{ needs.build-amd64.outputs.extra_tags }}" \
+            ${{ needs.build-amd64.outputs.extra_tags }} \
             $refs
 
   slack:

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -104,6 +104,7 @@ jobs:
     outputs:
       digest: ${{ steps.set-digest.outputs.digest }}
       primary_tag: ${{ steps.build_and_publish.outputs.PRIMARY_TAG }}
+      extra_tags: ${{ steps.build_and_publish.outputs.EXTRA_TAGS }}
     steps:
       - name: Get ref
         id: ref
@@ -251,30 +252,19 @@ jobs:
           TARGET: ${{ inputs.target }}
         run: |
           image_name=`make docker/name/${TARGET}`
-          alter_org=`make docker/name/org/alter`
-          alter_image_name=`make ORG="${alter_org}" docker/name/${TARGET}`
           echo "IMAGE_NAME is: ${image_name}"
-          echo "ALTER_IMAGE_NAME is: ${alter_image_name}"
           echo "IMAGE_NAME=${image_name}" >> $GITHUB_OUTPUT
-          echo "ALTER_IMAGE_NAME=${alter_image_name}" >> $GITHUB_OUTPUT
 
           AMD="${{ needs.build-amd64.outputs.digest }}"
           ARM="${{ needs.build-arm64.outputs.digest }}"
           refs=""
-          alter_refs=""
-          [ -n "$AMD" ] && \
-            refs="$image_name@$AMD" && \
-            alter_refs="$alter_image_name@$AMD"
-          [ -n "$ARM" ] && \
-            refs="$refs $image_name@$ARM" && \
-            alter_refs="$alter_refs $alter_image_name@$ARM"
+          [ -n "$AMD" ] && refs="$image_name@$AMD"
+          [ -n "$ARM" ] && refs="$refs $image_name@$ARM"
 
           docker buildx imagetools create \
             --tag "$image_name:${{ needs.build-amd64.outputs.primary_tag }}" \
+            ${{ needs.build-amd64.outputs.extra_tags }}" \
             $refs
-          docker buildx imagetools create \
-            --tag "$alter_image_name:${{ needs.build-amd64.outputs.primary_tag }}" \
-            $alter_refs
 
   slack:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

Currently, vald-buildkit:nightly image is broken and it makes all builds broken.
This is because extra_tags are not pushed including `nightly`.

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.17
- Go Version: v1.24.5
- Rust Version: v1.88.0
- Docker Version: v28.3.2
- Kubernetes Version: v1.33.3
- Helm Version: v3.18.4
- NGT Version: v2.4.3
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Published Docker images now include additional tags (exported as workflow outputs) for easier pulling.
- Chores
  - Simplified multi-architecture image publishing into a single primary image.
  - Removed alternate-image path and related outputs to reduce duplication.
  - Consolidated AMD/ARM reference construction and updated image creation to always include extra tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->