### PR TITLE
hotfix: Revert pool.go related files

### DIFF
--- a/internal/net/grpc/client.go
+++ b/internal/net/grpc/client.go
@@ -1127,7 +1127,7 @@ func (g *gRPCClient) Disconnect(ctx context.Context, addr string) error {
 		atomic.AddUint64(&g.clientCount, ^uint64(0))
 	}
 	log.Debugf("gRPC %s connection pool addr = %s will disconnect soon...", g.name, addr)
-	err := p.Disconnect(ctx)
+	err := p.Disconnect()
 	if err != nil {
 		if span != nil {
 			span.RecordError(err)

--- a/internal/net/grpc/pool/option.go
+++ b/internal/net/grpc/pool/option.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2019-2025 vdaas.org vald team <vald@vdaas.org>
+// Copyright (C) 2019-2024 vdaas.org vald team <vald@vdaas.org>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // You may not use this file except in compliance with the License.
@@ -14,144 +14,138 @@
 // limitations under the License.
 //
 
+// Package pool provides gRPC connection pool client
 package pool
 
 import (
 	"github.com/vdaas/vald/internal/backoff"
-	"github.com/vdaas/vald/internal/net"
 	"github.com/vdaas/vald/internal/sync/errgroup"
 	"github.com/vdaas/vald/internal/timeutil"
 )
 
-// Option defines a functional option for configuring the pool.
 type Option func(*pool)
 
-// Default options.
 var defaultOptions = []Option{
 	WithSize(defaultPoolSize),
 	WithStartPort(80),
 	WithEndPort(65535),
 	WithErrGroup(errgroup.Get()),
 	WithDialTimeout("1s"),
-	WithOldConnCloseDelay("2m"),
+	WithOldConnCloseDuration("2m"),
 	WithResolveDNS(true),
 }
 
-// WithAddr sets the target address. It also extracts the host and port.
 func WithAddr(addr string) Option {
 	return func(p *pool) {
-		if addr == "" {
+		if len(addr) == 0 {
 			return
 		}
 		p.addr = addr
-		var err error
-		// Attempt to split host and port.
-		if p.host, p.port, err = net.SplitHostPort(addr); err != nil {
-			p.host = addr
-		}
 	}
 }
 
-// WithHost sets the target host.
 func WithHost(host string) Option {
 	return func(p *pool) {
-		if host != "" {
-			p.host = host
+		if len(host) == 0 {
+			return
 		}
+		p.host = host
 	}
 }
 
-// WithPort sets the target port.
 func WithPort(port int) Option {
 	return func(p *pool) {
 		if port > 0 {
-			p.port = uint16(port)
+			return
 		}
+		p.port = uint16(port)
 	}
 }
 
-// WithStartPort sets the starting port for scanning.
 func WithStartPort(port int) Option {
 	return func(p *pool) {
 		if port > 0 {
-			p.startPort = uint16(port)
+			return
 		}
+		p.startPort = uint16(port)
 	}
 }
 
-// WithEndPort sets the ending port for scanning.
 func WithEndPort(port int) Option {
 	return func(p *pool) {
 		if port > 0 {
-			p.endPort = uint16(port)
+			return
 		}
+		p.endPort = uint16(port)
 	}
 }
 
-// WithResolveDNS enables or disables DNS resolution.
-func WithResolveDNS(enable bool) Option {
+func WithResolveDNS(flg bool) Option {
 	return func(p *pool) {
-		p.enableDNSLookup = enable
+		p.resolveDNS = flg
 	}
 }
 
-// WithBackoff sets the backoff strategy.
 func WithBackoff(bo backoff.Backoff) Option {
 	return func(p *pool) {
 		if bo != nil {
-			p.bo = bo
+			return
 		}
+		p.bo = bo
 	}
 }
 
-// WithSize sets the pool size.
 func WithSize(size uint64) Option {
 	return func(p *pool) {
 		if size < 1 {
 			return
 		}
-		p.poolSize.Store(size)
+		p.size.Store(size)
 	}
 }
 
-// WithDialOptions appends gRPC dial options.
 func WithDialOptions(opts ...DialOption) Option {
 	return func(p *pool) {
 		if len(opts) > 0 {
-			p.dialOpts = append(p.dialOpts, opts...)
+			if len(p.dopts) > 0 {
+				p.dopts = append(p.dopts, opts...)
+			} else {
+				p.dopts = opts
+			}
 		}
 	}
 }
 
-// WithDialTimeout sets the dial timeout duration.
 func WithDialTimeout(dur string) Option {
 	return func(p *pool) {
-		if dur == "" {
+		if len(dur) == 0 {
 			return
 		}
-		if t, err := timeutil.Parse(dur); err == nil {
-			p.dialTimeout = t
+		d, err := timeutil.Parse(dur)
+		if err != nil {
+			return
 		}
+		p.dialTimeout = d
 	}
 }
 
-// WithOldConnCloseDelay sets the delay before closing old connections.
-func WithOldConnCloseDelay(dur string) Option {
+func WithOldConnCloseDuration(dur string) Option {
 	return func(p *pool) {
-		if dur == "" {
+		if len(dur) == 0 {
 			return
 		}
-		if t, err := timeutil.Parse(dur); err == nil {
-			p.oldConnCloseDelay = t
+		d, err := timeutil.Parse(dur)
+		if err != nil {
+			return
 		}
+		p.roccd = d
 	}
 }
 
-// WithErrGroup sets the errgroup for goroutine management.
 func WithErrGroup(eg errgroup.Group) Option {
 	return func(p *pool) {
 		if eg != nil {
-			p.errGroup = eg
+			p.eg = eg
 		}
 	}
 }

--- a/internal/net/grpc/pool/pool.go
+++ b/internal/net/grpc/pool/pool.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2019-2025 vdaas.org vald team <vald@vdaas.org>
+// Copyright (C) 2019-2024 vdaas.org vald team <vald@vdaas.org>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // You may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
 // limitations under the License.
 //
 
-// This re-implementation maintains the public Conn interface unchanged while
-// using atomic operations for efficient, lock-free connection management.
-// Additional features such as DNS lookup, port scanning, and metrics collection are incorporated.
+// Package pool provides gRPC connection pool client
 package pool
 
 import (
 	"context"
 	"fmt"
+	"math"
+	"slices"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -30,6 +30,7 @@ import (
 	"github.com/vdaas/vald/internal/errors"
 	"github.com/vdaas/vald/internal/log"
 	"github.com/vdaas/vald/internal/net"
+	"github.com/vdaas/vald/internal/safety"
 	"github.com/vdaas/vald/internal/strings"
 	"github.com/vdaas/vald/internal/sync"
 	"github.com/vdaas/vald/internal/sync/errgroup"
@@ -37,171 +38,88 @@ import (
 	"google.golang.org/grpc/connectivity"
 )
 
-// Alias types for clarity.
 type (
 	ClientConn = grpc.ClientConn
 	DialOption = grpc.DialOption
 )
 
-// Conn defines the interface for a gRPC connection pool.
 type Conn interface {
-	// Connect establishes connections for all slots.
 	Connect(context.Context) (Conn, error)
-	// Disconnect gracefully closes all connections in the pool.
-	Disconnect(context.Context) error
-	// Do executes the provided function using a healthy connection.
-	Do(context.Context, func(*ClientConn) error) error
-	// Get returns a healthy connection from the pool, if available.
-	Get(context.Context) (*ClientConn, bool)
-	// IsHealthy checks the overall health of the pool.
+	Disconnect() error
+	Do(ctx context.Context, f func(*ClientConn) error) error
+	Get(ctx context.Context) (conn *ClientConn, ok bool)
 	IsHealthy(context.Context) bool
-	// IsIPConn indicates whether the pool is using direct IP connections.
 	IsIPConn() bool
-	// Len returns the number of connection slots.
 	Len() uint64
-	// Size returns the configured pool size.
 	Size() uint64
-	// Reconnect re-establishes connections if the pool is unhealthy or if forced.
-	Reconnect(context.Context, bool) (Conn, error)
-	// String returns a string representation of the pool's state.
+	Reconnect(ctx context.Context, force bool) (Conn, error)
 	String() string
 }
 
-// poolConn wraps a single gRPC connection and its target address.
 type poolConn struct {
-	conn *ClientConn // Underlying gRPC connection.
-	addr string      // Target address used for dialing this connection.
+	conn *ClientConn
+	addr string
 }
 
-// Close gracefully closes the connection with the specified delay.
-// It periodically checks the connection state until either the connection is closed or the delay elapses.
-func (pc *poolConn) Close(ctx context.Context, delay time.Duration) error {
-	// Determine the ticker interval (at least 5ms, at most 5s).
-	interval := delay / 10
-	if interval < 5*time.Millisecond {
-		interval = 5 * time.Millisecond
-	} else if interval > time.Minute {
-		interval = 5 * time.Second
-	}
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	// Create a context with timeout to ensure closure does not hang indefinitely.
-	ctx, cancel := context.WithTimeout(ctx, delay)
-	defer cancel()
-
-	log.Debugf("Closing connection for %s with delay %s", pc.addr, delay)
-	for {
-		switch pc.conn.GetState() {
-		case connectivity.Idle, connectivity.Connecting, connectivity.Ready, connectivity.TransientFailure:
-			err := pc.conn.Close()
-			if err != nil {
-				log.Errorf("failed to close gRPC pool connection for %s, error: %v", pc.addr, err)
-			}
-		case connectivity.Shutdown:
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			err := ctx.Err()
-			if errors.IsNot(err, context.DeadlineExceeded, context.Canceled) {
-				return err
-			}
-			return nil
-		case <-ticker.C:
-		}
-	}
-}
-
-// pool implements the Conn interface.
-// It stores connection slots in a lock-free manner using an atomic.Value.
 type pool struct {
-	// connSlots holds a slice of atomic pointers to poolConn.
-	connSlots atomic.Pointer[[]atomic.Pointer[poolConn]] // holds []atomic.Pointer[poolConn]
-
-	// Configuration parameters.
-	startPort       uint16 // Starting port for scanning if needed.
-	endPort         uint16 // Ending port for scanning if needed.
-	host            string // Target host.
-	port            uint16 // Target port.
-	addr            string // Complete address (host:port).
-	isIPAddr        bool   // True if the target is an IP address.
-	enableDNSLookup bool   // Whether to perform DNS resolution.
-
-	// Pool management fields.
-	poolSize     atomic.Uint64 // Configured pool size.
-	currentIndex atomic.Uint64 // Atomic counter for round-robin indexing.
-
-	// gRPC dial options and timeouts.
-	dialOpts          []DialOption
-	dialTimeout       time.Duration // Timeout for dialing a connection.
-	oldConnCloseDelay time.Duration // Delay before closing old connections.
-
-	// Retry/backoff strategy.
-	bo backoff.Backoff
-
-	// Goroutine management.
-	errGroup errgroup.Group
-
-	// Used for DNS change detection during reconnection.
-	dnsHash atomic.Pointer[string]
-
-	// Flag indicating whether the pool is closing.
-	closing atomic.Bool
+	pool          []atomic.Pointer[poolConn]
+	startPort     uint16
+	endPort       uint16
+	host          string
+	port          uint16
+	addr          string
+	size          atomic.Uint64
+	current       atomic.Uint64
+	bo            backoff.Backoff
+	eg            errgroup.Group
+	dopts         []DialOption
+	dialTimeout   time.Duration
+	roccd         time.Duration // reconnection old connection closing duration
+	closing       atomic.Bool
+	pmu           sync.RWMutex
+	isIP          bool
+	resolveDNS    bool
+	reconnectHash atomic.Pointer[string]
 }
 
-// Default pool size.
-const defaultPoolSize = uint64(4)
+const defaultPoolSize = 4
 
-// Global metrics are stored in a sync.Map (key: address, value: healthy connection count).
-var metrics sync.Map[string, uint64]
+func New(ctx context.Context, opts ...Option) (c Conn, err error) {
+	p := new(pool)
 
-// New creates a new connection pool with the provided options.
-// It parses the target address, initializes the connection slots, and performs an initial dial check.
-func New(ctx context.Context, opts ...Option) (Conn, error) {
-	p := &pool{
-		dialTimeout:       time.Second,
-		oldConnCloseDelay: 2 * time.Minute,
-		enableDNSLookup:   false,
-	}
-	// Apply default and user-specified options.
 	for _, opt := range append(defaultOptions, opts...) {
 		opt(p)
 	}
 
-	if p.addr == "" {
-		return nil, errors.Errorf("target address is not provided")
-	}
-
-	// Initialize the connection slots.
-	p.init()
+	p.init(true)
 	p.closing.Store(false)
 
-	// Parse the address to extract host and port.
-	var err error
-	var isIPv4, isIPv6 bool
-	p.host, p.port, _, isIPv4, isIPv6, err = net.Parse(ctx, p.addr)
-	p.isIPAddr = isIPv4 || isIPv6
+	var (
+		isIPv4, isIPv6 bool
+		port           uint16
+	)
+	p.host, p.port, _, isIPv4, isIPv6, err = net.Parse(p.addr)
+	p.isIP = isIPv4 || isIPv6
 	if err != nil {
 		log.Warnf("failed to parse addr %s: %s", p.addr, err)
-		// Fallback: split using Cut.
 		if p.host == "" {
-			p.host, p.port, err = net.SplitHostPort(p.addr)
-			if err != nil {
-				if host, portStr, ok := strings.Cut(p.addr, ":"); ok {
-					p.host = host
-					if portNum, err := strconv.ParseUint(portStr, 10, 16); err == nil {
-						p.port = uint16(portNum)
-					}
-				} else {
-					p.host = p.addr
+			var (
+				ok      bool
+				portStr string
+			)
+			p.host, portStr, ok = strings.Cut(p.addr, ":")
+			if !ok {
+				p.host = p.addr
+			} else {
+				portNum, err := strconv.ParseUint(portStr, 10, 16)
+				if err != nil {
+					p.port = uint16(portNum)
 				}
 			}
 		}
-		// If port is still zero, attempt port scanning.
 		if p.port == 0 {
-			var port uint16
-			if port, err = p.scanGRPCPort(ctx); err != nil {
+			port, err = p.scanGRPCPort(ctx)
+			if err != nil {
 				return nil, err
 			}
 			p.port = port
@@ -209,22 +127,27 @@ func New(ctx context.Context, opts ...Option) (Conn, error) {
 		p.addr = net.JoinHostPort(p.host, p.port)
 	}
 
-	log.Debugf("Initial connection target: %s, host: %s, port: %d, isIP: %t", p.addr, p.host, p.port, p.isIPAddr)
-	conn, err := p.dial(ctx, 0, p.addr)
+	conn, err := grpc.DialContext(ctx, p.addr, p.dopts...)
 	if err != nil {
-		log.Warnf("Initial dial check to %s failed: %v", p.addr, err)
-		var port uint16
-		if port, err = p.scanGRPCPort(ctx); err != nil {
+		log.Warnf("grpc.New initial Dial check to %s returned error: %v", p.addr, err)
+		if conn != nil {
+			err = conn.Close()
+			if err != nil && !errors.Is(err, grpc.ErrClientConnClosing) {
+				log.Warn("failed to close connection:", err)
+			}
+		}
+
+		port, err := p.scanGRPCPort(ctx)
+		if err != nil {
 			return nil, err
 		}
 		p.port = port
 		p.addr = net.JoinHostPort(p.host, p.port)
-		log.Debugf("Fallback target: %s, host: %s, port: %d, isIP: %t", p.addr, p.host, p.port, p.isIPAddr)
-		conn, err = p.dial(ctx, 0, p.addr)
+		conn, err = grpc.DialContext(ctx, p.addr, p.dopts...)
 		if err != nil {
 			if conn != nil {
 				cerr := conn.Close()
-				if cerr != nil {
+				if cerr != nil && !errors.Is(cerr, grpc.ErrClientConnClosing) {
 					return nil, errors.Join(err, cerr)
 				}
 			}
@@ -233,316 +156,300 @@ func New(ctx context.Context, opts ...Option) (Conn, error) {
 	}
 	if conn != nil {
 		err = conn.Close()
-		if err != nil {
+		if err != nil && !errors.Is(err, grpc.ErrClientConnClosing) {
 			return nil, err
 		}
 	}
 
-	if p.errGroup == nil {
-		p.errGroup = errgroup.Get()
+	if p.eg == nil {
+		p.eg = errgroup.Get()
 	}
 
 	return p, nil
 }
 
-// init initializes the connection slots slice using an atomic.Value.
-func (p *pool) init() {
-	size := p.Size()
-	if size < 1 {
-		size = defaultPoolSize
-		p.poolSize.Store(size)
-	}
-	slots := make([]atomic.Pointer[poolConn], size)
-	p.connSlots.Store(&slots)
-}
-
-// getSlots returns the current connection slots slice.
-func (p *pool) getSlots() []atomic.Pointer[poolConn] {
-	if v := p.connSlots.Load(); v != nil && len(*v) > 0 {
-		return *v
-	}
-	return nil
-}
-
-// grow increases the number of connection slots if the new size is larger.
-func (p *pool) grow(newSize uint64) {
-	oldSlots := p.getSlots()
-	newSlots := make([]atomic.Pointer[poolConn], newSize)
-	if oldSlots == nil {
-		p.connSlots.Store(&newSlots)
-		p.poolSize.Store(newSize)
+func (p *pool) init(force bool) {
+	if p == nil {
 		return
 	}
-	currentLen := uint64(len(oldSlots))
-	if currentLen >= newSize {
-		return
+	if p.Size() < 1 {
+		p.size.Store(defaultPoolSize)
 	}
-	copy(newSlots, oldSlots)
-	p.connSlots.Store(&newSlots)
-	p.poolSize.Store(newSize)
+	p.pmu.RLock()
+	if force || p.pool == nil || cap(p.pool) == 0 || len(p.pool) == 0 {
+		p.pmu.RUnlock()
+		p.pmu.Lock()
+		p.pool = make([]atomic.Pointer[poolConn], p.Size())
+		p.pmu.Unlock()
+	} else {
+		p.pmu.RUnlock()
+	}
 }
 
-// load retrieves the poolConn and real index pos at the specified index.
-func (p *pool) load(idx uint64) (ridx uint64, pc *poolConn) {
-	if idx >= p.poolSize.Load() {
-		return 0, nil
-	}
-	slots := p.getSlots()
-	sz := uint64(len(slots))
-	if slots != nil && sz != 0 {
-		if sz < idx {
-			return sz, slots[sz].Load()
-		}
-		return idx, slots[idx].Load()
-	}
-	return 0, nil
-}
-
-// store sets the poolConn at the specified index.
-func (p *pool) store(idx uint64, pc *poolConn) {
-	if idx >= p.poolSize.Load() {
+func (p *pool) grow(size uint64) {
+	if p == nil || p.Size() > size {
 		return
 	}
-	size := p.Size()
-	if size <= idx {
-		size = max(idx+1, defaultPoolSize)
-		p.grow(size)
-	}
-	slots := p.getSlots()
-	if slots == nil {
-		slots = make([]atomic.Pointer[poolConn], size)
-		slots[idx].Store(pc)
-		p.connSlots.Store(&slots)
+	l := p.Len()
+	if l >= size {
 		return
 	}
-	slots[idx].Store(pc)
+	epool := make([]atomic.Pointer[poolConn], size-l) // expand pool
+	log.Debugf("growing pool size %d o %d", l, size)
+	p.pmu.Lock()
+	if uint64(len(p.pool)) != l {
+		epool = make([]atomic.Pointer[poolConn], size-uint64(len(p.pool))) // re-expand pool
+	}
+	p.pool = append(p.pool, epool...)
+	p.pmu.Unlock()
+	p.size.Store(size)
 }
 
-// loop iterates over each connection slot and applies the provided function.
-func (p *pool) loop(
-	ctx context.Context, fn func(ctx context.Context, idx uint64, pc *poolConn) bool,
-) error {
-	var count uint64
-	for idx := range p.poolSize.Load() {
+func (p *pool) load(idx int) (pc *poolConn) {
+	if p == nil {
+		return nil
+	}
+	p.pmu.RLock()
+	if p.pool != nil && p.Size() > uint64(idx) && len(p.pool) > idx {
+		pc = p.pool[idx].Load()
+	}
+	p.pmu.RUnlock()
+	return pc
+}
+
+func (p *pool) store(idx int, pc *poolConn) {
+	if p == nil {
+		return
+	}
+	p.init(false)
+	p.pmu.RLock()
+	if p.pool != nil && p.Size() > uint64(idx) && len(p.pool) > idx {
+		p.pool[idx].Store(pc)
+	}
+	p.pmu.RUnlock()
+}
+
+func (p *pool) loop(ctx context.Context, fn func(ctx context.Context, idx int, pc *poolConn) bool) (err error) {
+	if p == nil || fn == nil {
+		return nil
+	}
+	p.init(false)
+	p.pmu.RLock()
+	defer p.pmu.RUnlock()
+	var cnt int
+	for idx, pool := range p.pool {
 		select {
 		case <-ctx.Done():
-			err := ctx.Err()
-			if errors.IsNot(err, context.DeadlineExceeded, context.Canceled) {
-				return err
-			}
-			return nil
+			return ctx.Err()
 		default:
-			count++
-			ridx, pc := p.load(idx)
-			if !fn(ctx, ridx, pc) {
-				return nil
+			if p.Size() > uint64(idx) && len(p.pool) > idx {
+				cnt++
+				if !fn(ctx, idx, pool.Load()) {
+					return nil
+				}
 			}
 		}
 	}
-	if count == 0 {
+	if cnt == 0 {
 		return errors.ErrGRPCPoolConnectionNotFound
 	}
 	return nil
 }
 
-// slotCount returns the number of connection slots.
-func (p *pool) slotCount() uint64 {
+func (p *pool) len() int {
 	if p == nil {
 		return 0
 	}
-	slots := p.getSlots()
-	if slots == nil {
+	p.pmu.RLock()
+	defer p.pmu.RUnlock()
+	return len(p.pool)
+}
+
+func (p *pool) cap() int {
+	if p == nil {
 		return 0
 	}
-	return uint64(len(slots))
+	p.pmu.RLock()
+	defer p.pmu.RUnlock()
+	return cap(p.pool)
 }
 
-// flush clears the connection slots.
 func (p *pool) flush() {
-	slots := make([]atomic.Pointer[poolConn], p.Size())
-	p.connSlots.Store(&slots)
+	if p == nil {
+		return
+	}
+	p.pmu.Lock()
+	p.pool = nil
+	p.pmu.Unlock()
 }
 
-// refreshConn checks if the connection at slot idx is healthy for the given address.
-// If not, it dials a new connection and updates the slot atomically.
-// It also schedules graceful closure of any existing (old) connection.
-func (p *pool) refreshConn(ctx context.Context, idx uint64, pc *poolConn, addr string) error {
-	if pc != nil {
-		state, healthy := p.isHealthy(idx, pc.conn)
-		if pc.addr == addr && healthy {
-			return nil
-		}
-		log.Debugf("connection for %s pool %d/%d len %d is unhealthy (state: %s) trying to establish new pool member connection to %s",
-			pc.addr, idx+1, p.Size(), p.Len(), state.String(), addr)
-	} else {
-		log.Debugf("connection pool %d/%d len %d is empty, establish new pool member connection to %s", idx+1, p.Size(), p.Len(), addr)
+func (p *pool) refreshConn(ctx context.Context, idx int, pc *poolConn, addr string) (err error) {
+	if pc != nil && pc.addr == addr && isHealthy(ctx, pc.conn) {
+		return nil
 	}
-	newConn, err := p.dial(ctx, idx, addr)
+	if pc != nil {
+		log.Debugf("connection for %s pool %d/%d is unhealthy trying to establish new pool member connection to %s", pc.addr, idx+1, p.Size(), addr)
+	} else {
+		log.Debugf("connection pool %d/%d is empty, establish new pool member connection to %s", idx+1, p.Size(), addr)
+	}
+	conn, err := p.dial(ctx, addr)
 	if err != nil {
 		if pc != nil {
-			state, healthy := p.isHealthy(idx, pc.conn)
-			if healthy {
+			if isHealthy(ctx, pc.conn) {
+				log.Debugf("dialing new connection to %s failed,\terror: %v,\tbut existing connection to %s is healthy will keep existing connection", addr, err, pc.addr)
 				return nil
 			}
-			log.Debugf("re-dialed connection for %s pool %d/%d len %d is still unhealthy (state: %s) going to close connection for %s",
-				pc.addr, idx+1, p.Size(), p.Len(), state.String(), addr)
-
 			if pc.conn != nil {
-				p.errGroup.Go(func() error {
-					log.Debugf("closing unhealthy connection pool %d/%d len %d for addr: %s", idx+1, p.Size(), p.Len(), pc.addr)
-					err := pc.Close(ctx, p.oldConnCloseDelay)
+				p.eg.Go(safety.RecoverFunc(func() error {
+					log.Debugf("waiting for invalid connection to %s to be closed...", pc.addr)
+					err = pc.Close(ctx, p.roccd)
 					if err != nil {
-						log.Errorf("failed to close connection pool %d/%d addr = %s\terror = %v", idx+1, p.Size(), pc.addr, err)
+						log.Debugf("failed to close connection pool addr = %s\terror = %v", pc.addr, err)
 					}
 					return nil
-				})
+				}))
 			}
 		}
 		return errors.Join(err, errors.ErrInvalidGRPCClientConn(addr))
 	}
-
-	p.store(idx, &poolConn{conn: newConn, addr: addr})
-
-	if pc != nil && pc.conn != nil {
-		p.errGroup.Go(func() error {
-			log.Debugf("closing unhealthy connection pool %d/%d len %d for addr: %s", idx+1, p.Size(), p.Len(), pc.addr)
-			err := pc.Close(ctx, p.oldConnCloseDelay)
+	p.store(idx, &poolConn{
+		conn: conn,
+		addr: addr,
+	})
+	if pc != nil {
+		p.eg.Go(safety.RecoverFunc(func() error {
+			log.Debugf("waiting for old connection to %s to be closed...", pc.addr)
+			err = pc.Close(ctx, p.roccd)
 			if err != nil {
-				log.Errorf("failed to close connection pool %d/%d addr = %s\terror = %v", idx+1, p.Size(), pc.addr, err)
+				log.Debugf("failed to close connection pool addr = %s\terror = %v", pc.addr, err)
 			}
 			return nil
-		})
+		}))
 	}
 	return nil
 }
 
-// Connect establishes connections for all slots.
-// It uses DNS lookup if enabled; otherwise, it connects to the single target address.
-func (p *pool) Connect(ctx context.Context) (Conn, error) {
-	if p.closing.Load() {
+func (p *pool) Connect(ctx context.Context) (c Conn, err error) {
+	if p == nil || p.closing.Load() {
 		return p, nil
 	}
-	log.Debugf("Connecting: addr=%s, host=%s, port=%d, isIP=%t, enableDNS=%t",
-		p.addr, p.host, p.port, p.isIPAddr, p.enableDNSLookup)
 
-	if p.isIPAddr || !p.enableDNSLookup {
-		return p.singleTargetConnect(ctx, p.addr)
+	p.init(false)
+
+	if p.isIP || !p.resolveDNS {
+		return p.singleTargetConnect(ctx)
 	}
 	ips, err := p.lookupIPAddr(ctx)
 	if err != nil {
-		return p.singleTargetConnect(ctx, p.addr)
-	}
-	if len(ips) == 1 {
-		return p.singleTargetConnect(ctx, net.JoinHostPort(ips[0], p.port))
+		return p.singleTargetConnect(ctx)
 	}
 	return p.connect(ctx, ips...)
 }
 
-// connect establishes connections using multiple IP addresses.
 func (p *pool) connect(ctx context.Context, ips ...string) (c Conn, err error) {
-	if p == nil || p.closing.Load() {
-		return p, nil
-	}
-
 	if uint64(len(ips)) > p.Size() {
 		p.grow(uint64(len(ips)))
 	}
-	log.Debugf("Connecting to %s multiple IPs: %v on port %d", p.addr, ips, p.port)
-	err = p.loop(ctx, func(ctx context.Context, idx uint64, pc *poolConn) bool {
-		target := net.JoinHostPort(ips[idx%uint64(len(ips))], p.port)
-		if err = p.refreshConn(ctx, idx, pc, target); err != nil {
-			if errors.IsNot(err, context.DeadlineExceeded, context.Canceled) {
-				log.Warnf("Failed to dialing to pool member %d/%d, addr: %s,\terror: %v", idx+1, p.Size(), target, err)
+
+	err = p.loop(ctx, func(ctx context.Context, idx int, pc *poolConn) bool {
+		addr := net.JoinHostPort(ips[idx%len(ips)], p.port)
+		ierr := p.refreshConn(ctx, idx, pc, addr)
+		if ierr != nil {
+			if !errors.Is(ierr, context.DeadlineExceeded) &&
+				!errors.Is(ierr, context.Canceled) {
+				log.Warnf("An error occurred while dialing pool member connection to %s,\terror: %v", addr, ierr)
 			} else {
-				log.Debugf("Connect loop operation has been canceled for connection pool %d/%d, addr: %s,\terror: %v", idx+1, p.Size(), target, err)
+				log.Debugf("Connect loop operation canceled while dialing pool member connection to %s,\terror: %v", addr, ierr)
 				return false
 			}
 		}
 		return true
 	})
-	if errors.IsNot(err, context.DeadlineExceeded, context.Canceled) {
+	if !errors.Is(err, context.Canceled) &&
+		!errors.Is(err, context.DeadlineExceeded) {
 		return p, err
 	}
+
 	hash := strings.Join(ips, "-")
-	p.dnsHash.Store(&hash)
+	p.reconnectHash.Store(&hash)
+
 	return p, nil
 }
 
-// singleTargetConnect connects every slot to a single target address.
-func (p *pool) singleTargetConnect(ctx context.Context, addr string) (Conn, error) {
+func (p *pool) Reconnect(ctx context.Context, force bool) (c Conn, err error) {
 	if p == nil || p.closing.Load() {
 		return p, nil
 	}
-	log.Debugf("Connecting to single target: %s", addr)
-	failCount := uint64(0)
-	err := p.loop(ctx, func(ctx context.Context, idx uint64, pc *poolConn) bool {
-		if err := p.refreshConn(ctx, idx, pc, addr); err != nil {
-			if errors.IsNot(err, context.DeadlineExceeded, context.Canceled) {
-				log.Warnf("Failed to dialing to pool member %d/%d, addr: %s,\terror: %v", idx+1, p.Size(), addr, err)
-				failCount++
-				if p.isIPAddr && (p.slotCount() <= 2 || failCount >= p.slotCount()/3) {
-					return false
-				}
-			} else {
-				log.Debugf("Connect loop operation has been canceled for connection pool %d/%d, addr: %s,\terror: %v", idx+1, p.Size(), addr, err)
-				return false
-			}
-		}
-		return true
-	})
-	if errors.IsNot(err, context.DeadlineExceeded, context.Canceled) {
-		return p, err
-	}
-	p.dnsHash.Store(&p.host)
-	return p, nil
-}
 
-// Reconnect re-establishes connections if the pool is unhealthy or if forced.
-func (p *pool) Reconnect(ctx context.Context, force bool) (Conn, error) {
-	if p == nil || p.closing.Load() {
-		return p, nil
-	}
-	hash := p.dnsHash.Load()
+	hash := p.reconnectHash.Load()
 	if force || hash == nil || *hash == "" {
 		return p.Connect(ctx)
 	}
-	if p.IsHealthy(ctx) {
-		if !p.isIPAddr && p.enableDNSLookup {
-			if *hash != "" {
-				ips, err := p.lookupIPAddr(ctx)
-				if err != nil {
-					return p, nil
-				}
-				if len(ips) == 1 {
-					return p.singleTargetConnect(ctx, net.JoinHostPort(ips[0], p.port))
-				}
-				if *hash != strings.Join(ips, "-") {
-					return p.connect(ctx, ips...)
-				}
+
+	healthy := p.IsHealthy(ctx)
+	if healthy {
+		if !p.isIP && p.resolveDNS && hash != nil && *hash != "" {
+			ips, err := p.lookupIPAddr(ctx)
+			if err != nil {
+				return p, nil
 			}
-		} else {
-			return p.singleTargetConnect(ctx, p.addr)
+			if *hash != strings.Join(ips, "-") {
+				return p.connect(ctx, ips...)
+			}
 		}
 		return p, nil
 	}
+
 	return p.Connect(ctx)
 }
 
-// Disconnect gracefully closes all connections in the pool.
-func (p *pool) Disconnect(ctx context.Context) (err error) {
-	log.Warn("Disconnecting pool...")
+func (p *pool) singleTargetConnect(ctx context.Context) (c Conn, err error) {
+	if p == nil || p.closing.Load() {
+		return p, nil
+	}
+
+	failCnt := 0
+	err = p.loop(ctx, func(ctx context.Context, idx int, pc *poolConn) bool {
+		ierr := p.refreshConn(ctx, idx, pc, p.addr)
+		if ierr != nil {
+			if !errors.Is(ierr, context.DeadlineExceeded) &&
+				!errors.Is(ierr, context.Canceled) {
+				log.Warnf("An error occurred while dialing pool member connection to %s,\terror: %v", p.addr, ierr)
+				failCnt++
+				if p.isIP && (p.len() <= 2 || failCnt >= p.len()/3) {
+					return false
+				}
+				return true
+			} else {
+				log.Debugf("Connect loop operation canceled while dialing pool member connection to %s,\terror: %v", p.addr, ierr)
+				return false
+			}
+		}
+		return true
+	})
+	if !errors.Is(err, context.Canceled) &&
+		!errors.Is(err, context.DeadlineExceeded) {
+		return p, err
+	}
+	p.reconnectHash.Store(&p.host)
+	return p, nil
+}
+
+func (p *pool) Disconnect() (err error) {
+	ctx := context.Background()
 	p.closing.Store(true)
 	defer p.closing.Store(false)
-	emap := make(map[string]error, p.Size())
-	err = p.loop(ctx, func(ctx context.Context, idx uint64, pc *poolConn) bool {
+	emap := make(map[string]error, p.len())
+	err = p.loop(ctx, func(ctx context.Context, _ int, pc *poolConn) bool {
 		if pc != nil && pc.conn != nil {
-			log.Debugf("Closing pool connection %d/%d for %s", idx+1, p.Size(), pc.addr)
-			if err := pc.Close(ctx, p.oldConnCloseDelay); err != nil {
-				if errors.IsNot(err, context.DeadlineExceeded, context.Canceled) {
-					log.Errorf("failed to close connection pool %d/%d addr = %s\terror = %v", idx+1, p.Size(), pc.addr, err)
-					emap[err.Error()] = err
+			ierr := pc.conn.Close()
+			if ierr != nil && !errors.Is(ierr, grpc.ErrClientConnClosing) {
+				if !errors.Is(ierr, context.DeadlineExceeded) &&
+					!errors.Is(ierr, context.Canceled) {
+					log.Debugf("failed to close connection pool addr = %s\terror = %v", pc.addr, ierr)
+					emap[ierr.Error()] = err
 				} else {
-					log.Debugf("Disconnect loop operation canceled while closing connection pool %d/%d addr = %s\terror = %v", idx+1, p.Size(), pc.addr, err)
+					log.Debugf("Disconnect loop operation canceled while closing pool member connection to %s,\terror: %v", pc.addr, ierr)
 					return false
 				}
 			}
@@ -556,260 +463,247 @@ func (p *pool) Disconnect(ctx context.Context) (err error) {
 	return err
 }
 
-// dial creates a new gRPC connection to the specified address.
-// It uses a dial timeout and, if configured, a backoff strategy.
-func (p *pool) dial(ctx context.Context, idx uint64, addr string) (*ClientConn, error) {
-	dialFunc := func(ctx context.Context) (*ClientConn, error) {
+func (p *pool) dial(ctx context.Context, addr string) (conn *ClientConn, err error) {
+	do := func() (conn *ClientConn, err error) {
 		ctx, cancel := context.WithTimeout(ctx, p.dialTimeout)
 		defer cancel()
-		log.Debugf("Dialing pool connection %d/%d to %s with timeout %s", idx+1, p.Size(), addr, p.dialTimeout.String())
-		conn, err := grpc.NewClient(addr, p.dialOpts...)
+		conn, err = grpc.DialContext(ctx, addr, append(p.dopts, grpc.WithBlock())...)
 		if err != nil {
 			if conn != nil {
-				return nil, errors.Join(err, conn.Close())
+				cerr := conn.Close()
+				if cerr != nil && !errors.Is(cerr, grpc.ErrClientConnClosing) {
+					err = errors.Join(err, cerr)
+				}
 			}
+			log.Debugf("failed to dial gRPC connection to %s,\terror: %v", addr, err)
 			return nil, err
 		}
-
-		_, healthy := p.isHealthy(idx, conn)
-		if !healthy {
+		if !isHealthy(ctx, conn) {
 			if conn != nil {
 				err = conn.Close()
-				if err != nil {
+				if err != nil && !errors.Is(err, grpc.ErrClientConnClosing) {
 					err = errors.Join(errors.ErrGRPCClientConnNotFound(addr), err)
 				} else {
 					err = errors.ErrGRPCClientConnNotFound(addr)
 				}
 			}
-			err = errors.Wrapf(err, "pool connection %d/%d for %s is unhealthy", idx+1, p.Size(), addr)
-			log.Debug(err)
+			log.Debugf("connection for %s is unhealthy: %v", addr, err)
 			return nil, err
 		}
 		return conn, nil
 	}
 	if p.bo != nil {
-		var conn *ClientConn
-		_, err := p.bo.Do(ctx, func(ctx context.Context) (any, bool, error) {
-			var err error
-			conn, err = dialFunc(ctx)
+		retry := 0
+		_, err = p.bo.Do(ctx, func(ctx context.Context) (r interface{}, ret bool, err error) {
+			log.Debugf("dialing to %s with backoff, retry: %d", addr, retry)
+			conn, err = do()
+			retry++
 			return conn, err != nil, err
 		})
-		if err != nil && conn != nil {
-			return nil, errors.Join(err, conn.Close())
-		}
 		return conn, nil
 	}
-	return dialFunc(ctx)
+
+	log.Debugf("dialing to %s", addr)
+	return do()
 }
 
-// getHealthyConn retrieves a healthy connection from the pool using round-robin indexing.
-// It attempts up to poolSize times.
-func (p *pool) getHealthyConn(ctx context.Context) (pc *poolConn, ok bool) {
+func (p *pool) IsHealthy(ctx context.Context) (healthy bool) {
 	if p == nil || p.closing.Load() {
-		return nil, false
+		return false
 	}
-	sz := p.Size()
-	if sz == 0 {
-		return nil, false
-	}
-	var idx uint64
-	for range sz {
-		idx, pc = p.load(p.currentIndex.Add(1) % sz)
-		if pc != nil {
-			state, healthy := p.isHealthy(idx, pc.conn)
-			if healthy {
-				return pc, true
-			}
-			log.Debugf("connection for %s pool %d/%d len %d is unhealthy (state: %s) trying to establish new pool member connection to %s",
-				pc.addr, idx+1, p.Size(), p.Len(), state.String(), p.addr)
-		}
-		if err := p.refreshConn(ctx, idx, pc, p.addr); err == nil {
-			if idx, pc = p.load(idx); pc != nil {
-				state, healthy := p.isHealthy(idx, pc.conn)
-				if healthy {
-					return pc, true
+	var cnt, unhealthy int
+	pl := p.len()
+	err := p.loop(ctx, func(ctx context.Context, idx int, pc *poolConn) bool {
+		if pc == nil || !isHealthy(ctx, pc.conn) {
+			if p.isIP {
+				if pc != nil && pc.addr != "" {
+					err := p.refreshConn(ctx, idx, pc, pc.addr)
+					if err != nil {
+						// target addr cannot re-connect so, connection is unhealthy
+						unhealthy++
+						return false
+					}
+					return true
 				}
-				log.Debugf("after re-connection for %s pool %d/%d len %d is still unhealthy (state: %s) going to close connection for %s",
-					pc.addr, idx+1, p.Size(), p.Len(), state.String(), p.addr)
+				return false
+			}
+			addr := p.addr
+			if pc != nil {
+				addr = pc.addr
+			}
+			// re-connect to last connected addr
+			err := p.refreshConn(ctx, idx, pc, addr)
+			if err != nil {
+				if addr == p.addr {
+					unhealthy++
+					return true
+				}
+				// last connect addr is not dns and cannot connect then try dns
+				err = p.refreshConn(ctx, idx, pc, p.addr)
+				// dns addr cannot connect so, connection is unhealthy
+				if err != nil {
+					unhealthy = pl - cnt
+					return false
+				}
 			}
 		}
+		cnt++
+		return true
+	})
+	if err != nil {
+		log.Debugf("health check loop for addr=%s returned error: %v,\thealthy %d/%d", p.addr, err, pl-unhealthy, pl)
 	}
-	return nil, false
+	if cnt == 0 {
+		log.Debugf("no connection pool %d/%d found for %s,\thealthy %d/%d", cnt, pl, p.addr, pl-unhealthy, pl)
+		return false
+	}
+	if p.isIP {
+		// if ip pool connection, each connection target should be healthy
+		return unhealthy == 0
+	}
+
+	// some pool target may unhealthy but pool client is healthy when unhealthy is less than pool length
+	return unhealthy < pl
 }
 
-// Do executes the provided function using a healthy connection.
-// If an error indicating a closed connection is returned, it attempts to refresh the connection and retries.
-func (p *pool) Do(ctx context.Context, f func(conn *ClientConn) error) (err error) {
+func (p *pool) Do(ctx context.Context, f func(conn *ClientConn) error) error {
 	if p == nil {
 		return errors.ErrGRPCClientConnNotFound("*")
 	}
-	pc, ok := p.getHealthyConn(ctx)
-	if !ok || pc == nil || pc.conn == nil {
+	conn, ok := p.Get(ctx)
+	if !ok || conn == nil {
 		return errors.ErrGRPCClientConnNotFound(p.addr)
 	}
-	return f(pc.conn)
+	return f(conn)
 }
 
-// Get returns a healthy connection from the pool, if available.
-func (p *pool) Get(ctx context.Context) (conn *ClientConn, ok bool) {
-	pc, ok := p.getHealthyConn(ctx)
-	if ok && pc != nil {
-		return pc.conn, true
+func (p *pool) Get(ctx context.Context) (*ClientConn, bool) {
+	return p.getHealthyConn(ctx, 0, p.Len())
+}
+
+func (p *pool) getHealthyConn(ctx context.Context, cnt, retry uint64) (*ClientConn, bool) {
+	if p == nil || p.closing.Load() {
+		return nil, false
 	}
-	return nil, false
-}
-
-// IsHealthy checks the overall health of the pool.
-// For IP-based connections, all slots must be healthy; otherwise, at least one healthy slot is acceptable.
-// Global metrics are updated accordingly.
-func (p *pool) IsHealthy(ctx context.Context) bool {
-	healthyCount := uint64(0)
-	err := p.loop(ctx, func(ctx context.Context, idx uint64, pc *poolConn) bool {
-		if pc != nil && pc.conn != nil {
-			state, healthy := p.isHealthy(idx, pc.conn)
-			if healthy {
-				healthyCount++
-				cnt, ok := metrics.Load(pc.addr)
-				if ok {
-					metrics.Store(pc.addr, cnt+1)
-				} else {
-					metrics.Store(pc.addr, 1)
-				}
-			} else {
-				log.Debugf("unhealthy connection detected for %s pool %d/%d len %d is unhealthy (state: %s)",
-					pc.addr, idx+1, p.Size(), p.Len(), state.String())
+	select {
+	case <-ctx.Done():
+		return nil, false
+	default:
+	}
+	pl := p.Len()
+	if retry <= 0 || retry > math.MaxUint64-pl || pl <= 0 {
+		if p.isIP {
+			log.Warnf("failed to find gRPC IP connection pool for %s.\tlen(pool): %d,\tretried: %d,\tseems IP %s is unhealthy will going to disconnect...", p.addr, pl, cnt, p.addr)
+			if err := p.Disconnect(); err != nil {
+				log.Debugf("failed to disconnect gRPC IP direct connection for %s,\terr: %v", p.addr, err)
 			}
-		} else {
-			newConn, err := p.dial(ctx, idx, p.addr)
-			if err == nil && newConn != nil {
-				state, healthy := p.isHealthy(idx, newConn)
-				addr := newConn.Target()
-				if healthy {
-					healthyCount++
-					pc = &poolConn{conn: newConn, addr: addr}
-					p.store(idx, pc)
-					cnt, ok := metrics.Load(pc.addr)
-					if ok {
-						metrics.Store(pc.addr, cnt+1)
-					} else {
-						metrics.Store(pc.addr, 1)
-					}
-				} else {
-					log.Debugf("unhealthy nil connection target %s detected for pool %d/%d len %d is unhealthy (state: %s)",
-						addr, idx+1, p.Size(), p.Len(), state.String())
-				}
-			} else {
-				log.Debugf("nil pool connection detected for %s pool %d/%d len %d is unhealthy", p.addr, idx+1, p.Size(), p.Len())
-			}
+			return nil, false
 		}
-		return true
-	})
-	metrics.Store(p.addr, healthyCount)
-	if err != nil {
-		log.Debugf("health check loop for addr=%s returned error: %v", p.addr, err)
+		var idx int
+		if pl > 0 {
+			idx = int(p.current.Add(1) % pl)
+		}
+		if pc := p.load(idx); pc != nil && isHealthy(ctx, pc.conn) {
+			return pc.conn, true
+		}
+		conn, err := p.dial(ctx, p.addr)
+		if err == nil && conn != nil && isHealthy(ctx, conn) {
+			p.store(idx, &poolConn{
+				conn: conn,
+				addr: p.addr,
+			})
+			return conn, true
+		}
+		log.Warnf("failed to find gRPC connection pool for %s.\tlen(pool): %d,\tretried: %d,\terror: %v", p.addr, pl, cnt, err)
+		return nil, false
 	}
-	if healthyCount == 0 {
-		log.Warnf("no connection pool member is healthy for addr=%s size=%d, len=%d", p.addr, p.Size(), p.Len())
-		return false
+
+	if pl > 0 {
+		if pc := p.load(int(p.current.Add(1) % pl)); pc != nil && isHealthy(ctx, pc.conn) {
+			return pc.conn, true
+		}
 	}
-	if p.isIPAddr {
-		return healthyCount == p.slotCount()
-	}
-	return healthyCount > 0
+	retry--
+	cnt++
+	return p.getHealthyConn(ctx, cnt, retry)
 }
 
-// Len returns the number of connection slots.
 func (p *pool) Len() uint64 {
-	return p.slotCount()
+	return uint64(p.len())
 }
 
-// Size returns the configured pool size.
 func (p *pool) Size() uint64 {
-	return p.poolSize.Load()
+	return p.size.Load()
 }
 
-// IsIPConn indicates whether the pool is using direct IP connections.
-func (p *pool) IsIPConn() bool {
-	return p.isIPAddr
-}
-
-// String returns a string representation of the pool's state.
-func (p *pool) String() string {
-	hash := ""
-	if rh := p.dnsHash.Load(); rh != nil {
-		hash = *rh
-	}
-	return fmt.Sprintf("addr: %s, host: %s, port: %d, isIP: %t, enableDNS: %t, dnsHash: %s, slotCount: %d, poolSize: %d, currentIndex: %d, dialTimeout: %s, oldConnCloseDelay: %s, closing: %t",
-		p.addr, p.host, p.port, p.isIPAddr, p.enableDNSLookup, hash, p.Len(), p.Size(), p.currentIndex.Load(),
-		p.dialTimeout.String(), p.oldConnCloseDelay.String(), p.closing.Load())
-}
-
-// lookupIPAddr performs DNS lookup for the host and returns a list of reachable IP addresses.
-// It also attempts a short TCP dial ("ping") for each IP.
-func (p *pool) lookupIPAddr(ctx context.Context) ([]string, error) {
+func (p *pool) lookupIPAddr(ctx context.Context) (ips []string, err error) {
 	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, p.host)
 	if err != nil {
-		log.Debugf("Failed to lookup IP addresses for %s: %s", p.addr, err.Error())
+		log.Debugf("failed to lookup ip addr for %s \terr: %s", p.addr, err.Error())
 		return nil, err
 	}
+
 	if len(addrs) == 0 {
 		return nil, errors.ErrGRPCLookupIPAddrNotFound(p.host)
 	}
-	var ips []string
+
+	ips = make([]string, 0, len(addrs))
 	for _, ip := range addrs {
 		ipStr := ip.String()
-		target := net.JoinHostPort(ipStr, p.port)
-		pingCtx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
-		conn, err := net.DialContext(pingCtx, net.TCP.String(), target)
+		var conn net.Conn
+		addr := net.JoinHostPort(ipStr, p.port)
+		ctx, cancel := context.WithTimeout(ctx, time.Millisecond*10)
+		conn, err := net.DialContext(ctx, net.TCP.String(), addr)
 		cancel()
-		if err == nil {
-			ips = append(ips, ipStr)
-		} else {
-			log.Warnf("Failed to ping %s: %s", target, err.Error())
+		if err != nil {
+			log.Warnf("failed to initialize ping addr: %s,\terr: %s", addr, err.Error())
+			if conn != nil {
+				err = conn.Close()
+				if err != nil && !errors.Is(err, grpc.ErrClientConnClosing) {
+					log.Warn("failed to close connection:", err)
+				}
+			}
+			continue
 		}
 		if conn != nil {
 			err = conn.Close()
-			if errors.IsNot(err, context.DeadlineExceeded, context.Canceled) {
+			if err != nil && !errors.Is(err, grpc.ErrClientConnClosing) {
 				log.Warn("failed to close connection:", err)
 			}
 		}
+		ips = append(ips, ipStr)
 	}
+
 	if len(ips) == 0 {
 		return nil, errors.ErrGRPCLookupIPAddrNotFound(p.host)
 	}
-	// Sorting can be added here if needed.
+
+	slices.Sort(ips)
+
 	return ips, nil
 }
 
-// scanGRPCPort scans ports from startPort to endPort for a valid gRPC endpoint.
 func (p *pool) scanGRPCPort(ctx context.Context) (port uint16, err error) {
 	ports, err := net.ScanPorts(ctx, p.startPort, p.endPort, p.host)
 	if err != nil {
 		return 0, err
 	}
-	log.Debugf("Scanning available gRPC ports: %v", ports)
 	var conn *ClientConn
 	for _, port := range ports {
 		select {
 		case <-ctx.Done():
-			err = ctx.Err()
-			if errors.IsNot(err, context.DeadlineExceeded, context.Canceled) {
-				return 0, err
-			}
-			return 0, nil
+			return 0, ctx.Err()
 		default:
-			conn, err = grpc.NewClient(net.JoinHostPort(p.host, port), p.dialOpts...)
-			if err == nil && conn != nil {
-				_, healthy := p.isHealthy(0, conn)
-				if healthy {
-					log.Debugf("Found valid gRPC port: %d", port)
-					err = conn.Close()
-					if err != nil {
-						log.Warnf("Failed to close connection for port %d: %s", port, err.Error())
-					}
-					return port, nil
-				}
+			// try gRPC dialing to target port
+			conn, err = grpc.DialContext(ctx,
+				net.JoinHostPort(p.host, port),
+				append(p.dopts, grpc.WithBlock())...)
+
+			if err == nil && isHealthy(ctx, conn) && conn.Close() == nil {
+				// if no error and healthy the port is ready for gRPC
+				return port, nil
 			}
+
 			if conn != nil {
 				_ = conn.Close()
 			}
@@ -818,42 +712,105 @@ func (p *pool) scanGRPCPort(ctx context.Context) (port uint16, err error) {
 	return 0, errors.ErrInvalidGRPCPort(p.addr, p.host, p.port)
 }
 
-// Metrics returns a map of healthy connection counts per target address.
-func Metrics(ctx context.Context) map[string]uint64 {
-	result := make(map[string]uint64, metrics.Len())
-	metrics.Range(func(addr string, count uint64) bool {
-		if addr != "" {
-			result[addr] = count
-		}
-		return true
-	})
-	if len(result) == 0 {
-		return nil
-	}
-	return result
+func (p *pool) IsIPConn() (isIP bool) {
+	return p.isIP
 }
 
-// p.isHealthy checks whether a given gRPC connection is healthy by examining its connectivity state.
-func (p *pool) isHealthy(idx uint64, conn *ClientConn) (state connectivity.State, healthy bool) {
-	if conn == nil {
-		log.Warnf("gRPC target %s's pool connection %d/%d is nil", p.addr, idx+1, p.Size())
-		return connectivity.State(-1), false
+func (p *pool) String() (str string) {
+	if p == nil {
+		return "<nil>"
 	}
-	state = conn.GetState()
+	var hash string
+	rh := p.reconnectHash.Load()
+	if rh != nil {
+		hash = *rh
+	}
+	return fmt.Sprintf("addr: %s, host: %s, port %d, isIP: %v, resolveDNS: %v, hash: %s, pool_size: %d, current_seek: %d, dopt_len: %d, dial_timeout: %v, roccd: %v, closing: %v",
+		p.addr,
+		p.host,
+		p.port,
+		p.isIP,
+		p.resolveDNS,
+		hash,
+		p.size.Load(),
+		p.current.Load(),
+		len(p.dopts),
+		p.dialTimeout,
+		p.roccd,
+		p.closing.Load())
+}
+
+func (pc *poolConn) Close(ctx context.Context, delay time.Duration) error {
+	tdelay := delay / 10
+	if tdelay < time.Millisecond*200 {
+		tdelay = time.Millisecond * 200
+	} else if tdelay > time.Minute {
+		tdelay = time.Second * 5
+	}
+	tick := time.NewTicker(tdelay)
+	defer tick.Stop()
+	ctx, cancel := context.WithTimeout(ctx, delay)
+	defer cancel()
+	for {
+		select {
+		case <-ctx.Done():
+			err := pc.conn.Close()
+			if err != nil && !errors.Is(err, grpc.ErrClientConnClosing) {
+				if ctx.Err() != nil &&
+					!errors.Is(ctx.Err(), context.DeadlineExceeded) &&
+					!errors.Is(ctx.Err(), context.Canceled) {
+					return errors.Join(err, ctx.Err())
+				}
+				return err
+			}
+			if ctx.Err() != nil &&
+				!errors.Is(ctx.Err(), context.DeadlineExceeded) &&
+				!errors.Is(ctx.Err(), context.Canceled) {
+				return ctx.Err()
+			}
+			return nil
+		case <-tick.C:
+			switch pc.conn.GetState() {
+			case connectivity.Idle, connectivity.Connecting, connectivity.TransientFailure:
+				err := pc.conn.Close()
+				if err != nil && !errors.Is(err, grpc.ErrClientConnClosing) {
+					return err
+				}
+				return nil
+			case connectivity.Shutdown:
+				return nil
+			}
+		}
+	}
+}
+
+func isHealthy(ctx context.Context, conn *ClientConn) bool {
+	if conn == nil {
+		log.Warn("gRPC target connection is nil")
+		return false
+	}
+	state := conn.GetState()
 	switch state {
 	case connectivity.Ready:
-		return state, true
+		return true
 	case connectivity.Connecting:
-		return state, true
+		log.Debugf("gRPC target %s's connection status will be Ready soon\tstatus: %s", conn.Target(), state.String())
+		return true
 	case connectivity.Idle:
-		log.Debugf("gRPC target %s's pool connection %d/%d status is Idle\tstate: %s\twill re-connect...", conn.Target(), idx+1, p.Size(), state.String())
+		log.Debugf("gRPC target %s's connection status is waiting for target\tstatus: %s\ttrying to re-connect...", conn.Target(), state.String())
 		conn.Connect()
-		return state, true
+		if conn.WaitForStateChange(ctx, state) {
+			state = conn.GetState()
+			if state == connectivity.Ready || state == connectivity.Connecting {
+				log.Debugf("gRPC target %s's connection status enabled for target\tstatus: %s", conn.Target(), state.String())
+				return true
+			}
+		}
+		return false
 	case connectivity.Shutdown, connectivity.TransientFailure:
-		log.Errorf("gRPC target %s's pool connection %d/%d is unhealthy (state: %s)", conn.Target(), idx+1, p.Size(), state.String())
-		return state, false
-	default:
-		log.Errorf("gRPC target %s's pool connection %d/%d has unknown state: %s", conn.Target(), idx+1, p.Size(), state.String())
-		return state, false
+		log.Errorf("gRPC target %s's connection status is unhealthy\tstatus: %s", conn.Target(), state.String())
+		return false
 	}
+	log.Errorf("gRPC target %s's connection status is unknown\tstatus: %s", conn.Target(), state.String())
+	return false
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->
- Vald Version: v1.7.17
- Go Version: v1.24.5
- Rust Version: v1.88.0
- Docker Version: v28.3.2
- Kubernetes Version: v1.33.3
- Helm Version: v3.18.4
- NGT Version: v2.4.3
- Faiss Version: v1.11.0

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [ ] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More resilient connection management: DNS-based multi-IP resolution, smarter health checks/reconnects, and port-scan fallback for dialing.
  - Graceful shutdown of old connections with timed close behavior.
- Refactor
  - Breaking change: Disconnect no longer requires a context parameter.
  - Option renamed: Old connection close delay → Old connection close duration.
  - Removed the exported pool metrics helper.
- Chores
  - Simplified and updated gRPC metrics: removed pool-connection metrics and streamlined registration; latency and completed RPCs metrics remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->