### PR TITLE
hotfix: ARM64 dev-container build

### DIFF
--- a/dockers/dev/Dockerfile
+++ b/dockers/dev/Dockerfile
@@ -114,6 +114,7 @@ RUN --mount=type=bind,target=.,rw \
     && make gotests/install \
     && make impl/install \
     && make staticcheck/install \
+    && update-ca-certificates \
     && make GOARCH=${TARGETARCH} GOOS=${TARGETOS} deps GO_CLEAN_DEPS=false \
     && make GOARCH=${TARGETARCH} GOOS=${TARGETOS} golangci-lint/install \
     && make GOARCH=${TARGETARCH} GOOS=${TARGETOS} gotestfmt/install \

--- a/hack/docker/gen/main.go
+++ b/hack/docker/gen/main.go
@@ -527,6 +527,7 @@ var (
 		"make gotests/install",
 		"make impl/install",
 		"make staticcheck/install",
+		"update-ca-certificates",
 	}
 )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

SSIA

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

#3191

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.17
- Go Version: v1.24.5
- Rust Version: v1.88.0
- Docker Version: v28.3.2
- Kubernetes Version: v1.33.3
- Helm Version: v3.18.4
- NGT Version: v2.4.3
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->

Confirmed ARM64 dev-container build
https://github.com/vdaas/vald/actions/runs/17638690577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Development container now refreshes CA certificates during build to maintain an up-to-date certificate store.
  * Enhances reliability of tools and dependency fetching over HTTPS within the dev environment.
  * No changes to application features or behavior; end users are unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->