### PR TITLE
refactor: add missing k8s type aliases to types.go

### DIFF
--- a/internal/k8s/types.go
+++ b/internal/k8s/types.go
@@ -46,6 +46,12 @@ type (
 	VolumeSnapshot            = snapshotv1.VolumeSnapshot
 	VolumeSnapshotList        = snapshotv1.VolumeSnapshotList
 	Pod                       = corev1.Pod
+	PodList                   = corev1.PodList
+	Node                      = corev1.Node
+	NodeList                  = corev1.NodeList
+	Service                   = corev1.Service
+	ServiceList               = corev1.ServiceList
+	ServicePort               = corev1.ServicePort
 	Deployment                = appsv1.Deployment
 	DeploymentList            = appsv1.DeploymentList
 	ObjectMeta                = metav1.ObjectMeta
@@ -69,4 +75,9 @@ const (
 	SelectionOpEquals           = selection.Equals
 	SelectionOpExists           = selection.Exists
 	PodIndexLabel               = appsv1.PodIndexLabel
+	PodRunning                  = corev1.PodRunning
+	NodeInternalIP              = corev1.NodeInternalIP
+	NodeInternalDNS             = corev1.NodeInternalDNS
+	NodeExternalIP              = corev1.NodeExternalIP
+	NodeExternalDNS             = corev1.NodeExternalDNS
 )


### PR DESCRIPTION
Fixes #3152

## Changes
- Add commonly used k8s types to internal/k8s/types.go for unified access
- Type aliases: PodList, Node, NodeList, Service, ServiceList, ServicePort
- Constants: PodRunning, NodeInternalIP, NodeInternalDNS, NodeExternalIP, NodeExternalDNS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded public API with additional Kubernetes resource type aliases and related status/address constants to improve interoperability and make more Kubernetes types available to integrations.
  * No runtime or control-flow changes; additions are backward-compatible and intended to broaden tooling compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->