### PR TITLE
investigate revert status.go v1.7.12

### DIFF
--- a/internal/net/grpc/status/status.go
+++ b/internal/net/grpc/status/status.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2019-2025 vdaas.org vald team <vald@vdaas.org>
+// Copyright (C) 2019-2024 vdaas.org vald team <vald@vdaas.org>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // You may not use this file except in compliance with the License.
@@ -14,13 +14,12 @@
 // limitations under the License.
 //
 
+// Package status provides statuses and errors returned by grpc handler functions
 package status
 
 import (
-	"cmp"
 	"context"
-	"slices"
-	"strconv"
+	"os"
 
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/info"
@@ -29,8 +28,6 @@ import (
 	"github.com/vdaas/vald/internal/net/grpc/errdetails"
 	"github.com/vdaas/vald/internal/net/grpc/proto"
 	"github.com/vdaas/vald/internal/net/grpc/types"
-	"github.com/vdaas/vald/internal/os"
-	"github.com/vdaas/vald/internal/strings"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/status"
 )
@@ -44,80 +41,76 @@ func New(c codes.Code, msg string) *Status {
 	return status.New(c, msg)
 }
 
-func Is(err error, code codes.Code) bool {
-	return status.Code(err) == code
-}
-
-func newStatus(code codes.Code, msg string, err error, details ...any) (st *Status) {
+func newStatus(code codes.Code, msg string, err error, details ...interface{}) (st *Status) {
 	st = New(code, msg)
 	return withDetails(st, err, details...)
 }
 
-func WrapWithCanceled(msg string, err error, details ...any) error {
+func WrapWithCanceled(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.Canceled, msg, err, details...).Err()
 }
 
-func WrapWithUnknown(msg string, err error, details ...any) error {
+func WrapWithUnknown(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.Unknown, msg, err, details...).Err()
 }
 
-func WrapWithInvalidArgument(msg string, err error, details ...any) error {
+func WrapWithInvalidArgument(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.InvalidArgument, msg, err, details...).Err()
 }
 
-func WrapWithDeadlineExceeded(msg string, err error, details ...any) error {
+func WrapWithDeadlineExceeded(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.DeadlineExceeded, msg, err, details...).Err()
 }
 
-func WrapWithNotFound(msg string, err error, details ...any) error {
+func WrapWithNotFound(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.NotFound, msg, err, details...).Err()
 }
 
-func WrapWithAlreadyExists(msg string, err error, details ...any) error {
+func WrapWithAlreadyExists(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.AlreadyExists, msg, err, details...).Err()
 }
 
-func WrapWithPermissionDenied(msg string, err error, details ...any) error {
+func WrapWithPermissionDenied(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.PermissionDenied, msg, err, details...).Err()
 }
 
-func WrapWithResourceExhausted(msg string, err error, details ...any) error {
+func WrapWithResourceExhausted(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.ResourceExhausted, msg, err, details...).Err()
 }
 
-func WrapWithFailedPrecondition(msg string, err error, details ...any) error {
+func WrapWithFailedPrecondition(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.FailedPrecondition, msg, err, details...).Err()
 }
 
-func WrapWithAborted(msg string, err error, details ...any) error {
+func WrapWithAborted(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.Aborted, msg, err, details...).Err()
 }
 
-func WrapWithOutOfRange(msg string, err error, details ...any) error {
+func WrapWithOutOfRange(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.OutOfRange, msg, err, details...).Err()
 }
 
-func WrapWithUnimplemented(msg string, err error, details ...any) error {
+func WrapWithUnimplemented(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.Unimplemented, msg, err, details...).Err()
 }
 
-func WrapWithInternal(msg string, err error, details ...any) error {
+func WrapWithInternal(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.Internal, msg, err, details...).Err()
 }
 
-func WrapWithUnavailable(msg string, err error, details ...any) error {
+func WrapWithUnavailable(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.Unavailable, msg, err, details...).Err()
 }
 
-func WrapWithDataLoss(msg string, err error, details ...any) error {
+func WrapWithDataLoss(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.DataLoss, msg, err, details...).Err()
 }
 
-func WrapWithUnauthenticated(msg string, err error, details ...any) error {
+func WrapWithUnauthenticated(msg string, err error, details ...interface{}) error {
 	return newStatus(codes.Unauthenticated, msg, err, details...).Err()
 }
 
-func CreateWithNotFound(msg string, err error, details ...any) *Status {
+func CreateWithNotFound(msg string, err error, details ...interface{}) *Status {
 	return newStatus(codes.NotFound, msg, err, details...)
 }
 
@@ -125,13 +118,11 @@ func Error(code codes.Code, msg string) error {
 	return status.Error(code, msg)
 }
 
-func Errorf(code codes.Code, format string, args ...any) error {
+func Errorf(code codes.Code, format string, args ...interface{}) error {
 	return status.Errorf(code, format, args...)
 }
 
-func ParseError(
-	err error, defaultCode codes.Code, defaultMsg string, details ...any,
-) (st *Status, msg string, rerr error) {
+func ParseError(err error, defaultCode codes.Code, defaultMsg string, details ...interface{}) (st *Status, msg string, rerr error) {
 	if err == nil {
 		st = newStatus(codes.OK, "", nil, details...)
 		msg = st.Message()
@@ -141,7 +132,7 @@ func ParseError(
 	st, ok = FromError(err)
 	if !ok || st == nil {
 		if defaultCode == 0 {
-			defaultCode = codes.Unknown
+			defaultCode = codes.Internal
 		}
 		if len(defaultMsg) == 0 {
 			defaultMsg = "failed to parse gRPC status from error"
@@ -160,18 +151,6 @@ func ParseError(
 			msg = defaultMsg
 		}
 		return st, msg, err
-	}
-
-	switch st.Code() {
-	case codes.Aborted,
-		codes.Canceled,
-		codes.DeadlineExceeded,
-		codes.AlreadyExists,
-		codes.NotFound,
-		codes.OK,
-		codes.Unimplemented:
-		return st, st.Message(), st.Err()
-	default:
 	}
 
 	sst := withDetails(st, err, details...)
@@ -255,532 +234,77 @@ func FromError(err error) (st *Status, ok bool) {
 	}
 }
 
-var hostname = func() (h string) {
-	var err error
-	h, err = os.Hostname()
+func withDetails(st *Status, err error, details ...interface{}) *Status {
+	msgs := make([]proto.MessageV1, 0, 1+len(details)*2)
 	if err != nil {
-		log.Warnf("failed to fetch hostname: %s,\terror: %v", h, err)
-		h = "unknown-host"
-	}
-	return h
-}()
-
-func toProtoMessage(err error, details ...any) (dmap map[string][]proto.Message) {
-	dmap = make(map[string][]proto.Message, len(details)+1)
-	if err != nil {
-		typeName := errdetails.ErrorInfoMessageName
-		dmap[typeName] = []proto.Message{&errdetails.ErrorInfo{
+		msgs = append(msgs, &errdetails.ErrorInfo{
 			Reason: err.Error(),
-			Domain: hostname,
-		}}
+			Domain: func() (hostname string) {
+				var err error
+				hostname, err = os.Hostname()
+				if err != nil {
+					log.Warn("failed to fetch hostname:", err)
+				}
+				return hostname
+			}(),
+		})
 	}
 	for _, detail := range details {
 		if detail == nil {
 			continue
 		}
-		var (
-			typeName string
-			msg      proto.Message
-		)
 		switch v := detail.(type) {
 		case *spb.Status:
 			if v != nil {
-				for _, d := range v.GetDetails() {
-					typeName = d.GetTypeUrl()
-					if typeName != "" {
-						msg = errdetails.AnyToErrorDetail(d)
-						if msg != nil {
-							dm, ok := dmap[typeName]
-							if ok && dm != nil {
-								dmap[typeName] = append(dm, msg)
-							} else {
-								dmap[typeName] = []proto.Message{msg}
-							}
-						}
-					}
-				}
+				msgs = append(msgs, proto.ToMessageV1(v))
 			}
 		case spb.Status:
-			for _, d := range v.GetDetails() {
-				typeName = d.GetTypeUrl()
-				if typeName != "" {
-					msg = errdetails.AnyToErrorDetail(d)
-					if msg != nil {
-						d, ok := dmap[typeName]
-						if ok && d != nil {
-							dmap[typeName] = append(d, msg)
-						} else {
-							dmap[typeName] = []proto.Message{msg}
-						}
-					}
-				}
-			}
+			msgs = append(msgs, proto.ToMessageV1(&v))
 		case *status.Status:
 			if v != nil {
-				for _, d := range v.Proto().GetDetails() {
-					typeName = d.GetTypeUrl()
-					if typeName != "" {
-						msg = errdetails.AnyToErrorDetail(d)
-						if msg != nil {
-							d, ok := dmap[typeName]
-							if ok && d != nil {
-								dmap[typeName] = append(d, msg)
-							} else {
-								dmap[typeName] = []proto.Message{msg}
-							}
-						}
-					}
+				msgs = append(msgs, proto.ToMessageV1(&spb.Status{
+					Code:    v.Proto().GetCode(),
+					Message: v.Message(),
+				}))
+				for _, d := range v.Proto().Details {
+					msgs = append(msgs, proto.ToMessageV1(errdetails.AnyToErrorDetail(d)))
 				}
 			}
 		case status.Status:
-			for _, d := range v.Proto().GetDetails() {
-				typeName = d.GetTypeUrl()
-				if typeName != "" {
-					msg = errdetails.AnyToErrorDetail(d)
-					if msg != nil {
-						d, ok := dmap[typeName]
-						if ok && d != nil {
-							dmap[typeName] = append(d, msg)
-						} else {
-							dmap[typeName] = []proto.Message{msg}
-						}
-					}
-				}
+			msgs = append(msgs, proto.ToMessageV1(&spb.Status{
+				Code:    v.Proto().GetCode(),
+				Message: v.Message(),
+			}))
+			for _, d := range v.Proto().Details {
+				msgs = append(msgs, proto.ToMessageV1(errdetails.AnyToErrorDetail(d)))
 			}
 		case *info.Detail:
 			if v != nil {
-				typeName = errdetails.DebugInfoMessageName
-				msg = errdetails.DebugInfoFromInfoDetail(v)
-				if msg != nil {
-					d, ok := dmap[typeName]
-					if ok && d != nil {
-						dmap[typeName] = append(d, msg)
-					} else {
-						dmap[typeName] = []proto.Message{msg}
-					}
-				}
+				msgs = append(msgs, errdetails.DebugInfoFromInfoDetail(v))
 			}
 		case info.Detail:
-			typeName = errdetails.DebugInfoMessageName
-			msg = errdetails.DebugInfoFromInfoDetail(&v)
-			if msg != nil {
-				d, ok := dmap[typeName]
-				if ok && d != nil {
-					dmap[typeName] = append(d, msg)
-				} else {
-					dmap[typeName] = []proto.Message{msg}
-				}
-			}
+			msgs = append(msgs, errdetails.DebugInfoFromInfoDetail(&v))
 		case *types.Any:
 			if v != nil {
-				typeName = v.GetTypeUrl()
-				msg = errdetails.AnyToErrorDetail(v)
-				if msg != nil {
-					d, ok := dmap[typeName]
-					if ok && d != nil {
-						dmap[typeName] = append(d, msg)
-					} else {
-						dmap[typeName] = []proto.Message{msg}
-					}
-				}
+				msgs = append(msgs, proto.ToMessageV1(errdetails.AnyToErrorDetail(v)))
 			}
 		case types.Any:
-			typeName = v.GetTypeUrl()
-			msg = errdetails.AnyToErrorDetail(&v)
-			if msg != nil {
-				d, ok := dmap[typeName]
-				if ok && d != nil {
-					dmap[typeName] = append(d, msg)
-				} else {
-					dmap[typeName] = []proto.Message{msg}
-				}
-			}
+			msgs = append(msgs, proto.ToMessageV1(errdetails.AnyToErrorDetail(&v)))
 		case *proto.Message:
 			if v != nil {
-				typeName = typeURL(*v)
-				d, ok := dmap[typeName]
-				if ok && d != nil {
-					dmap[typeName] = append(d, *v)
-				} else {
-					dmap[typeName] = []proto.Message{*v}
-				}
+				msgs = append(msgs, proto.ToMessageV1(*v))
 			}
 		case proto.Message:
-			typeName = typeURL(v)
-			d, ok := dmap[typeName]
-			if ok && d != nil {
-				dmap[typeName] = append(d, v)
-			} else {
-				dmap[typeName] = []proto.Message{v}
-			}
+			msgs = append(msgs, proto.ToMessageV1(v))
 		case *proto.MessageV1:
 			if v != nil {
-				msg = proto.ToMessageV2(*v)
-				typeName = typeURL(msg)
-				if msg != nil {
-					d, ok := dmap[typeName]
-					if ok && d != nil {
-						dmap[typeName] = append(d, msg)
-					} else {
-						dmap[typeName] = []proto.Message{msg}
-					}
-				}
+				msgs = append(msgs, *v)
 			}
 		case proto.MessageV1:
-			msg = proto.ToMessageV2(v)
-			typeName = typeURL(msg)
-			if msg != nil {
-				d, ok := dmap[typeName]
-				if ok && d != nil {
-					dmap[typeName] = append(d, msg)
-				} else {
-					dmap[typeName] = []proto.Message{msg}
-				}
-			}
+			msgs = append(msgs, v)
 		}
 	}
-	return dmap
-}
 
-func withDetails(st *Status, err error, details ...any) *Status {
-	if st != nil {
-		if len(st.Details()) == 0 {
-			ds := make([]proto.MessageV1, 0, len(details))
-			for _, msgs := range toProtoMessage(err, details) {
-				for _, msg := range msgs {
-					ds = append(ds, proto.ToMessageV1(msg))
-				}
-			}
-			sst, err := st.WithDetails(ds...)
-			if err != nil {
-				return st
-			}
-			return sst
-
-		}
-		details = append(st.Details(), details...)
-	}
-
-	dmap := toProtoMessage(err, details)
-
-	msgs := make([]proto.MessageV1, 0, len(dmap))
-	visited := make(map[string]bool, len(dmap))
-	for typeName, ds := range dmap {
-		switch typeName {
-		case errdetails.DebugInfoMessageName:
-			m := new(errdetails.DebugInfo)
-			for _, msg := range ds {
-				d, ok := msg.(*errdetails.DebugInfo)
-				if ok && d != nil {
-					key := errdetails.DebugInfoMessageName + d.GetDetail() + strings.Join(d.GetStackEntries(), ",")
-					if !visited[key] {
-						visited[key] = true
-						if m.GetDetail() == "" {
-							m.Detail = d.GetDetail()
-						} else if m.GetDetail() != d.GetDetail() && !strings.Contains(m.GetDetail(), d.GetDetail()) {
-							m.Detail += "\t" + d.GetDetail()
-						}
-						if len(m.GetStackEntries()) < len(d.GetStackEntries()) {
-							m.StackEntries = d.GetStackEntries()
-						}
-					}
-				}
-			}
-			m.Detail = removeDuplicatesFromTSVLine(m.GetDetail())
-			msgs = append(msgs, m)
-		case errdetails.ErrorInfoMessageName:
-			m := new(errdetails.ErrorInfo)
-			for _, msg := range ds {
-				e, ok := msg.(*errdetails.ErrorInfo)
-				if ok && e != nil && !visited[e.GetReason()] {
-					visited[e.GetReason()] = true
-					key := errdetails.ErrorInfoMessageName + e.GetDomain() + e.GetReason()
-					if !visited[key] {
-						visited[key] = true
-						if m.GetDomain() == "" {
-							m.Domain = e.GetDomain()
-						} else if m.GetDomain() != e.GetDomain() && !strings.Contains(m.GetDomain(), e.GetDomain()) {
-							m.Domain += "\t" + e.GetDomain()
-						}
-						if m.GetReason() == "" {
-							m.Reason += e.GetReason()
-						} else if m.GetReason() != e.GetReason() && !strings.Contains(m.GetReason(), e.GetReason()) {
-							m.Reason += "\t" + e.GetReason()
-						}
-						if e.GetMetadata() != nil {
-							if m.GetMetadata() == nil {
-								m.Metadata = e.GetMetadata()
-							} else {
-								m.Metadata = appendM(m.GetMetadata(), e.GetMetadata())
-							}
-						}
-					}
-				}
-			}
-			m.Reason = removeDuplicatesFromTSVLine(m.GetReason())
-			m.Domain = removeDuplicatesFromTSVLine(m.GetDomain())
-			msgs = append(msgs, m)
-		case errdetails.BadRequestMessageName:
-			m := new(errdetails.BadRequest)
-			for _, msg := range ds {
-				b, ok := msg.(*errdetails.BadRequest)
-				if ok && b != nil && b.GetFieldViolations() != nil && !visited[b.String()] {
-					visited[b.String()] = true
-					if m.GetFieldViolations() == nil {
-						m = b
-					} else {
-						m.FieldViolations = append(m.GetFieldViolations(), b.GetFieldViolations()...)
-					}
-				}
-			}
-			slices.SortFunc(m.FieldViolations, func(left, right *errdetails.BadRequestFieldViolation) int {
-				return cmp.Compare(left.GetField(), right.GetField())
-			})
-			m.FieldViolations = slices.CompactFunc(m.GetFieldViolations(), func(left, right *errdetails.BadRequestFieldViolation) bool {
-				return left.GetField() == right.GetField()
-			})
-			msgs = append(msgs, m)
-		case errdetails.BadRequestFieldViolationMessageName:
-			m := new(errdetails.BadRequestFieldViolation)
-			for _, msg := range ds {
-				b, ok := msg.(*errdetails.BadRequestFieldViolation)
-				if ok && b != nil {
-					key := errdetails.BadRequestFieldViolationMessageName + b.GetField() + b.GetDescription()
-					if !visited[key] {
-						visited[key] = true
-						if m.GetField() == "" {
-							m.Field = b.GetField()
-						} else if m.GetField() != b.GetField() && !strings.Contains(m.GetField(), b.GetField()) {
-							m.Field += "\t" + b.GetField()
-						}
-						if m.GetDescription() == "" {
-							m.Description = b.GetDescription()
-						} else if m.GetDescription() != b.GetDescription() && !strings.Contains(m.GetDescription(), b.GetDescription()) {
-							m.Description += "\t" + b.GetDescription()
-						}
-					}
-				}
-			}
-			msgs = append(msgs, m)
-		case errdetails.LocalizedMessageMessageName:
-			m := new(errdetails.LocalizedMessage)
-			for _, msg := range ds {
-				l, ok := msg.(*errdetails.LocalizedMessage)
-				if ok && l != nil {
-					key := errdetails.LocalizedMessageMessageName + l.GetLocale() + l.GetMessage()
-					if !visited[key] {
-						visited[key] = true
-						if m.GetLocale() == "" {
-							m.Locale = l.GetLocale()
-						} else if m.GetLocale() != l.GetLocale() && !strings.Contains(m.GetLocale(), l.GetLocale()) {
-							m.Locale += "\t" + l.GetLocale()
-						}
-						if m.GetMessage() == "" {
-							m.Message = l.GetMessage()
-						} else if m.GetMessage() != l.GetMessage() && !strings.Contains(m.GetMessage(), l.GetMessage()) {
-							m.Message += "\t" + l.GetMessage()
-						}
-					}
-				}
-			}
-			msgs = append(msgs, m)
-		case errdetails.PreconditionFailureMessageName:
-			m := new(errdetails.PreconditionFailure)
-			for _, msg := range ds {
-				p, ok := msg.(*errdetails.PreconditionFailure)
-				if ok && p != nil && p.GetViolations() != nil && !visited[p.String()] {
-					visited[p.String()] = true
-					if m.GetViolations() == nil {
-						m = p
-					} else {
-						m.Violations = append(m.GetViolations(), p.GetViolations()...)
-					}
-				}
-			}
-			slices.SortFunc(m.Violations, func(left, right *errdetails.PreconditionFailureViolation) int {
-				return cmp.Compare(left.GetType(), right.GetType())
-			})
-			m.Violations = slices.CompactFunc(m.GetViolations(), func(left, right *errdetails.PreconditionFailureViolation) bool {
-				return left.GetType() == right.GetType()
-			})
-			msgs = append(msgs, m)
-		case errdetails.PreconditionFailureViolationMessageName:
-			m := new(errdetails.PreconditionFailureViolation)
-			for _, msg := range ds {
-				p, ok := msg.(*errdetails.PreconditionFailureViolation)
-				if ok && p != nil {
-					key := errdetails.PreconditionFailureViolationMessageName + p.GetType() + p.GetSubject() + p.GetDescription()
-					if !visited[key] {
-						visited[key] = true
-						if m.GetType() == "" {
-							m.Type = p.GetType()
-						} else if m.GetType() != p.GetType() && !strings.Contains(m.GetType(), p.GetType()) {
-							m.Type += "\t" + p.GetType()
-						}
-						if m.GetSubject() == "" {
-							m.Subject = p.GetSubject()
-						} else if m.GetSubject() != p.GetSubject() && !strings.Contains(m.GetSubject(), p.GetSubject()) {
-							m.Subject += "\t" + p.GetSubject()
-						}
-						if m.GetDescription() == "" {
-							m.Description = p.GetDescription()
-						} else if m.GetDescription() != p.GetDescription() && !strings.Contains(m.GetDescription(), p.GetDescription()) {
-							m.Description += "\t" + p.GetDescription()
-						}
-					}
-				}
-			}
-			msgs = append(msgs, m)
-		case errdetails.HelpMessageName:
-			m := new(errdetails.Help)
-			for _, msg := range ds {
-				h, ok := msg.(*errdetails.Help)
-				if ok && h != nil && h.GetLinks() != nil && !visited[h.String()] {
-					visited[h.String()] = true
-					if m.GetLinks() == nil {
-						m = h
-					} else {
-						m.Links = append(m.GetLinks(), h.GetLinks()...)
-					}
-				}
-			}
-			slices.SortFunc(m.Links, func(left, right *errdetails.HelpLink) int {
-				return cmp.Compare(left.GetUrl(), right.GetUrl())
-			})
-			m.Links = slices.CompactFunc(m.GetLinks(), func(left, right *errdetails.HelpLink) bool {
-				return left.GetUrl() == right.GetUrl()
-			})
-			msgs = append(msgs, m)
-		case errdetails.HelpLinkMessageName:
-			m := new(errdetails.HelpLink)
-			for _, msg := range ds {
-				h, ok := msg.(*errdetails.HelpLink)
-				if ok && h != nil {
-					key := errdetails.HelpLinkMessageName + h.GetUrl() + h.GetDescription()
-					if !visited[key] {
-						visited[key] = true
-						if m.GetUrl() == "" {
-							m.Url = h.GetUrl()
-						} else if m.GetUrl() != h.GetUrl() && !strings.Contains(m.GetUrl(), h.GetUrl()) {
-							m.Url += "\t" + h.GetUrl()
-						}
-						if m.GetDescription() == "" {
-							m.Description = h.GetDescription()
-						} else if m.GetDescription() != h.GetDescription() && !strings.Contains(m.GetDescription(), h.GetDescription()) {
-							m.Description += "\t" + h.GetDescription()
-						}
-					}
-				}
-			}
-			msgs = append(msgs, m)
-		case errdetails.QuotaFailureMessageName:
-			m := new(errdetails.QuotaFailure)
-			for _, msg := range ds {
-				q, ok := msg.(*errdetails.QuotaFailure)
-				if ok && q != nil && q.GetViolations() != nil && !visited[q.String()] {
-					visited[q.String()] = true
-					if m.GetViolations() == nil {
-						m = q
-					} else {
-						m.Violations = append(m.GetViolations(), q.GetViolations()...)
-					}
-				}
-			}
-			slices.SortFunc(m.Violations, func(left, right *errdetails.QuotaFailureViolation) int {
-				return cmp.Compare(left.GetSubject(), right.GetSubject())
-			})
-			m.Violations = slices.CompactFunc(m.GetViolations(), func(left, right *errdetails.QuotaFailureViolation) bool {
-				return left.GetSubject() == right.GetSubject()
-			})
-			msgs = append(msgs, m)
-		case errdetails.QuotaFailureViolationMessageName:
-			m := new(errdetails.QuotaFailureViolation)
-			for _, msg := range ds {
-				q, ok := msg.(*errdetails.QuotaFailureViolation)
-				if ok && q != nil {
-					key := errdetails.QuotaFailureViolationMessageName + q.GetSubject() + q.GetDescription()
-					if !visited[key] {
-						visited[key] = true
-						if m.GetSubject() == "" {
-							m.Subject = q.GetSubject()
-						} else if m.GetSubject() != q.GetSubject() && !strings.Contains(m.GetSubject(), q.GetSubject()) {
-							m.Subject += "\t" + q.GetSubject()
-						}
-						if m.GetDescription() == "" {
-							m.Description = q.GetDescription()
-						} else if m.GetDescription() != q.GetDescription() && !strings.Contains(m.GetDescription(), q.GetDescription()) {
-							m.Description += "\t" + q.GetDescription()
-						}
-					}
-				}
-			}
-			msgs = append(msgs, m)
-		case errdetails.RequestInfoMessageName:
-			m := new(errdetails.RequestInfo)
-			for _, msg := range ds {
-				r, ok := msg.(*errdetails.RequestInfo)
-				if ok && r != nil {
-					key := errdetails.RequestInfoMessageName + r.GetRequestId() + r.GetServingData()
-					if !visited[key] {
-						visited[key] = true
-						if m.GetRequestId() == "" {
-							m.RequestId = r.GetRequestId()
-						} else if m.GetRequestId() != r.GetRequestId() && !strings.Contains(m.GetRequestId(), r.GetRequestId()) {
-							m.RequestId += "\t" + r.GetRequestId()
-						}
-						if m.GetServingData() == "" {
-							m.ServingData = r.GetServingData()
-						} else if m.GetServingData() != r.GetServingData() && !strings.Contains(m.GetServingData(), r.GetServingData()) {
-							m.ServingData += "\t" + r.GetServingData()
-						}
-					}
-				}
-			}
-			msgs = append(msgs, m)
-		case errdetails.ResourceInfoMessageName:
-			m := new(errdetails.ResourceInfo)
-			for _, msg := range ds {
-				r, ok := msg.(*errdetails.ResourceInfo)
-				if ok && r != nil {
-					key := errdetails.ResourceInfoMessageName + r.GetResourceType() + r.GetResourceName() + r.GetDescription()
-					if !visited[key] {
-						visited[key] = true
-						if m.GetResourceType() == "" {
-							m.ResourceType = r.GetResourceType()
-						} else if m.GetResourceType() != r.GetResourceType() && len(m.GetResourceType()) < len(r.GetResourceType()) {
-							m.ResourceType += r.GetResourceType()
-						}
-						if m.GetResourceName() == "" {
-							m.ResourceName = r.GetResourceName()
-						} else if m.GetResourceName() != r.GetResourceName() && !strings.Contains(m.GetResourceName(), r.GetResourceName()) {
-							m.ResourceName += "\t" + r.GetResourceName()
-						}
-						if m.GetDescription() == "" {
-							m.Description = r.GetDescription()
-						} else if m.GetDescription() != r.GetDescription() && !strings.Contains(m.GetDescription(), r.GetDescription()) {
-							m.Description += "\t" + r.GetDescription()
-						}
-					}
-				}
-			}
-			msgs = append(msgs, m)
-		case errdetails.RetryInfoMessageName:
-			m := new(errdetails.RetryInfo)
-			for _, msg := range ds {
-				r, ok := msg.(*errdetails.RetryInfo)
-				if ok && r != nil {
-					key := errdetails.RetryInfoMessageName + strconv.FormatInt(r.GetRetryDelay().GetSeconds(), 10) + strconv.FormatInt(int64(r.GetRetryDelay().GetNanos()), 10)
-					if !visited[key] {
-						visited[key] = true
-						if m.GetRetryDelay() == nil || r.GetRetryDelay().GetSeconds() < m.GetRetryDelay().GetSeconds() {
-							m.RetryDelay = r.GetRetryDelay()
-						}
-					}
-				}
-			}
-			msgs = append(msgs, m)
-		}
-	}
 	if st == nil {
 		if err != nil {
 			st = New(codes.Unknown, err.Error())
@@ -788,78 +312,19 @@ func withDetails(st *Status, err error, details ...any) *Status {
 			st = New(codes.Unknown, "")
 		}
 	}
-	if msgs != nil {
-		sst, err := status.New(st.Code(), st.Message()).WithDetails(msgs...)
-		if err == nil {
+
+	if len(msgs) != 0 {
+		sst, err := st.WithDetails(msgs...)
+		if err == nil && sst != nil {
 			st = sst
+		} else {
+			log.Warn("failed to set error details:", err)
 		}
 	}
+
 	Log(st.Code(), st.Err())
+
 	return st
-}
-
-func typeURL(msg proto.Message) string {
-	switch msg.(type) {
-	case *errdetails.DebugInfo:
-		return errdetails.DebugInfoMessageName
-	case *errdetails.ErrorInfo:
-		return errdetails.ErrorInfoMessageName
-	case *errdetails.BadRequest:
-		return errdetails.BadRequestMessageName
-	case *errdetails.BadRequestFieldViolation:
-		return errdetails.BadRequestFieldViolationMessageName
-	case *errdetails.LocalizedMessage:
-		return errdetails.LocalizedMessageMessageName
-	case *errdetails.PreconditionFailure:
-		return errdetails.PreconditionFailureMessageName
-	case *errdetails.PreconditionFailureViolation:
-		return errdetails.PreconditionFailureViolationMessageName
-	case *errdetails.Help:
-		return errdetails.HelpMessageName
-	case *errdetails.HelpLink:
-		return errdetails.HelpLinkMessageName
-	case *errdetails.QuotaFailure:
-		return errdetails.QuotaFailureMessageName
-	case *errdetails.QuotaFailureViolation:
-		return errdetails.QuotaFailureViolationMessageName
-	case *errdetails.RequestInfo:
-		return errdetails.RequestInfoMessageName
-	case *errdetails.ResourceInfo:
-		return errdetails.ResourceInfoMessageName
-	case *errdetails.RetryInfo:
-		return errdetails.RetryInfoMessageName
-	}
-	return "unknown"
-}
-
-func appendM[K comparable](maps ...map[K]string) (result map[K]string) {
-	if len(maps) == 0 {
-		return nil
-	}
-	result = maps[0]
-	for _, m := range maps[1:] {
-		for k, v := range m {
-			ev, ok := result[k]
-			if ok && v != ev && !strings.Contains(v, ev) {
-				v += "\t" + ev
-			}
-			result[k] = v
-		}
-	}
-	return result
-}
-
-func removeDuplicatesFromTSVLine(line string) string {
-	fields := strings.Split(line, "\t")
-	uniqueFields := make(map[string]bool)
-	result := make([]string, 0, len(fields))
-	for _, field := range fields {
-		if !uniqueFields[field] {
-			uniqueFields[field] = true
-			result = append(result, field)
-		}
-	}
-	return strings.Join(result, "\t")
 }
 
 func Log(code codes.Code, err error) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

- SSIA
<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.17
- Go Version: v1.24.5
- Rust Version: v1.88.0
- Docker Version: v28.3.2
- Kubernetes Version: v1.33.3
- Helm Version: v3.18.4
- NGT Version: v2.4.3
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - More consistent, structured error details for clearer messages.
  - Hostname is now included directly in error details when available.
  - Logging reorganized by status code for clearer, level-appropriate output.

- Bug Fixes
  - Unparsable errors now default to “Internal” instead of “Unknown,” reducing ambiguity.

- Documentation
  - Added package-level documentation for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->