### PR TITLE
revert: Platform Separation

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -24,9 +24,9 @@ inputs:
     description: "Buildx builder name"
     required: true
     default: ""
-  platform:
-    description: "Build platform"
-    required: true
+  platforms:
+    description: "If it is specified, specified platforms will be used."
+    required: false
     default: ""
 outputs:
   IMAGE_NAME:
@@ -38,6 +38,9 @@ outputs:
   PRIMARY_TAG:
     description: "Primary tag"
     value: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
+  PLATFORMS:
+    description: "Target platforms"
+    value: ${{ steps.determine_platforms.outputs.PLATFORMS }}
   EXTRA_TAGS:
     description: "Extra tags"
     value: ${{ steps.add_extra_tags.outputs.EXTRA_TAGS }}
@@ -60,6 +63,28 @@ runs:
     - name: Determine tag name
       id: determine_tag_name
       uses: ./.github/actions/determine-docker-image-tag
+    - name: Determine platforms
+      shell: bash
+      id: determine_platforms
+      run: |
+        if [ "${TARGET_PLATFORMS}" = "" ]; then
+          if [[ "$GITHUB_REF" =~ ^refs/heads/main$ ]] || [[ "$GITHUB_REF" =~ ^refs/heads/master$ ]] || [[ "$GITHUB_REF" =~ ^refs/heads/release.* ]] || [[ "${PRIMARY_TAG}" == "nightly" ]]; then
+            platforms=`make docker/platforms`
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            platforms="linux/amd64"
+          elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            platforms="linux/amd64"
+          else
+            platforms=`make docker/platforms`
+          fi
+        else
+          platforms="${TARGET_PLATFORMS}"
+        fi
+        echo "PLATFORMS is determined: ${platforms}"
+        echo "PLATFORMS=${platforms}" >> $GITHUB_OUTPUT
+      env:
+        TARGET_PLATFORMS: ${{ inputs.platforms }}
+        PRIMARY_TAG: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
     - name: Update Vald version
       shell: bash
       run: echo "${PRIMARY_TAG}" > versions/VALD_VERSION
@@ -88,17 +113,18 @@ runs:
           REMOTE="true" \
           DOCKER="docker" \
           BUILDKIT_INLINE_CACHE=0 \
-          DOCKER_OPTS="--platform ${{ inputs.platform }} --builder ${BUILDER} ${LABEL_OPTS} \
+          DOCKER_OPTS="--platform ${PLATFORMS} --builder ${BUILDER} ${LABEL_OPTS} \
           --label org.opencontainers.image.version=${PRIMARY_TAG} \
           --label org.opencontainers.image.title=${TARGET} \
           --label org.opencontainers.image.created=\"$(date --rfc-3339=ns)\" \
           --label org.opencontainers.image.licenses=\"Apache 2.0\"" \
           EXTRA_ARGS="${EXTRA_TAGS}" \
-          TAG="${PRIMARY_TAG}-${{ contains(inputs.platform, 'arm64') && 'arm64' || 'amd64' }}" \
+          TAG="${PRIMARY_TAG}" \
           docker/build/${TARGET}
       env:
         TARGET: ${{ inputs.target }}
         DOCKER_BUILDKIT: "1"
+        PLATFORMS: ${{ steps.determine_platforms.outputs.PLATFORMS }}
         BUILDER: ${{ inputs.builder }}
         LABEL_OPTS: "--label org.opencontainers.image.url=${{ github.event.repository.html_url }} --label org.opencontainers.image.source=${{ github.event.repository.html_url }} --label org.opencontainers.image.revision=${{ github.sha }}"
         PRIMARY_TAG: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -104,7 +104,6 @@ jobs:
     outputs:
       digest: ${{ steps.set-digest.outputs.digest }}
       primary_tag: ${{ steps.build_and_publish.outputs.PRIMARY_TAG }}
