### PR TITLE
fix typo

### DIFF
--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -330,13 +330,13 @@ func (s *Server) Opts() []server.Option {
 
 			if s.GRPC.EnableReflection {
 				opts = append(opts,
-					server.WithGRPCRegisterFunc(func(srv *grpc.Server) {
+					server.WithGRPCRegisterar(func(srv *grpc.Server) {
 						reflection.Register(srv)
 					}))
 			}
 			if s.GRPC.EnableAdmin || s.GRPC.EnableChannelz {
 				opts = append(opts,
-					server.WithGRPCRegisterFunc(func(srv *grpc.Server) {
+					server.WithGRPCRegisterar(func(srv *grpc.Server) {
 						admin.Register(srv)
 					}))
 			}

--- a/internal/servers/server/option.go
+++ b/internal/servers/server/option.go
@@ -401,7 +401,7 @@ func WithGRPCOption(opts ...grpc.ServerOption) Option {
 	}
 }
 
-func WithGRPCRegisterFunc(f func(*grpc.Server)) Option {
+func WithGRPCRegisterar(f func(*grpc.Server)) Option {
 	return func(s *server) error {
 		if f != nil {
 			if s.grpc.regs == nil {

--- a/internal/servers/server/option_test.go
+++ b/internal/servers/server/option_test.go
@@ -1083,7 +1083,7 @@ func TestWithGRPCOption(t *testing.T) {
 	}
 }
 
-func TestWithGRPCRegisterFunc(t *testing.T) {
+func TestWithGRPCRegisterar(t *testing.T) {
 	type test struct {
 		name      string
 		fn        func(*grpc.Server)
@@ -1130,7 +1130,7 @@ func TestWithGRPCRegisterFunc(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			opt := WithGRPCRegisterFunc(tt.fn)
+			opt := WithGRPCRegisterar(tt.fn)
 			if err := tt.checkFunc(opt); err != nil {
 				t.Error(err)
 			}

--- a/internal/servers/server/server_test.go
+++ b/internal/servers/server/server_test.go
@@ -197,7 +197,7 @@ func TestNew(t *testing.T) {
 				name: "returns gRPC server instance when in gRPC mode",
 				opts: []Option{
 					WithServerMode(GRPC),
-					WithGRPCRegisterFunc(fn),
+					WithGRPCRegisterar(fn),
 					WithGRPCKeepaliveTime("1s"),
 					WithGRPCOption([]grpc.ServerOption{}...),
 					WithTLSConfig(new(tls.Config)),

--- a/internal/servers/starter/starter_test.go
+++ b/internal/servers/starter/starter_test.go
@@ -154,7 +154,7 @@ func TestSetupAPIs(t *testing.T) {
 					},
 					grpc: func(cfg *config.Server) []server.Option {
 						return []server.Option{
-							server.WithGRPCRegisterFunc(fn),
+							server.WithGRPCRegisterar(fn),
 						}
 					},
 					gql: func(cfg *config.Server) []server.Option {

--- a/internal/tls/tls_bench_test.go
+++ b/internal/tls/tls_bench_test.go
@@ -100,7 +100,7 @@ func serverStarter(
 		}).Bind()),
 		starter.WithGRPC(func(_ *config.Server) []server.Option {
 			return []server.Option{
-				server.WithGRPCRegisterFunc(func(gs *grpc.Server) {
+				server.WithGRPCRegisterar(func(gs *grpc.Server) {
 					vald.RegisterIndexServer(gs, mockIndexInfoServer{})
 				}),
 				server.WithGRPCOption(grpc.Creds(credentials.NewTLS(stls))),

--- a/pkg/agent/core/faiss/usecase/agentd.go
+++ b/pkg/agent/core/faiss/usecase/agentd.go
@@ -78,7 +78,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	eg := errgroup.Get()
 
 	grpcServerOptions := []server.Option{
-		server.WithGRPCRegisterFunc(func(srv *grpc.Server) {
+		server.WithGRPCRegisterar(func(srv *grpc.Server) {
 			agent.RegisterAgentServer(srv, g)
 			vald.RegisterValdServer(srv, g)
 		}),

--- a/pkg/agent/core/ngt/usecase/agentd.go
+++ b/pkg/agent/core/ngt/usecase/agentd.go
@@ -102,7 +102,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	eg := errgroup.Get()
 
 	grpcServerOptions := []server.Option{
-		server.WithGRPCRegisterFunc(func(srv *grpc.Server) {
+		server.WithGRPCRegisterar(func(srv *grpc.Server) {
 			agent.RegisterAgentServer(srv, g)
 			vald.RegisterValdServer(srv, g)
 		}),

--- a/pkg/agent/sidecar/usecase/initcontainer/initcontainer.go
+++ b/pkg/agent/sidecar/usecase/initcontainer/initcontainer.go
@@ -157,7 +157,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	g := handler.New()
 
 	grpcServerOptions := []server.Option{
-		server.WithGRPCRegisterFunc(func(srv *grpc.Server) {
+		server.WithGRPCRegisterar(func(srv *grpc.Server) {
 			sidecar.RegisterSidecarServer(srv, g)
 		}),
 		server.WithPreStopFunction(func() error {

--- a/pkg/agent/sidecar/usecase/sidecar/sidecar.go
+++ b/pkg/agent/sidecar/usecase/sidecar/sidecar.go
@@ -169,7 +169,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	g := handler.New(handler.WithStorageObserver(so))
 
 	grpcServerOptions := []server.Option{
-		server.WithGRPCRegisterFunc(func(srv *grpc.Server) {
+		server.WithGRPCRegisterar(func(srv *grpc.Server) {
 			sidecar.RegisterSidecarServer(srv, g)
 		}),
 		server.WithPreStopFunction(func() error {

--- a/pkg/discoverer/k8s/usecase/discovered.go
+++ b/pkg/discoverer/k8s/usecase/discovered.go
@@ -79,7 +79,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	}
 
 	grpcServerOptions := []server.Option{
-		server.WithGRPCRegisterFunc(func(srv *grpc.Server) {
+		server.WithGRPCRegisterar(func(srv *grpc.Server) {
 			discoverer.RegisterDiscovererServer(srv, h)
 		}),
 		server.WithPreStartFunc(func() error {

--- a/pkg/gateway/filter/usecase/vald.go
+++ b/pkg/gateway/filter/usecase/vald.go
@@ -163,7 +163,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	)
 
 	grpcServerOptions := []server.Option{
-		server.WithGRPCRegisterFunc(func(srv *grpc.Server) {
+		server.WithGRPCRegisterar(func(srv *grpc.Server) {
 			vald.RegisterValdServerWithFilter(srv, v)
 		}),
 		server.WithPreStopFunction(func() error {

--- a/pkg/gateway/lb/usecase/vald.go
+++ b/pkg/gateway/lb/usecase/vald.go
@@ -123,7 +123,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	)
 
 	grpcServerOptions := []server.Option{
-		server.WithGRPCRegisterFunc(func(srv *grpc.Server) {
+		server.WithGRPCRegisterar(func(srv *grpc.Server) {
 			vald.RegisterValdServer(srv, v)
 		}),
 		server.WithPreStopFunction(func() error {

--- a/pkg/gateway/mirror/usecase/vald.go
+++ b/pkg/gateway/mirror/usecase/vald.go
@@ -122,7 +122,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	}
 
 	grpcServerOptions := []server.Option{
-		server.WithGRPCRegisterFunc(func(srv *grpc.Server) {
+		server.WithGRPCRegisterar(func(srv *grpc.Server) {
 			vald.RegisterValdServer(srv, v)
 			mirror.RegisterMirrorServer(srv, v)
 		}),

--- a/pkg/manager/index/usecase/indexer.go
+++ b/pkg/manager/index/usecase/indexer.go
@@ -108,7 +108,7 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 	idx := handler.New(handler.WithIndexer(indexer))
 
 	grpcServerOptions := []server.Option{
-		server.WithGRPCRegisterFunc(func(srv *grpc.Server) {
+		server.WithGRPCRegisterar(func(srv *grpc.Server) {
 			index.RegisterIndexServer(srv, idx)
 		}),
 		server.WithPreStopFunction(func() error {

--- a/pkg/tools/benchmark/job/usecase/benchmarkd.go
+++ b/pkg/tools/benchmark/job/usecase/benchmarkd.go
@@ -136,7 +136,7 @@ func New(cfg *config.Config) (r runner.Runner, err error) {
 	}
 
 	grpcServerOptions := []server.Option{
-		server.WithGRPCRegisterFunc(func(srv *grpc.Server) {
+		server.WithGRPCRegisterar(func(srv *grpc.Server) {
 			// TODO register grpc server handler here
 		}),
 		server.WithGRPCOption(

--- a/pkg/tools/benchmark/operator/usecase/benchmarkd.go
+++ b/pkg/tools/benchmark/operator/usecase/benchmarkd.go
@@ -76,7 +76,7 @@ func New(cfg *config.Config) (r runner.Runner, err error) {
 	}
 
 	grpcServerOptions := []server.Option{
-		server.WithGRPCRegisterFunc(func(srv *grpc.Server) {
+		server.WithGRPCRegisterar(func(srv *grpc.Server) {
 			// TODO register grpc server handler here
 		}),
 		server.WithGRPCOption(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

- fix typo Regist to Register
<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Vald Version: v1.7.17
- Go Version: v1.25.5
- Rust Version: v1.92.0
- Docker Version: v29.1.3
- Kubernetes Version: v1.34.3
- Helm Version: v4.0.4
- NGT Version: v2.5.0
- Faiss Version: v1.13.1

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the gRPC server registration option across the codebase for naming consistency; all internal usages updated.
  * This is a breaking API change for integrations that construct gRPC server registration hooks — update callers accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->