### PR TITLE
add certmanager for monitoring

### DIFF
--- a/Makefile.d/k8s.mk
+++ b/Makefile.d/k8s.mk
@@ -532,6 +532,7 @@ k8s/otel/collector/delete:
 .PHONY: k8s/monitoring/deploy
 ## deploy monitoring stack
 k8s/monitoring/deploy: \
+	k8s/external/cert-manager/deploy \
 	k8s/metrics/jaeger/deploy \
 	k8s/metrics/prometheus/operator/deploy \
 	k8s/metrics/grafana/deploy \
@@ -546,6 +547,7 @@ k8s/monitoring/delete: \
 	k8s/metrics/grafana/delete \
 	k8s/metrics/jaeger/delete \
 	k8s/metrics/prometheus/operator/delete \
+	k8s/external/cert-manager/delete
 
 .PHONY: k8s/e2e/deploy
 ## deploy e2e job


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
This PR enhances the k8s/monitoring/deploy target by adding cert-manager deployment as a prerequisite. With this change, certificate management is ensured to be in place before deploying the monitoring stack (Jaeger, Prometheus, Grafana).

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

### Related Issue
#3203 

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.17
- Go Version: v1.24.5
- Rust Version: v1.88.0
- Docker Version: v28.3.2
- Kubernetes Version: v1.33.3
- Helm Version: v3.18.4
- NGT Version: v2.4.3
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->