-      extra_tags: ${{ steps.build_and_publish.outputs.EXTRA_TAGS }}
     steps:
       - name: Get ref
         id: ref
@@ -252,19 +251,30 @@ jobs:
           TARGET: ${{ inputs.target }}
         run: |
           image_name=`make docker/name/${TARGET}`
+          alter_org=`make docker/name/org/alter`
+          alter_image_name=`make ORG="${alter_org}" docker/name/${TARGET}`
           echo "IMAGE_NAME is: ${image_name}"
+          echo "ALTER_IMAGE_NAME is: ${alter_image_name}"
           echo "IMAGE_NAME=${image_name}" >> $GITHUB_OUTPUT
+          echo "ALTER_IMAGE_NAME=${alter_image_name}" >> $GITHUB_OUTPUT
 
           AMD="${{ needs.build-amd64.outputs.digest }}"
           ARM="${{ needs.build-arm64.outputs.digest }}"
           refs=""
-          [ -n "$AMD" ] && refs="$image_name@$AMD"
-          [ -n "$ARM" ] && refs="$refs $image_name@$ARM"
+          alter_refs=""
+          [ -n "$AMD" ] && \
+            refs="$image_name@$AMD" && \
+            alter_refs="$alter_image_name@$AMD"
+          [ -n "$ARM" ] && \
+            refs="$refs $image_name@$ARM" && \
+            alter_refs="$alter_refs $alter_image_name@$ARM"
 
           docker buildx imagetools create \
             --tag "$image_name:${{ needs.build-amd64.outputs.primary_tag }}" \
-            ${{ needs.build-amd64.outputs.extra_tags }} \
             $refs
+          docker buildx imagetools create \
+            --tag "$alter_image_name:${{ needs.build-amd64.outputs.primary_tag }}" \
+            $alter_refs
 
   slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -162,18 +162,18 @@ jobs:
           alter_org=`make docker/name/org/alter`
           alter_image_name=`make ORG="${alter_org}" docker/name/${{ inputs.target }}`
           # Append images to the unified tag, create a new one if not exists
-          (docker buildx imagetools create --append \
+          docker buildx imagetools create --append \
             --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
             "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
           docker buildx imagetools create --append \
             --tag "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
-            "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}") || \
-          (docker buildx imagetools create \
+            "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" || \
+          docker buildx imagetools create \
             --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
             "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
           docker buildx imagetools create \
             --tag "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
-            "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}")
+            "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
 
   slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -41,22 +41,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       platforms: ${{ steps.determine_platforms.outputs.result }}
-    if: >-
-      ${{
-        (github.event_name == 'pull_request' &&
-         github.event.pull_request.head.repo.fork == false) ||
-        (github.event.pull_request.head.repo.fork == true &&
-         github.event_name == 'pull_request_target' &&
-         (
-           (github.event.action == 'labeled' && github.event.label.name == 'ci/approved') ||
-           contains(github.event.pull_request.labels.*.name, 'ci/approved')
-         )
-        ) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/v')) ||
-        startsWith(github.ref, 'refs/tags/') ||
-        (github.event_name == 'schedule')
-      }}
     steps:
       - name: Get ref
         id: ref
@@ -95,15 +79,31 @@ jobs:
         env:
           TARGET_PLATFORMS: ${{ inputs.platforms }}
           PRIMARY_TAG: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
-  build-amd64:
+  build:
     runs-on: ubuntu-latest
     needs: setup-matrix
-    if: ${{ contains(fromJson(needs.setup-matrix.outputs.platforms), 'linux/amd64') }}
     permissions:
       packages: write
