### PR TITLE
Use context.Background for Disconnect

### DIFF
--- a/internal/net/grpc/pool/pool.go
+++ b/internal/net/grpc/pool/pool.go
@@ -529,7 +529,8 @@ func (p *pool) Reconnect(ctx context.Context, force bool) (Conn, error) {
 }
 
 // Disconnect gracefully closes all connections in the pool.
-func (p *pool) Disconnect(ctx context.Context) (err error) {
+func (p *pool) Disconnect(_ context.Context) (err error) {
+	ctx := context.Background()
 	log.Warn("Disconnecting pool...")
 	p.closing.Store(true)
 	defer p.closing.Store(false)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.17
- Go Version: v1.24.5
- Rust Version: v1.88.0
- Docker Version: v28.3.2
- Kubernetes Version: v1.33.3
- Helm Version: v3.18.4
- NGT Version: v2.4.3
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of disconnect operations by preventing them from being interrupted by timeouts or cancellations, ensuring all connections close and cleanup completes consistently. Reduces sporadic shutdown errors.

* **Refactor**
  * Streamlined disconnect flow for more predictable shutdown behavior and improved stability across varying network conditions. No changes required for existing usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->