### PR TITLE
fix(k8s): correct helm/benchmark operator manifest output paths in make targets

### DIFF
--- a/Makefile.d/k8s.mk
+++ b/Makefile.d/k8s.mk
@@ -76,7 +76,7 @@ k8s/manifest/operator/helm/update: \
 	--output-dir $(TEMP_DIR) \
 	charts/operator/helm
 	mkdir -p $(ROOTDIR)/k8s/operator
-	mv $(TEMP_DIR)/operator/helm/templates $(ROOTDIR)/k8s/operator/helm
+	mv $(TEMP_DIR)/vald-helm-operator/templates $(ROOTDIR)/k8s/operator/helm
 	rm -rf $(TEMP_DIR)
 	cp -r $(ROOTDIR)/charts/operator/helm/crds $(ROOTDIR)/k8s/operator/helm/crds
 
@@ -117,7 +117,7 @@ k8s/manifest/operator/benchmark/update: \
 	--output-dir $(TEMP_DIR) \
 	charts/operator/benchmark
 	mkdir -p $(ROOTDIR)/k8s/tools/benchmark
-	mv $(TEMP_DIR)/operator/benchmark/templates $(ROOTDIR)/k8s/operator/benchmark
+	mv $(TEMP_DIR)/vald-benchmark-operator/templates $(ROOTDIR)/k8s/operator/benchmark
 	rm -rf $(TEMP_DIR)
 	cp -r $(ROOTDIR)/charts/operator/benchmark/crds $(ROOTDIR)/k8s/operator/benchmark/crds
 
@@ -240,9 +240,9 @@ k8s/operator/helm/deploy:
 	$(HELM_EXTRA_OPTIONS) \
 	--include-crds \
 	charts/operator/helm
-	kubectl create -f $(TEMP_DIR)/operator/helm/crds/valdrelease.yaml
-	kubectl create -f $(TEMP_DIR)/operator/helm/crds/valdhelmoperatorrelease.yaml
-	kubectl apply -f $(TEMP_DIR)/operator/helm/templates
+	kubectl create -f $(TEMP_DIR)/vald-helm-operator/crds/valdrelease.yaml
+	kubectl create -f $(TEMP_DIR)/vald-helm-operator/crds/valdhelmoperatorrelease.yaml
+	kubectl apply -f $(TEMP_DIR)/vald-helm-operator/templates
 	sleep 2
 	kubectl wait --for=condition=ready pod -l name=vald-helm-operator --timeout=600s
 
@@ -254,9 +254,9 @@ k8s/operator/helm/delete:
 	--set image.tag=$(VERSION) \
 	--include-crds \
 	charts/operator/helm
-	kubectl delete -f $(TEMP_DIR)/operator/helm/templates
+	kubectl delete -f $(TEMP_DIR)/vald-helm-operator/templates
 	kubectl wait --for=delete pod -l name=vald-helm-operator --timeout=600s
-	kubectl delete -f $(TEMP_DIR)/operator/helm/crds
+	kubectl delete -f $(TEMP_DIR)/vald-helm-operator/crds
 	rm -rf $(TEMP_DIR)
 
 .PHONY: k8s/operator/vald/deploy
@@ -347,10 +347,10 @@ k8s/operator/benchmark/deploy:
 	--set image.tag=${VERSION} \
 	--include-crds \
 	charts/operator/benchmark
-	kubectl create -f $(TEMP_DIR)/operator/benchmark/crds/valdbenchmarkjob.yaml
-	kubectl create -f $(TEMP_DIR)/operator/benchmark/crds/valdbenchmarkscenario.yaml
-	kubectl create -f $(TEMP_DIR)/operator/benchmark/crds/valdbenchmarkoperatorrelease.yaml
-	kubectl apply -f $(TEMP_DIR)/operator/benchmark/templates
+	kubectl create -f $(TEMP_DIR)/vald-benchmark-operator/crds/valdbenchmarkjob.yaml
+	kubectl create -f $(TEMP_DIR)/vald-benchmark-operator/crds/valdbenchmarkscenario.yaml
+	kubectl create -f $(TEMP_DIR)/vald-benchmark-operator/crds/valdbenchmarkoperatorrelease.yaml
+	kubectl apply -f $(TEMP_DIR)/vald-benchmark-operator/templates
 	sleep 2
 	kubectl wait --for=condition=ready pod -l name=vald-benchmark-operator --timeout=600s
 
@@ -362,9 +362,9 @@ k8s/operator/benchmark/delete:
 	--set image.tag=${VERSION} \
 	--include-crds \
 	charts/operator/benchmark
-	kubectl delete -f $(TEMP_DIR)/operator/benchmark/templates
+	kubectl delete -f $(TEMP_DIR)/vald-benchmark-operator/templates
 	kubectl wait --for=delete pod -l name=vald-benchmark-operator --timeout=600s
-	kubectl delete -f $(TEMP_DIR)/operator/benchmark/crds
+	kubectl delete -f $(TEMP_DIR)/vald-benchmark-operator/crds
 	rm -rf $(TEMP_DIR)
 
 .PHONY: k8s/external/cert-manager/deploy


### PR DESCRIPTION
### Description

`helm template --output-dir $(TEMP_DIR)` renders manifests under a directory named after the **chart** (`vald-helm-operator` / `vald-benchmark-operator`), but the `k8s/operator/helm/*` and `k8s/operator/benchmark/*` make targets referenced `$(TEMP_DIR)/operator/helm/...` and `$(TEMP_DIR)/operator/benchmark/...`, which never exist.

As a result those targets failed immediately with:

```
error: the path ".../operator/helm/crds/valdrelease.yaml" does not exist
```

so `make k8s/operator/helm/deploy` (and the `delete` / `update` and the benchmark-operator equivalents) could not deploy or render the operators at all.

**What changed:** point the paths to the chart-name directories (`vald-helm-operator` / `vald-benchmark-operator`) across the affected targets:

- `k8s/operator/helm/{deploy,delete,update}`
- `k8s/operator/benchmark/{deploy,delete,update}`

**Why:** this is purely a path mismatch introduced when the render layout changed to `helm template --output-dir`. The `k8s/operator/vald/update` target was already using the correct `vald-operator` directory, which confirms the intended pattern.

**Verification:** on a local k3d cluster, after the fix `make k8s/operator/helm/delete` → `make k8s/operator/helm/deploy` runs end-to-end (CRDs created, `vald-helm-operator` pods reach Ready).

### Related Issue

N/A — found while manually verifying the vald-operator deploy flow locally (kind/k3d). Happy to open a tracking issue if preferred.

### Versions

- Vald Version: v1.7.17
- Go Version: v1.26.1
- Rust Version: v1.94.1
- Docker Version: v29.3.1
- Kubernetes Version: v1.35.3
- Helm Version: v4.1.3
- NGT Version: v2.7.2
- Faiss Version: v1.14.1

### Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

- Scope is intentionally limited to the make-target output-path fix. It does not touch operator behavior.
- Note: `make e2e/v2/actions/run/operator` deploys only vald-operator (no vald-helm-operator) and verifies ValdRelease generation, so this broken path was not exercised by CI — it surfaces when deploying vald-helm-operator / benchmark-operator via make. The fix was verified manually on k3d.
- A separate topic found during the same verification — how vald-operator should handle multiple `clusters[]` entries on a single cluster (the multi-cluster sample / distribution question) — is intentionally **not** part of this PR and is being discussed separately.