-    outputs:
-      digest: ${{ steps.set-digest.outputs.digest }}
-      primary_tag: ${{ steps.build_and_publish.outputs.PRIMARY_TAG }}
+    strategy:
+      max-parallel: 1
+      matrix:
+        platform: ${{ fromJson(needs.setup-matrix.outputs.platforms) }}
+    if: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.fork == false) ||
+        (github.event.pull_request.head.repo.fork == true &&
+         github.event_name == 'pull_request_target' &&
+         (
+           (github.event.action == 'labeled' && github.event.label.name == 'ci/approved') ||
+           contains(github.event.pull_request.labels.*.name, 'ci/approved')
+         )
+        ) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/v')) ||
+        startsWith(github.ref, 'refs/tags/') ||
+        (github.event_name == 'schedule')
+      }}
     steps:
       - name: Get ref
         id: ref
@@ -134,13 +134,13 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           image: ghcr.io/vdaas/vald/vald-binfmt:nightly
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
         with:
           version: latest
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           driver-opts: |
             image=ghcr.io/vdaas/vald/vald-buildkit:nightly
             network=host
@@ -150,135 +150,34 @@ jobs:
         uses: ./.github/actions/docker-build
         with:
           target: ${{ inputs.target }}
-          platform: linux/amd64
+          platform: ${{ matrix.platform }}
           builder: ${{ steps.buildx.outputs.name }}
       - name: Scan the Docker image
         if: startsWith(github.ref, 'refs/tags/')
         uses: ./.github/actions/scan-docker-image
         with:
-          image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-amd64"
-      - id: set-digest
-        run: |
-          REF="${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-amd64"
-          digest=$(docker buildx imagetools inspect --raw "$REF" | jq -r '.manifests[]? | select(.platform.os=="linux" and .platform.architecture=="amd64") | .digest')
-          echo "digest=${digest}" >> $GITHUB_OUTPUT
-  build-arm64:
-    runs-on: ubuntu-latest
-    needs: setup-matrix
-    if: ${{ contains(fromJson(needs.setup-matrix.outputs.platforms), 'linux/arm64') }}
-    permissions:
-      packages: write
-    outputs:
-      digest: ${{ steps.set-digest.outputs.digest }}
-    steps:
-      - name: Get ref
-        id: ref
-        run: |
-          if [ "${{ github.event.pull_request.head.sha }}" != "" ]; then
-            echo ref=${{ github.event.pull_request.head.sha }} >> $GITHUB_OUTPUT
-          else
-            echo ref=${{ github.sha }} >> $GITHUB_OUTPUT
-          fi
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.ref.outputs.ref }}
-      - name: Set Git config
-        run: |
-          git config --global --add safe.directory ${GITHUB_WORKSPACE}
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_PASS }}
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.PACKAGE_USER }}
-          password: ${{ secrets.PACKAGE_TOKEN }}
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          image: ghcr.io/vdaas/vald/vald-binfmt:nightly
-          platforms: linux/arm64
-      - name: Setup Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          version: latest
-          platforms: linux/arm64
-          driver-opts: |
-            image=ghcr.io/vdaas/vald/vald-buildkit:nightly
-            network=host
-          buildkitd-flags: "--debug --oci-worker-gc=false --oci-worker-snapshotter=stargz"
-      - name: Build and Publish
-        id: build_and_publish
-        uses: ./.github/actions/docker-build
-        with:
-          target: ${{ inputs.target }}
-          platform: linux/arm64
-          builder: ${{ steps.buildx.outputs.name }}
-      - name: Scan the Docker image
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: ./.github/actions/scan-docker-image
-        with:
-          image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-arm64"
-      - id: set-digest
-        run: |
-          REF="${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-arm64"
-          digest=$(docker buildx imagetools inspect --raw "$REF" | jq -r '.manifests[]? | select(.platform.os=="linux" and .platform.architecture=="arm64") | .digest')
-          echo "digest=${digest}" >> $GITHUB_OUTPUT
-
-  unify:
-    needs: [build-amd64, build-arm64]
-    if: ${{ always() && (needs.build-amd64.result == 'success' || needs.build-arm64.result == 'success') }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_PASS }}
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.PACKAGE_USER }}
-          password: ${{ secrets.PACKAGE_TOKEN }}
+          image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
       - name: Unify multiple platforms
-        env:
-          TARGET: ${{ inputs.target }}
         run: |
-          image_name=`make docker/name/${TARGET}`
           alter_org=`make docker/name/org/alter`
-          alter_image_name=`make ORG="${alter_org}" docker/name/${TARGET}`
-          echo "IMAGE_NAME is: ${image_name}"
-          echo "ALTER_IMAGE_NAME is: ${alter_image_name}"
-          echo "IMAGE_NAME=${image_name}" >> $GITHUB_OUTPUT
-          echo "ALTER_IMAGE_NAME=${alter_image_name}" >> $GITHUB_OUTPUT
-
-          AMD="${{ needs.build-amd64.outputs.digest }}"
-          ARM="${{ needs.build-arm64.outputs.digest }}"
-          refs=""
-          alter_refs=""
-          [ -n "$AMD" ] && \
-            refs="$image_name@$AMD" && \
-            alter_refs="$alter_image_name@$AMD"
-          [ -n "$ARM" ] && \
-            refs="$refs $image_name@$ARM" && \
-            alter_refs="$alter_refs $alter_image_name@$ARM"
-
+          alter_image_name=`make ORG="${alter_org}" docker/name/${{ inputs.target }}`
+          # Append images to the unified tag, create a new one if not exists
+          (docker buildx imagetools create --append \
+            --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
+            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
+          docker buildx imagetools create --append \
+            --tag "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
+            "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}") || \
+          (docker buildx imagetools create \
+            --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
+            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
           docker buildx imagetools create \
-            --tag "$image_name:${{ needs.build-amd64.outputs.primary_tag }}" \
-            $refs
-          docker buildx imagetools create \
-            --tag "$alter_image_name:${{ needs.build-amd64.outputs.primary_tag }}" \
-            $alter_refs
+            --tag "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
+            "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}")
 
   slack:
     runs-on: ubuntu-latest
-    needs: [unify]
+    needs: [build]
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_docker-image.yaml
+++ b/.github/workflows/_docker-image.yaml
@@ -37,57 +37,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dump-context
-  setup-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      platforms: ${{ steps.determine_platforms.outputs.result }}
-    steps:
-      - name: Get ref
-        id: ref
-        run: |
-          if [ "${{ github.event.pull_request.head.sha }}" != "" ]; then
-            echo ref=${{ github.event.pull_request.head.sha }} >> $GITHUB_OUTPUT
-          else
-            echo ref=${{ github.sha }} >> $GITHUB_OUTPUT
-          fi
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.ref.outputs.ref }}
-      - name: Determine tag name
-        id: determine_tag_name
-        uses: ./.github/actions/determine-docker-image-tag
-      - name: Determine platforms
-        shell: bash
-        id: determine_platforms
-        run: |
-          if [ "${TARGET_PLATFORMS}" = "" ]; then
-            if [[ "$GITHUB_REF" =~ ^refs/heads/main$ ]] || [[ "$GITHUB_REF" =~ ^refs/heads/master$ ]] || [[ "$GITHUB_REF" =~ ^refs/heads/release.* ]] || [[ "${PRIMARY_TAG}" == "nightly" ]]; then
-              platforms=`make docker/platforms`
-            elif [ "${{ github.event_name }}" = "pull_request" ]; then
-              platforms="linux/amd64"
-            elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
-              platforms="linux/amd64"
-            else
-              platforms=`make docker/platforms`
-            fi
-          else
-            platforms="${TARGET_PLATFORMS}"
-          fi
-          echo "PLATFORMS is determined: ${platforms}"
-          json=$(jq -Rsc '[split(",") | .[] | gsub("\n"; "")]' <<< "$platforms")
-          echo "result=$json" >> $GITHUB_OUTPUT
-        env:
-          TARGET_PLATFORMS: ${{ inputs.platforms }}
-          PRIMARY_TAG: ${{ steps.determine_tag_name.outputs.PRIMARY_TAG }}
   build:
     runs-on: ubuntu-latest
-    needs: setup-matrix
-    permissions:
-      packages: write
-    strategy:
-      max-parallel: 1
-      matrix:
-        platform: ${{ fromJson(needs.setup-matrix.outputs.platforms) }}
     if: >-
       ${{
         (github.event_name == 'pull_request' &&
@@ -134,13 +85,13 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           image: ghcr.io/vdaas/vald/vald-binfmt:nightly
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
         with:
           version: latest
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           driver-opts: |
             image=ghcr.io/vdaas/vald/vald-buildkit:nightly
             network=host
@@ -150,31 +101,13 @@ jobs:
         uses: ./.github/actions/docker-build
         with:
           target: ${{ inputs.target }}
-          platform: ${{ matrix.platform }}
+          platforms: ${{ inputs.platforms }}
           builder: ${{ steps.buildx.outputs.name }}
       - name: Scan the Docker image
         if: startsWith(github.ref, 'refs/tags/')
         uses: ./.github/actions/scan-docker-image
         with:
-          image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
-      - name: Unify multiple platforms
-        run: |
-          alter_org=`make docker/name/org/alter`
-          alter_image_name=`make ORG="${alter_org}" docker/name/${{ inputs.target }}`
-          # Append images to the unified tag, create a new one if not exists
-          docker buildx imagetools create --append \
-            --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
-            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
-          docker buildx imagetools create --append \
-            --tag "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
-            "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" || \
-          docker buildx imagetools create \
-            --tag "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
-            "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}" && \
-          docker buildx imagetools create \
-            --tag "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}" \
-            "$alter_image_name:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}"
-
+          image_ref: "${{ steps.build_and_publish.outputs.IMAGE_NAME }}:${{ steps.build_and_publish.outputs.PRIMARY_TAG }}"
   slack:
     runs-on: ubuntu-latest
     needs: [build]

--- a/Makefile.d/helm.mk
+++ b/Makefile.d/helm.mk
@@ -23,7 +23,7 @@ $(BINDIR)/helm:
 	$(eval DARCH := $(subst aarch64,arm64,$(ARCH)))
 	TAR_NAME=helm-$(HELM_VERSION)-$(OS)-$(subst x86_64,amd64,$(shell echo $(DARCH) | tr '[:upper:]' '[:lower:]')) \
 	    && cd $(TEMP_DIR) \
-	    && curl -fsSL --retry 3 "https://get.helm.sh/$${TAR_NAME}.tar.gz" -o "$(TEMP_DIR)/$${TAR_NAME}" \
+	    && curl -fsSL "https://get.helm.sh/$${TAR_NAME}.tar.gz" -o "$(TEMP_DIR)/$${TAR_NAME}" \
 	    && tar -xzvf "$(TEMP_DIR)/$${TAR_NAME}" --strip=1 \
 	    && mv helm $(BINDIR)/helm
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

- Tried to separate platform builds (arm64/amd64) to make them stable and independent
- but the cost was too much for the unreliable results
- Let's revert all PRs

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.17
- Go Version: v1.24.5
- Rust Version: v1.88.0
- Docker Version: v28.3.2
- Kubernetes Version: v1.33.3
- Helm Version: v3.18.4
- NGT Version: v2.4.3
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Publish multi-architecture Docker images (amd64 and arm64) under a single tag.
  - Action now accepts multiple target platforms and exposes the resolved platforms as an output.

- Changes
  - Image tags no longer include architecture suffixes; a single tag covers all platforms.
  - Platforms are auto-determined when not specified, based on the event context.
  - Unified build pipeline replaces per-architecture builds.

- Chores
  - Simplified CI by removing per-arch digest/scan steps and consolidating jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->