### PR TITLE
fix: eliminate package-name/identifier stutter across 33 exported symbols

### DIFF
--- a/cmd/agent/core/faiss/main.go
+++ b/cmd/agent/core/faiss/main.go
@@ -41,13 +41,13 @@ func main() {
 			runner.WithName[*config.Data](name),
 			runner.WithVersion[*config.Data](info.Version, maxVersion, minVersion),
 			runner.WithConfigLoader(func(path string) (*config.Data, *config.GlobalConfig, error) {
-				cfg, err := config.NewConfig(path)
+				cfg, err := config.New(path)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "failed to load "+name+"'s configuration")
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/agent/core/ngt/main.go
+++ b/cmd/agent/core/ngt/main.go
@@ -47,7 +47,7 @@ func main() {
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/agent/sidecar/main.go
+++ b/cmd/agent/sidecar/main.go
@@ -41,13 +41,13 @@ func main() {
 			runner.WithName[*config.Data](name),
 			runner.WithVersion[*config.Data](info.Version, maxVersion, minVersion),
 			runner.WithConfigLoader(func(path string) (*config.Data, *config.GlobalConfig, error) {
-				cfg, err := config.NewConfig(path)
+				cfg, err := config.New(path)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "failed to load "+name+"'s configuration")
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/discoverer/k8s/main.go
+++ b/cmd/discoverer/k8s/main.go
@@ -47,7 +47,7 @@ func main() {
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/gateway/filter/main.go
+++ b/cmd/gateway/filter/main.go
@@ -41,13 +41,13 @@ func main() {
 			runner.WithName[*config.Data](name),
 			runner.WithVersion[*config.Data](info.Version, maxVersion, minVersion),
 			runner.WithConfigLoader(func(path string) (*config.Data, *config.GlobalConfig, error) {
-				cfg, err := config.NewConfig(path)
+				cfg, err := config.New(path)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "failed to load "+name+"'s configuration")
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/gateway/lb/main.go
+++ b/cmd/gateway/lb/main.go
@@ -41,13 +41,13 @@ func main() {
 			runner.WithName[*config.Data](name),
 			runner.WithVersion[*config.Data](info.Version, maxVersion, minVersion),
 			runner.WithConfigLoader(func(path string) (*config.Data, *config.GlobalConfig, error) {
-				cfg, err := config.NewConfig(path)
+				cfg, err := config.New(path)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "failed to load "+name+"'s configuration")
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/gateway/mirror/main.go
+++ b/cmd/gateway/mirror/main.go
@@ -44,7 +44,7 @@ func main() {
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/index/job/correction/main.go
+++ b/cmd/index/job/correction/main.go
@@ -38,13 +38,13 @@ func main() {
 			runner.WithName[*config.Data](name),
 			runner.WithVersion[*config.Data](info.Version, maxVersion, minVersion),
 			runner.WithConfigLoader(func(path string) (*config.Data, *config.GlobalConfig, error) {
-				cfg, err := config.NewConfig(path)
+				cfg, err := config.New(path)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "failed to load "+name+"'s configuration")
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/index/job/creation/main.go
+++ b/cmd/index/job/creation/main.go
@@ -38,13 +38,13 @@ func main() {
 			runner.WithName[*config.Data](name),
 			runner.WithVersion[*config.Data](info.Version, maxVersion, minVersion),
 			runner.WithConfigLoader(func(path string) (*config.Data, *config.GlobalConfig, error) {
-				cfg, err := config.NewConfig(path)
+				cfg, err := config.New(path)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "failed to load "+name+"'s configuration")
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/index/job/deletion/main.go
+++ b/cmd/index/job/deletion/main.go
@@ -44,7 +44,7 @@ func main() {
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/index/job/exportation/main.go
+++ b/cmd/index/job/exportation/main.go
@@ -38,13 +38,13 @@ func main() {
 			runner.WithName[*config.Data](name),
 			runner.WithVersion[*config.Data](info.Version, maxVersion, minVersion),
 			runner.WithConfigLoader(func(path string) (*config.Data, *config.GlobalConfig, error) {
-				cfg, err := config.NewConfig(path)
+				cfg, err := config.New(path)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "failed to load "+name+"'s configuration")
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/index/job/readreplica/rotate/main.go
+++ b/cmd/index/job/readreplica/rotate/main.go
@@ -38,13 +38,13 @@ func main() {
 			runner.WithName[*config.Data](name),
 			runner.WithVersion[*config.Data](info.Version, maxVersion, minVersion),
 			runner.WithConfigLoader(func(path string) (*config.Data, *config.GlobalConfig, error) {
-				cfg, err := config.NewConfig(path)
+				cfg, err := config.New(path)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "failed to load "+name+"'s configuration")
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/index/job/save/main.go
+++ b/cmd/index/job/save/main.go
@@ -38,13 +38,13 @@ func main() {
 			runner.WithName[*config.Data](name),
 			runner.WithVersion[*config.Data](info.Version, maxVersion, minVersion),
 			runner.WithConfigLoader(func(path string) (*config.Data, *config.GlobalConfig, error) {
-				cfg, err := config.NewConfig(path)
+				cfg, err := config.New(path)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "failed to load "+name+"'s configuration")
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/index/operator/main.go
+++ b/cmd/index/operator/main.go
@@ -44,7 +44,7 @@ func main() {
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/manager/index/main.go
+++ b/cmd/manager/index/main.go
@@ -41,13 +41,13 @@ func main() {
 			runner.WithName[*config.Data](name),
 			runner.WithVersion[*config.Data](info.Version, maxVersion, minVersion),
 			runner.WithConfigLoader(func(path string) (*config.Data, *config.GlobalConfig, error) {
-				cfg, err := config.NewConfig(path)
+				cfg, err := config.New(path)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "failed to load "+name+"'s configuration")
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/operator/benchmark/main.go
+++ b/cmd/operator/benchmark/main.go
@@ -41,13 +41,13 @@ func main() {
 			runner.WithName[*config.Config](name),
 			runner.WithVersion[*config.Config](info.Version, maxVersion, minVersion),
 			runner.WithConfigLoader(func(path string) (*config.Config, *config.GlobalConfig, error) {
-				cfg, err := config.NewConfig(path)
+				cfg, err := config.NewData(path)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "failed to load "+name+"'s configuration")
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Config) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Config) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/operator/vald/main.go
+++ b/cmd/operator/vald/main.go
@@ -38,13 +38,13 @@ func main() {
 			runner.WithName[*config.Data](name),
 			runner.WithVersion[*config.Data](info.Version, maxVersion, minVersion),
 			runner.WithConfigLoader(func(path string) (*config.Data, *config.GlobalConfig, error) {
-				cfg, err := config.NewConfig(path)
+				cfg, err := config.New(path)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "failed to load "+name+"'s configuration")
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Data) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/cmd/tools/benchmark/job/main.go
+++ b/cmd/tools/benchmark/job/main.go
@@ -48,7 +48,7 @@ func main() {
 				}
 				return cfg, &cfg.GlobalConfig, nil
 			}),
-			runner.WithDaemonInitializer(func(cfg *config.Config) (runner.Runner, error) {
+			runner.WithDaemonInitializer(func(cfg *config.Config) (runner.Interface, error) {
 				return usecase.New(cfg)
 			}),
 		)

--- a/hack/benchmark/core/benchmark/strategy/bulk_insert.go
+++ b/hack/benchmark/core/benchmark/strategy/bulk_insert.go
@@ -30,8 +30,8 @@ const (
 	maxBulkSize = 100000
 )
 
-func NewBulkInsert(opts ...StrategyOption) benchmark.Strategy {
-	return newStrategy(append([]StrategyOption{
+func NewBulkInsert(opts ...Option) benchmark.Strategy {
+	return newStrategy(append([]Option{
 		WithPropName("BulkInsert"),
 		WithProp32(
 			func(ctx context.Context, b *testing.B, c algorithm.Bit32, dataset assets.Dataset, ids []uint, cnt *uint64) (any, error) {

--- a/hack/benchmark/core/benchmark/strategy/bulk_insert_commit.go
+++ b/hack/benchmark/core/benchmark/strategy/bulk_insert_commit.go
@@ -26,8 +26,8 @@ import (
 	"github.com/vdaas/vald/hack/benchmark/internal/core/algorithm"
 )
 
-func NewBulkInsertCommit(poolSize uint32, opts ...StrategyOption) benchmark.Strategy {
-	return newStrategy(append([]StrategyOption{
+func NewBulkInsertCommit(poolSize uint32, opts ...Option) benchmark.Strategy {
+	return newStrategy(append([]Option{
 		WithPropName("BulkInsertCommit"),
 		WithProp32(
 			func(ctx context.Context, b *testing.B, c algorithm.Bit32, dataset assets.Dataset, ids []uint, cnt *uint64) (any, error) {

--- a/hack/benchmark/core/benchmark/strategy/get_vector.go
+++ b/hack/benchmark/core/benchmark/strategy/get_vector.go
@@ -27,8 +27,8 @@ import (
 	"github.com/vdaas/vald/hack/benchmark/internal/core/algorithm"
 )
 
-func NewGetVector(opts ...StrategyOption) benchmark.Strategy {
-	return newStrategy(append([]StrategyOption{
+func NewGetVector(opts ...Option) benchmark.Strategy {
+	return newStrategy(append([]Option{
 		WithPropName("GetVector"),
 		WithPreProp32(
 			func(ctx context.Context, b *testing.B, c algorithm.Bit32, dataset assets.Dataset) (ids []uint, err error) {

--- a/hack/benchmark/core/benchmark/strategy/insert.go
+++ b/hack/benchmark/core/benchmark/strategy/insert.go
@@ -27,8 +27,8 @@ import (
 	"github.com/vdaas/vald/hack/benchmark/internal/core/algorithm"
 )
 
-func NewInsert(opts ...StrategyOption) benchmark.Strategy {
-	return newStrategy(append([]StrategyOption{
+func NewInsert(opts ...Option) benchmark.Strategy {
+	return newStrategy(append([]Option{
 		WithPropName("Insert"),
 		WithProp32(
 			func(ctx context.Context, b *testing.B, c algorithm.Bit32, dataset assets.Dataset, ids []uint, cnt *uint64) (any, error) {

--- a/hack/benchmark/core/benchmark/strategy/insert_commit.go
+++ b/hack/benchmark/core/benchmark/strategy/insert_commit.go
@@ -27,8 +27,8 @@ import (
 	"github.com/vdaas/vald/hack/benchmark/internal/core/algorithm"
 )
 
-func NewInsertCommit(poolSize uint32, opts ...StrategyOption) benchmark.Strategy {
-	return newStrategy(append([]StrategyOption{
+func NewInsertCommit(poolSize uint32, opts ...Option) benchmark.Strategy {
+	return newStrategy(append([]Option{
 		WithPropName("InsertCommit"),
 		WithProp32(
 			func(ctx context.Context, b *testing.B, c algorithm.Bit32, dataset assets.Dataset, ids []uint, cnt *uint64) (any, error) {

--- a/hack/benchmark/core/benchmark/strategy/remove.go
+++ b/hack/benchmark/core/benchmark/strategy/remove.go
@@ -27,8 +27,8 @@ import (
 	"github.com/vdaas/vald/hack/benchmark/internal/core/algorithm"
 )
 
-func NewRemove(opts ...StrategyOption) benchmark.Strategy {
-	return newStrategy(append([]StrategyOption{
+func NewRemove(opts ...Option) benchmark.Strategy {
+	return newStrategy(append([]Option{
 		WithPropName("Remove"),
 		WithPreProp32(
 			func(ctx context.Context, b *testing.B, c algorithm.Bit32, dataset assets.Dataset) (ids []uint, err error) {

--- a/hack/benchmark/core/benchmark/strategy/search.go
+++ b/hack/benchmark/core/benchmark/strategy/search.go
@@ -27,8 +27,8 @@ import (
 	"github.com/vdaas/vald/hack/benchmark/internal/core/algorithm"
 )
 
-func NewSearch(size int, epsilon, radius float32, opts ...StrategyOption) benchmark.Strategy {
-	return newStrategy(append([]StrategyOption{
+func NewSearch(size int, epsilon, radius float32, opts ...Option) benchmark.Strategy {
+	return newStrategy(append([]Option{
 		WithPropName("Search"),
 		WithPreProp32(
 			func(ctx context.Context, b *testing.B, c algorithm.Bit32, dataset assets.Dataset) (ids []uint, err error) {

--- a/hack/benchmark/core/benchmark/strategy/strategy.go
+++ b/hack/benchmark/core/benchmark/strategy/strategy.go
@@ -43,7 +43,7 @@ type strategy struct {
 	parallel  bool
 }
 
-func newStrategy(opts ...StrategyOption) benchmark.Strategy {
+func newStrategy(opts ...Option) benchmark.Strategy {
 	s := &strategy{
 		// invalid mode.
 		mode: algorithm.Mode(100),

--- a/hack/benchmark/core/benchmark/strategy/strategy_option.go
+++ b/hack/benchmark/core/benchmark/strategy/strategy_option.go
@@ -25,9 +25,9 @@ import (
 	"github.com/vdaas/vald/hack/benchmark/internal/core/algorithm"
 )
 
-type StrategyOption func(*strategy) error
+type Option func(*strategy) error
 
-var defaultStrategyOptions = []StrategyOption{
+var defaultStrategyOptions = []Option{
 	WithPreProp32(func(context.Context, *testing.B, algorithm.Bit32, assets.Dataset) ([]uint, error) {
 		return nil, nil
 	}),
@@ -38,7 +38,7 @@ var defaultStrategyOptions = []StrategyOption{
 
 func WithPreProp32(
 	fn func(context.Context, *testing.B, algorithm.Bit32, assets.Dataset) ([]uint, error),
-) StrategyOption {
+) Option {
 	return func(s *strategy) error {
 		if fn != nil {
 			s.preProp32 = fn
@@ -49,7 +49,7 @@ func WithPreProp32(
 
 func WithProp32(
 	fn func(context.Context, *testing.B, algorithm.Bit32, assets.Dataset, []uint, *uint64) (any, error),
-) StrategyOption {
+) Option {
 	return func(s *strategy) error {
 		if fn != nil {
 			s.prop32 = fn
@@ -60,7 +60,7 @@ func WithProp32(
 
 func WithPreProp64(
 	fn func(context.Context, *testing.B, algorithm.Bit64, assets.Dataset) ([]uint, error),
-) StrategyOption {
+) Option {
 	return func(s *strategy) error {
 		if fn != nil {
 			s.preProp64 = fn
@@ -71,7 +71,7 @@ func WithPreProp64(
 
 func WithProp64(
 	fn func(context.Context, *testing.B, algorithm.Bit64, assets.Dataset, []uint, *uint64) (any, error),
-) StrategyOption {
+) Option {
 	return func(s *strategy) error {
 		if fn != nil {
 			s.prop64 = fn
@@ -80,7 +80,7 @@ func WithProp64(
 	}
 }
 
-func WithPropName(str string) StrategyOption {
+func WithPropName(str string) Option {
 	return func(s *strategy) error {
 		if len(str) != 0 {
 			s.propName = str
@@ -91,7 +91,7 @@ func WithPropName(str string) StrategyOption {
 
 func WithBit32(
 	fn func(context.Context, *testing.B, assets.Dataset) (algorithm.Bit32, algorithm.Closer, error),
-) StrategyOption {
+) Option {
 	return func(s *strategy) (err error) {
 		if fn != nil {
 			s.mode = algorithm.Float32
@@ -103,7 +103,7 @@ func WithBit32(
 
 func WithBit64(
 	fn func(context.Context, *testing.B, assets.Dataset) (algorithm.Bit64, algorithm.Closer, error),
-) StrategyOption {
+) Option {
 	return func(s *strategy) error {
 		if fn != nil {
 			s.mode = algorithm.Float64
@@ -113,7 +113,7 @@ func WithBit64(
 	}
 }
 
-func WithParallel() StrategyOption {
+func WithParallel() Option {
 	return func(s *strategy) error {
 		s.parallel = true
 		return nil

--- a/internal/circuitbreaker/manager.go
+++ b/internal/circuitbreaker/manager.go
@@ -41,8 +41,8 @@ type breakerManager struct {
 	opts []BreakerOption
 }
 
-// NewCircuitBreaker returns CircuitBreaker object if no error occurs.
-func NewCircuitBreaker(opts ...Option) (CircuitBreaker, error) {
+// New returns CircuitBreaker object if no error occurs.
+func New(opts ...Option) (CircuitBreaker, error) {
 	bm := &breakerManager{}
 	for _, opt := range append(defaultOpts, opts...) {
 		if err := opt(bm); err != nil {

--- a/internal/client/v1/client/agent/core/client.go
+++ b/internal/client/v1/client/agent/core/client.go
@@ -87,7 +87,7 @@ func New(opts ...Option) (Client, error) {
 
 func NewAgentClient(cc *grpc.ClientConn) Client {
 	return &singleAgentClient{
-		Client: vald.NewValdClient(cc),
+		Client: vald.NewFromConn(cc),
 		ac:     agent.NewAgentClient(cc),
 	}
 }

--- a/internal/client/v1/client/vald/vald.go
+++ b/internal/client/v1/client/vald/vald.go
@@ -64,7 +64,7 @@ func New(opts ...Option) (Client, error) {
 	return c, nil
 }
 
-func NewValdClient(cc *grpc.ClientConn) Client {
+func NewFromConn(cc *grpc.ClientConn) Client {
 	return &singleClient{vc: vald.NewValdClient(cc)}
 }
 

--- a/internal/compress/zstd.go
+++ b/internal/compress/zstd.go
@@ -27,7 +27,7 @@ import (
 
 type zstdCompressor struct {
 	gobc     Compressor
-	zstd     zstd.Zstd
+	zstd     zstd.Compressor
 	eoptions []zstd.EOption
 }
 

--- a/internal/compress/zstd/zstd.go
+++ b/internal/compress/zstd/zstd.go
@@ -39,16 +39,16 @@ type Decoder interface {
 	WriteTo(w io.Writer) (int64, error)
 }
 
-// Zstd is an interface to create Writer and Reader implementation.
-type Zstd interface {
+// Compressor is an interface to create Writer and Reader implementation.
+type Compressor interface {
 	NewWriter(w io.Writer, opts ...EOption) (Encoder, error)
 	NewReader(r io.Reader, opts ...DOption) (Decoder, error)
 }
 
 type compress struct{}
 
-// New returns Zstd implementation.
-func New() Zstd {
+// New returns Compressor implementation.
+func New() Compressor {
 	return new(compress)
 }
 

--- a/internal/compress/zstd_test.go
+++ b/internal/compress/zstd_test.go
@@ -146,7 +146,7 @@ func Test_zstdCompressor_CompressVector(t *testing.T) {
 	}
 	type fields struct {
 		gobc     Compressor
-		zstd     zstd.Zstd
+		zstd     zstd.Compressor
 		eoptions []zstd.EOption
 	}
 	type want struct {
@@ -405,7 +405,7 @@ func Test_zstdCompressor_DecompressVector(t *testing.T) {
 	}
 	type fields struct {
 		gobc     Compressor
-		zstd     zstd.Zstd
+		zstd     zstd.Compressor
 		eoptions []zstd.EOption
 	}
 	type want struct {
@@ -578,7 +578,7 @@ func Test_zstdCompressor_Reader(t *testing.T) {
 	}
 	type fields struct {
 		gobc     Compressor
-		zstd     zstd.Zstd
+		zstd     zstd.Compressor
 		eoptions []zstd.EOption
 	}
 	type want struct {
@@ -687,7 +687,7 @@ func Test_zstdCompressor_Writer(t *testing.T) {
 	}
 	type fields struct {
 		gobc     Compressor
-		zstd     zstd.Zstd
+		zstd     zstd.Compressor
 		eoptions []zstd.EOption
 	}
 	type want struct {

--- a/internal/config/grpc.go
+++ b/internal/config/grpc.go
@@ -272,7 +272,7 @@ func (g *GRPCClient) Opts() ([]grpc.Option, error) {
 	}
 
 	if g.CircuitBreaker != nil {
-		cb, err := circuitbreaker.NewCircuitBreaker(
+		cb, err := circuitbreaker.New(
 			circuitbreaker.WithBreakerOpts(
 				circuitbreaker.WithClosedErrorRate(g.CircuitBreaker.ClosedErrorRate),
 				circuitbreaker.WithHalfOpenErrorRate(g.CircuitBreaker.HalfOpenErrorRate),

--- a/internal/db/kvs/redis/redis.go
+++ b/internal/db/kvs/redis/redis.go
@@ -34,11 +34,11 @@ var Nil = redis.Nil
 
 // Connector is an interface to connect to Redis servers.
 type Connector interface {
-	Connect(ctx context.Context) (Redis, error)
+	Connect(ctx context.Context) (Client, error)
 }
 
-// Redis is an interface to communicate with Redis servers.
-type Redis interface {
+// Client is an interface to communicate with Redis servers.
+type Client interface {
 	TxPipeline() redis.Pipeliner
 	Ping(context.Context) *StatusCmd
 	Close() error
@@ -61,7 +61,7 @@ type (
 
 type redisClient struct {
 	dialer               net.Dialer
-	client               Redis
+	client               Client
 	limiter              Limiter
 	tlsConfig            *tls.Config
 	dialerFunc           func(ctx context.Context, network, addr string) (net.Conn, error)
@@ -263,7 +263,7 @@ func (rc *redisClient) newClusterClient(ctx context.Context) (c *redis.ClusterCl
 }
 
 // Connect returns Redis instance that has connection to servers.
-func (rc *redisClient) Connect(ctx context.Context) (Redis, error) {
+func (rc *redisClient) Connect(ctx context.Context) (Client, error) {
 	if rc.dialer != nil {
 		rc.dialer.StartDialerCache(ctx)
 		rc.dialerFunc = rc.dialer.GetDialer()
@@ -276,7 +276,7 @@ func (rc *redisClient) Connect(ctx context.Context) (Redis, error) {
 	return rc.ping(ctx)
 }
 
-func (rc *redisClient) ping(ctx context.Context) (r Redis, err error) {
+func (rc *redisClient) ping(ctx context.Context) (r Client, err error) {
 	pctx, cancel := context.WithTimeout(ctx, rc.initialPingTimeLimit)
 	defer cancel()
 	tick := time.NewTicker(rc.initialPingDuration)

--- a/internal/db/kvs/redis/redis_mock.go
+++ b/internal/db/kvs/redis/redis_mock.go
@@ -28,7 +28,7 @@ type MockRedis struct {
 	DelFunc        func(keys ...string) *redis.IntCmd
 }
 
-var _ Redis = (*MockRedis)(nil)
+var _ Client = (*MockRedis)(nil)
 
 func (m *MockRedis) TxPipeline() redis.Pipeliner {
 	return m.TxPipelineFunc()

--- a/internal/db/kvs/redis/redis_test.go
+++ b/internal/db/kvs/redis/redis_test.go
@@ -166,24 +166,24 @@ func Test_redisClient_ping(t *testing.T) {
 		ctx context.Context
 	}
 	type fields struct {
-		client               Redis
+		client               Client
 		initialPingDuration  time.Duration
 		initialPingTimeLimit time.Duration
 	}
 	type want struct {
-		wantR Redis
+		wantR Client
 		err   error
 	}
 	type test struct {
 		want       want
 		args       args
-		checkFunc  func(want, Redis, error) error
+		checkFunc  func(want, Client, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 		name       string
 		fields     fields
 	}
-	defaultCheckFunc := func(w want, gotR Redis, err error) error {
+	defaultCheckFunc := func(w want, gotR Client, err error) error {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 		}
@@ -228,7 +228,7 @@ func Test_redisClient_ping(t *testing.T) {
 				fields: fields{
 					initialPingDuration:  time.Millisecond,
 					initialPingTimeLimit: 3 * time.Millisecond,
-					client: func() Redis {
+					client: func() Client {
 						return &MockRedis{
 							PingFunc: func() (cmd *StatusCmd) {
 								cmd = new(StatusCmd)
@@ -279,7 +279,7 @@ func Test_redisClient_setClient(t *testing.T) {
 		ctx context.Context
 	}
 	type fields struct {
-		client               Redis
+		client               Client
 		dialer               net.Dialer
 		clusterSlots         func(context.Context) ([]redis.ClusterSlot, error)
 		dialerFunc           func(ctx context.Context, network, addr string) (net.Conn, error)
@@ -452,7 +452,7 @@ func Test_redisClient_setClient(t *testing.T) {
 
 func Test_redisClient_newClient(t *testing.T) {
 	type fields struct {
-		client               Redis
+		client               Client
 		dialer               net.Dialer
 		clusterSlots         func(context.Context) ([]redis.ClusterSlot, error)
 		dialerFunc           func(ctx context.Context, network, addr string) (net.Conn, error)
@@ -675,7 +675,7 @@ func Test_redisClient_newClusterClient(t *testing.T) {
 		ctx context.Context
 	}
 	type fields struct {
-		client               Redis
+		client               Client
 		dialer               net.Dialer
 		clusterSlots         func(context.Context) ([]redis.ClusterSlot, error)
 		dialerFunc           func(ctx context.Context, network, addr string) (net.Conn, error)
@@ -925,7 +925,7 @@ func Test_redisClient_Connect(t *testing.T) {
 		ctx context.Context
 	}
 	type fields struct {
-		client               Redis
+		client               Client
 		dialer               net.Dialer
 		clusterSlots         func(ctx context.Context) ([]redis.ClusterSlot, error)
 		dialerFunc           func(ctx context.Context, network, addr string) (net.Conn, error)
@@ -956,19 +956,19 @@ func Test_redisClient_Connect(t *testing.T) {
 		readOnly             bool
 	}
 	type want struct {
-		want Redis
+		want Client
 		err  error
 	}
 	type test struct {
 		want       want
 		args       args
-		checkFunc  func(want, Redis, error) error
+		checkFunc  func(want, Client, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 		name       string
 		fields     fields
 	}
-	defaultCheckFunc := func(w want, got Redis, err error) error {
+	defaultCheckFunc := func(w want, got Client, err error) error {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 		}

--- a/internal/k8s/vald/benchmark/job/job.go
+++ b/internal/k8s/vald/benchmark/job/job.go
@@ -22,13 +22,13 @@ import (
 	v1 "github.com/vdaas/vald/internal/k8s/vald/benchmark/api/v1"
 )
 
-type BenchmarkJobWatcher k8s.ResourceController
+type BenchmarkWatcher k8s.ResourceController
 
-// New creates a BenchmarkJobWatcher that lists ValdBenchmarkJob resources on
+// New creates a BenchmarkWatcher that lists ValdBenchmarkJob resources on
 // every reconcile and reports them, keyed by name, to the callback registered
 // via WithOnReconcileFunc. Option application errors abort construction only
 // when critical; any other option error is logged as a warning and skipped.
-func New(opts ...Option) (BenchmarkJobWatcher, error) {
+func New(opts ...Option) (BenchmarkWatcher, error) {
 	return vald.NewListWatcher(
 		v1.AddToScheme,
 		func(job *v1.ValdBenchmarkJob) v1.ValdBenchmarkJob { return *job },

--- a/internal/k8s/vald/benchmark/job/job_template.go
+++ b/internal/k8s/vald/benchmark/job/job_template.go
@@ -52,8 +52,8 @@ const (
 	containerPortReadiness = 3001
 )
 
-type BenchmarkJobTpl interface {
-	CreateJobTpl(opts ...BenchmarkJobOption) (k8s.Job, error)
+type BenchmarkTpl interface {
+	CreateJobTpl(opts ...BenchmarkOption) (k8s.Job, error)
 }
 
 // fieldRefEnvVar builds an EnvVar sourced from the downward-API field at
@@ -81,9 +81,9 @@ type benchmarkJobTpl struct {
 // Option application errors abort construction only when critical (an empty
 // required field such as the container name or image); any other option error
 // is logged as a warning and skipped.
-func NewBenchmarkJob(opts ...BenchmarkJobTemplateOption) (BenchmarkJobTpl, error) {
+func NewBenchmarkJob(opts ...BenchmarkTemplateOption) (BenchmarkTpl, error) {
 	bjTpl := new(benchmarkJobTpl)
-	for _, opt := range append(defaultBenchmarkJobTemplateOptions, opts...) {
+	for _, opt := range append(defaultBenchmarkTemplateOptions, opts...) {
 		if err := opt(bjTpl); err != nil {
 			if abort, oerr := vald.SkipNonCriticalOptionError(err, opt); abort {
 				return nil, oerr
@@ -97,7 +97,7 @@ func NewBenchmarkJob(opts ...BenchmarkJobTemplateOption) (BenchmarkJobTpl, error
 // given options, with the same severity handling as NewBenchmarkJob: only
 // critical option errors (an empty job name) abort, any other option error is
 // logged as a warning and skipped.
-func (b *benchmarkJobTpl) CreateJobTpl(opts ...BenchmarkJobOption) (k8s.Job, error) {
+func (b *benchmarkJobTpl) CreateJobTpl(opts ...BenchmarkOption) (k8s.Job, error) {
 	for _, opt := range append(defaultBenchmarkJobOpts, opts...) {
 		if err := opt(&b.jobTpl); err != nil {
 			if abort, oerr := vald.SkipNonCriticalOptionError(err, opt); abort {

--- a/internal/k8s/vald/benchmark/job/job_template_option.go
+++ b/internal/k8s/vald/benchmark/job/job_template_option.go
@@ -22,21 +22,21 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// BenchmarkJobTemplateOption configures the benchmark job template built by
+// BenchmarkTemplateOption configures the benchmark job template built by
 // NewBenchmarkJob. Empty required fields (container name/image, operator
 // config map) fail with errors.ErrCriticalOption and abort construction; any
 // other invalid value fails with errors.ErrInvalidOption, which NewBenchmarkJob
 // logs as a warning and skips.
-type BenchmarkJobTemplateOption func(b *benchmarkJobTpl) error
+type BenchmarkTemplateOption func(b *benchmarkJobTpl) error
 
-var defaultBenchmarkJobTemplateOptions = []BenchmarkJobTemplateOption{
+var defaultBenchmarkTemplateOptions = []BenchmarkTemplateOption{
 	WithContainerName("vald-benchmark-job"),
 	WithContainerImage("vdaas/vald-benchmark-job"),
 	WithImagePullPolicy(PullAlways),
 }
 
 // WithContainerName sets the docker container name of benchmark job.
-func WithContainerName(name string) BenchmarkJobTemplateOption {
+func WithContainerName(name string) BenchmarkTemplateOption {
 	return func(b *benchmarkJobTpl) error {
 		if name == "" {
 			return errors.NewErrCriticalOption("containerName", name)
@@ -47,7 +47,7 @@ func WithContainerName(name string) BenchmarkJobTemplateOption {
 }
 
 // WithContainerImage sets the docker image path for benchmark job.
-func WithContainerImage(name string) BenchmarkJobTemplateOption {
+func WithContainerImage(name string) BenchmarkTemplateOption {
 	return func(b *benchmarkJobTpl) error {
 		if name == "" {
 			return errors.NewErrCriticalOption("containerImage", name)
@@ -58,7 +58,7 @@ func WithContainerImage(name string) BenchmarkJobTemplateOption {
 }
 
 // WithImagePullPolicy sets the docker image pull policy for benchmark job.
-func WithImagePullPolicy(p ImagePullPolicy) BenchmarkJobTemplateOption {
+func WithImagePullPolicy(p ImagePullPolicy) BenchmarkTemplateOption {
 	return func(b *benchmarkJobTpl) error {
 		if p == "" {
 			return errors.NewErrInvalidOption("imagePullPolicy", p)
@@ -69,7 +69,7 @@ func WithImagePullPolicy(p ImagePullPolicy) BenchmarkJobTemplateOption {
 }
 
 // WithOperatorConfigMap sets the configMapName for mounting Job Pod.
-func WithOperatorConfigMap(cm string) BenchmarkJobTemplateOption {
+func WithOperatorConfigMap(cm string) BenchmarkTemplateOption {
 	return func(b *benchmarkJobTpl) error {
 		if cm == "" {
 			return errors.NewErrCriticalOption("operatorConfigMap", cm)
@@ -79,11 +79,11 @@ func WithOperatorConfigMap(cm string) BenchmarkJobTemplateOption {
 	}
 }
 
-// BenchmarkJobOption represents the option for create benchmark job template.
+// BenchmarkOption represents the option for create benchmark job template.
 // An empty job name fails with errors.ErrCriticalOption and aborts
 // CreateJobTpl; any other invalid value fails with errors.ErrInvalidOption,
 // which CreateJobTpl logs as a warning and skips.
-type BenchmarkJobOption func(b *k8s.Job) error
+type BenchmarkOption func(b *k8s.Job) error
 
 const (
 	// defaultTTLSeconds represents the default TTLSecondsAfterFinished for benchmark job template.
@@ -94,7 +94,7 @@ const (
 	defaultParallelism int32 = 1
 )
 
-var defaultBenchmarkJobOpts = []BenchmarkJobOption{
+var defaultBenchmarkJobOpts = []BenchmarkOption{
 	WithSvcAccountName(svcAccount),
 	WithRestartPolicy(RestartPolicyNever),
 	WithTTLSecondsAfterFinished(defaultTTLSeconds),
@@ -103,7 +103,7 @@ var defaultBenchmarkJobOpts = []BenchmarkJobOption{
 }
 
 // WithSvcAccountName sets the service account name for benchmark job.
-func WithSvcAccountName(name string) BenchmarkJobOption {
+func WithSvcAccountName(name string) BenchmarkOption {
 	return func(b *k8s.Job) error {
 		if name == "" {
 			return errors.NewErrInvalidOption("svcAccountName", name)
@@ -114,7 +114,7 @@ func WithSvcAccountName(name string) BenchmarkJobOption {
 }
 
 // WithRestartPolicy sets the job restart policy for benchmark job.
-func WithRestartPolicy(rp RestartPolicy) BenchmarkJobOption {
+func WithRestartPolicy(rp RestartPolicy) BenchmarkOption {
 	return func(b *k8s.Job) error {
 		if rp == "" {
 			return errors.NewErrInvalidOption("restartPolicy", rp)
@@ -125,7 +125,7 @@ func WithRestartPolicy(rp RestartPolicy) BenchmarkJobOption {
 }
 
 // WithName sets the job name of benchmark job.
-func WithName(name string) BenchmarkJobOption {
+func WithName(name string) BenchmarkOption {
 	return func(b *k8s.Job) error {
 		if name == "" {
 			return errors.NewErrCriticalOption("name", name)
@@ -136,7 +136,7 @@ func WithName(name string) BenchmarkJobOption {
 }
 
 // WithNamespace specify namespace where job will execute.
-func WithNamespace(ns string) BenchmarkJobOption {
+func WithNamespace(ns string) BenchmarkOption {
 	return func(b *k8s.Job) error {
 		if ns == "" {
 			return errors.NewErrInvalidOption("namespace", ns)
@@ -147,7 +147,7 @@ func WithNamespace(ns string) BenchmarkJobOption {
 }
 
 // WithOwnerRef sets the OwnerReference to the job resource.
-func WithOwnerRef(refs []k8s.OwnerReference) BenchmarkJobOption {
+func WithOwnerRef(refs []k8s.OwnerReference) BenchmarkOption {
 	return func(b *k8s.Job) error {
 		if len(refs) == 0 {
 			return errors.NewErrInvalidOption("ownerRefs", refs)
@@ -158,7 +158,7 @@ func WithOwnerRef(refs []k8s.OwnerReference) BenchmarkJobOption {
 }
 
 // WithCompletions sets the job completion.
-func WithCompletions(com int32) BenchmarkJobOption {
+func WithCompletions(com int32) BenchmarkOption {
 	return func(b *k8s.Job) error {
 		if com > 1 {
 			b.Spec.Completions = &com
@@ -168,7 +168,7 @@ func WithCompletions(com int32) BenchmarkJobOption {
 }
 
 // WithParallelism sets the job parallelism.
-func WithParallelism(parallelism int32) BenchmarkJobOption {
+func WithParallelism(parallelism int32) BenchmarkOption {
 	return func(b *k8s.Job) error {
 		if parallelism > 1 {
 			b.Spec.Parallelism = &parallelism
@@ -178,7 +178,7 @@ func WithParallelism(parallelism int32) BenchmarkJobOption {
 }
 
 // WithLabel sets the label to the job resource.
-func WithLabel(label map[string]string) BenchmarkJobOption {
+func WithLabel(label map[string]string) BenchmarkOption {
 	return func(b *k8s.Job) error {
 		if len(label) == 0 {
 			return errors.NewErrInvalidOption("label", label)
@@ -189,7 +189,7 @@ func WithLabel(label map[string]string) BenchmarkJobOption {
 }
 
 // WithTTLSecondsAfterFinished sets the TTLSecondsAfterFinished to the job template.
-func WithTTLSecondsAfterFinished(ttl int32) BenchmarkJobOption {
+func WithTTLSecondsAfterFinished(ttl int32) BenchmarkOption {
 	return func(b *k8s.Job) error {
 		if ttl > 0 {
 			b.Spec.TTLSecondsAfterFinished = &ttl

--- a/internal/k8s/vald/benchmark/job/job_template_test.go
+++ b/internal/k8s/vald/benchmark/job/job_template_test.go
@@ -37,7 +37,7 @@ func TestNewBenchmarkJob_OptionErrorSeverity(t *testing.T) {
 		t.Parallel()
 
 		tests := []struct {
-			opt  BenchmarkJobTemplateOption
+			opt  BenchmarkTemplateOption
 			name string
 		}{
 			{name: "container name", opt: WithContainerName("")},
@@ -108,7 +108,7 @@ func TestCreateJobTpl_OptionErrorSeverity(t *testing.T) {
 		t.Parallel()
 
 		tests := []struct {
-			opt  BenchmarkJobOption
+			opt  BenchmarkOption
 			name string
 		}{
 			{name: "empty namespace", opt: WithNamespace("")},
@@ -356,21 +356,21 @@ func TestCreateJobTpl_FieldRefEnvVars(t *testing.T) {
 //
 // func TestNewBenchmarkJob(t *testing.T) {
 // 	type args struct {
-// 		opts []BenchmarkJobTemplateOption
+// 		opts []BenchmarkTemplateOption
 // 	}
 // 	type want struct {
-// 		want BenchmarkJobTpl
+// 		want BenchmarkTpl
 // 		err  error
 // 	}
 // 	type test struct {
 // 		name       string
 // 		args       args
 // 		want       want
-// 		checkFunc  func(want, BenchmarkJobTpl, error) error
+// 		checkFunc  func(want, BenchmarkTpl, error) error
 // 		beforeFunc func(*testing.T, args)
 // 		afterFunc  func(*testing.T, args)
 // 	}
-// 	defaultCheckFunc := func(w want, got BenchmarkJobTpl, err error) error {
+// 	defaultCheckFunc := func(w want, got BenchmarkTpl, err error) error {
 // 		if !errors.Is(err, w.err) {
 // 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 // 		}
@@ -445,7 +445,7 @@ func TestCreateJobTpl_FieldRefEnvVars(t *testing.T) {
 //
 // func Test_benchmarkJobTpl_CreateJobTpl(t *testing.T) {
 // 	type args struct {
-// 		opts []BenchmarkJobOption
+// 		opts []BenchmarkOption
 // 	}
 // 	type fields struct {
 // 		jobTpl             k8s.Job

--- a/internal/k8s/vald/benchmark/job/job_test.go
+++ b/internal/k8s/vald/benchmark/job/job_test.go
@@ -274,7 +274,7 @@ func TestNew_ProductionCallPattern(t *testing.T) {
 	}
 }
 
-// TestNew_Metadata verifies New() returns a BenchmarkJobWatcher whose
+// TestNew_Metadata verifies New() returns a BenchmarkWatcher whose
 // GetName() reflects WithControllerName, and that it plugs into the batch
 // watch/list contract (For unused, Watches installed) rather than the
 // hand-rolled For()-based contract the old reconciler used.
@@ -437,18 +437,18 @@ func TestNew_Reconcile(t *testing.T) {
 // 		opts []Option
 // 	}
 // 	type want struct {
-// 		want BenchmarkJobWatcher
+// 		want BenchmarkWatcher
 // 		err  error
 // 	}
 // 	type test struct {
 // 		name       string
 // 		args       args
 // 		want       want
-// 		checkFunc  func(want, BenchmarkJobWatcher, error) error
+// 		checkFunc  func(want, BenchmarkWatcher, error) error
 // 		beforeFunc func(*testing.T, args)
 // 		afterFunc  func(*testing.T, args)
 // 	}
-// 	defaultCheckFunc := func(w want, got BenchmarkJobWatcher, err error) error {
+// 	defaultCheckFunc := func(w want, got BenchmarkWatcher, err error) error {
 // 		if !errors.Is(err, w.err) {
 // 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 // 		}

--- a/internal/k8s/vald/benchmark/scenario/scenario.go
+++ b/internal/k8s/vald/benchmark/scenario/scenario.go
@@ -22,14 +22,14 @@ import (
 	v1 "github.com/vdaas/vald/internal/k8s/vald/benchmark/api/v1"
 )
 
-type BenchmarkScenarioWatcher k8s.ResourceController
+type BenchmarkWatcher k8s.ResourceController
 
-// New builds a BenchmarkScenarioWatcher that lists ValdBenchmarkScenario
+// New builds a BenchmarkWatcher that lists ValdBenchmarkScenario
 // objects on every reconcile and hands them to the configured
 // OnReconcileFunc callback as a map keyed by object name. Option application
 // errors abort construction only when critical; any other option error is
 // logged as a warning and skipped.
-func New(opts ...Option) (BenchmarkScenarioWatcher, error) {
+func New(opts ...Option) (BenchmarkWatcher, error) {
 	return vald.NewListWatcher(
 		v1.AddToScheme,
 		func(sc *v1.ValdBenchmarkScenario) v1.ValdBenchmarkScenario { return *sc },

--- a/internal/k8s/vald/benchmark/scenario/scenario_test.go
+++ b/internal/k8s/vald/benchmark/scenario/scenario_test.go
@@ -115,7 +115,7 @@ func newReconciler(t *testing.T, client k8s.Client, opts ...Option) k8s.Reconcil
 func TestNew(t *testing.T) {
 	t.Parallel()
 
-	t.Run("returns a BenchmarkScenarioWatcher with the configured name", func(t *testing.T) {
+	t.Run("returns a BenchmarkWatcher with the configured name", func(t *testing.T) {
 		t.Parallel()
 
 		watcher, err := New(WithControllerName(testControllerName))

--- a/internal/k8s/vald/mirror/target/option.go
+++ b/internal/k8s/vald/mirror/target/option.go
@@ -20,25 +20,25 @@ import (
 )
 
 // Option represents the functional option for the settings collected by New;
-// it is the Target instantiation of the shared watcher factory option, which
+// it is the Endpoint instantiation of the shared watcher factory option, which
 // validates every value it is given.
-type Option = vald.WatcherOption[Target]
+type Option = vald.WatcherOption[Endpoint]
 
 // WithControllerName returns the option to set the name of controller; an
 // empty name is rejected with errors.ErrInvalidOption.
 func WithControllerName(name string) Option {
-	return vald.WithWatcherControllerName[Target](name)
+	return vald.WithWatcherControllerName[Endpoint](name)
 }
 
 // WithOnErrorFunc returns the option to set the function to notify an error;
 // a nil callback is rejected with errors.ErrInvalidOption.
 func WithOnErrorFunc(f func(error)) Option {
-	return vald.WithWatcherOnErrorFunc[Target](f)
+	return vald.WithWatcherOnErrorFunc[Endpoint](f)
 }
 
 // WithOnReconcileFunc returns the option to set the function to get the
 // reconciled result; a nil callback is rejected with errors.ErrInvalidOption.
-func WithOnReconcileFunc(f func(context.Context, map[string]Target)) Option {
+func WithOnReconcileFunc(f func(context.Context, map[string]Endpoint)) Option {
 	return vald.WithWatcherOnReconcileFunc(f)
 }
 
@@ -48,12 +48,12 @@ func WithOnReconcileFunc(f func(context.Context, map[string]Target)) Option {
 // wins (known pre-existing limitation of the shared watcher factory, kept
 // as-is).
 func WithNamespaces(nss ...string) Option {
-	return vald.WithWatcherNamespaces[Target](nss...)
+	return vald.WithWatcherNamespaces[Endpoint](nss...)
 }
 
 // WithLabels returns the option to set the label selector to get resources
 // matching the given label; an empty (or nil) label set is rejected with
 // errors.ErrInvalidOption.
 func WithLabels(labels map[string]string) Option {
-	return vald.WithWatcherLabels[Target](labels)
+	return vald.WithWatcherLabels[Endpoint](labels)
 }

--- a/internal/k8s/vald/mirror/target/target.go
+++ b/internal/k8s/vald/mirror/target/target.go
@@ -33,7 +33,7 @@ const (
 	MirrorTargetPhaseUnknown      = mirrv1.MirrorTargetUnknown
 )
 
-type Target struct {
+type Endpoint struct {
 	Colocation string
 	Host       string
 	Phase      MirrorTargetPhase
@@ -41,15 +41,15 @@ type Target struct {
 }
 
 // New creates a MirrorTargetWatcher that lists ValdMirrorTarget resources on
-// every reconcile and reports them, converted into Target values keyed by
+// every reconcile and reports them, converted into Endpoint values keyed by
 // name, to the callback registered via WithOnReconcileFunc. Option
 // application errors abort construction only when critical; any other option
 // error is logged as a warning and skipped.
 func New(opts ...Option) (MirrorTargetWatcher, error) {
 	return vald.NewListWatcher(
 		mirrv1.AddToScheme,
-		func(m *mirrv1.ValdMirrorTarget) Target {
-			return Target{
+		func(m *mirrv1.ValdMirrorTarget) Endpoint {
+			return Endpoint{
 				Colocation: m.Spec.Colocation,
 				Host:       m.Spec.Target.Host,
 				Port:       m.Spec.Target.Port,

--- a/internal/k8s/vald/mirror/target/target_test.go
+++ b/internal/k8s/vald/mirror/target/target_test.go
@@ -117,7 +117,7 @@ func TestNew_ControllerName(t *testing.T) {
 
 			watcher, err := New(
 				WithControllerName(tc.opt),
-				WithOnReconcileFunc(func(context.Context, map[string]Target) {}),
+				WithOnReconcileFunc(func(context.Context, map[string]Endpoint) {}),
 			)
 			if err != nil {
 				t.Fatalf("New() error = %v, want nil", err)
@@ -164,13 +164,13 @@ func TestNew_InvalidOptionsAreNonFatal(t *testing.T) {
 
 // TestNew_Reconcile drives the reconciler returned by New() end-to-end
 // through a fake controller-runtime client, characterizing the List ->
-// map[string]Target conversion and the namespace/label filtering options.
+// map[string]Endpoint conversion and the namespace/label filtering options.
 func TestNew_Reconcile(t *testing.T) {
 	t.Parallel()
 
 	type test struct {
 		client  func(t *testing.T) k8s.Client
-		targets map[string]Target
+		targets map[string]Endpoint
 		name    string
 		opts    []Option
 	}
@@ -185,7 +185,7 @@ func TestNew_Reconcile(t *testing.T) {
 					newMirrorTarget("t2", "default", testHostB, 8082, testColocationAZB, MirrorTargetPhasePending),
 				)
 			},
-			targets: map[string]Target{
+			targets: map[string]Endpoint{
 				"t1": {Colocation: testColocationAZA, Host: testHostA, Port: 8081, Phase: MirrorTargetPhaseConnected},
 				"t2": {Colocation: testColocationAZB, Host: testHostB, Port: 8082, Phase: MirrorTargetPhasePending},
 			},
@@ -200,7 +200,7 @@ func TestNew_Reconcile(t *testing.T) {
 				)
 			},
 			opts: []Option{WithNamespaces("ns-a")},
-			targets: map[string]Target{
+			targets: map[string]Endpoint{
 				"t1": {Colocation: testColocationAZA, Host: testHostA, Port: 8081, Phase: MirrorTargetPhaseConnected},
 			},
 		},
@@ -215,7 +215,7 @@ func TestNew_Reconcile(t *testing.T) {
 				return newFakeClient(t, a, b)
 			},
 			opts: []Option{WithLabels(map[string]string{testRoleLabelKey: "primary"})},
-			targets: map[string]Target{
+			targets: map[string]Endpoint{
 				"t1": {Colocation: testColocationAZA, Host: testHostA, Port: 8081, Phase: MirrorTargetPhaseConnected},
 			},
 		},
@@ -226,10 +226,10 @@ func TestNew_Reconcile(t *testing.T) {
 			t.Parallel()
 
 			var errored int
-			var got map[string]Target
+			var got map[string]Endpoint
 			watcher, err := New(append([]Option{
 				WithControllerName("mirror target watcher"),
-				WithOnReconcileFunc(func(_ context.Context, m map[string]Target) { got = m }),
+				WithOnReconcileFunc(func(_ context.Context, m map[string]Endpoint) { got = m }),
 				WithOnErrorFunc(func(error) { errored++ }),
 			}, tc.opts...)...)
 			if err != nil {
@@ -314,7 +314,7 @@ func TestNew_Reconcile_ListErrors(t *testing.T) {
 			var errored int
 			watcher, err := New(
 				WithControllerName("mirror target watcher"),
-				WithOnReconcileFunc(func(context.Context, map[string]Target) {}),
+				WithOnReconcileFunc(func(context.Context, map[string]Endpoint) {}),
 				WithOnErrorFunc(func(error) { errored++ }),
 			)
 			if err != nil {

--- a/internal/log/glg/glg.go
+++ b/internal/log/glg/glg.go
@@ -40,7 +40,7 @@ type logger struct {
 }
 
 // New returns a new logger instance.
-func New(opts ...Option) log.Logger {
+func New(opts ...Option) log.Interface {
 	l := new(logger)
 	for _, opt := range append(defaultOptions, opts...) {
 		opt(l)

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	l    logger.Logger
+	l    logger.Interface
 	once sync.Once
 )
 
@@ -59,7 +59,7 @@ func Close() error {
 	return l.Close()
 }
 
-func getLogger(o *option) logger.Logger {
+func getLogger(o *option) logger.Interface {
 	switch o.logType {
 	case logger.NOP:
 		return nop.New()

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -40,17 +40,17 @@ func TestInit(t *testing.T) {
 		opts []Option
 	}
 	type want struct {
-		l logger.Logger
+		l logger.Interface
 	}
 	type test struct {
 		want       want
-		checkFunc  func(want, logger.Logger) error
+		checkFunc  func(want, logger.Interface) error
 		beforeFunc func(*testing.T, args)
 		afterFunc  func(*testing.T, args)
 		name       string
 		args       args
 	}
-	defaultCheckFunc := func(w want, got logger.Logger) error {
+	defaultCheckFunc := func(w want, got logger.Interface) error {
 		if !reflect.DeepEqual(got, l) {
 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.l)
 		}
@@ -121,17 +121,17 @@ func Test_getLogger(t *testing.T) {
 		o *option
 	}
 	type want struct {
-		want logger.Logger
+		want logger.Interface
 	}
 	type test struct {
 		want       want
 		args       args
-		checkFunc  func(want, logger.Logger) error
+		checkFunc  func(want, logger.Interface) error
 		beforeFunc func(*testing.T, args)
 		afterFunc  func(*testing.T, args)
 		name       string
 	}
-	defaultCheckFunc := func(w want, got logger.Logger) error {
+	defaultCheckFunc := func(w want, got logger.Interface) error {
 		if !reflect.DeepEqual(got, w.want) {
 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
 		}
@@ -146,7 +146,7 @@ func Test_getLogger(t *testing.T) {
 						logType: logger.ZAP,
 					},
 				},
-				checkFunc: func(w want, got logger.Logger) error {
+				checkFunc: func(w want, got logger.Interface) error {
 					if got == nil {
 						return errors.New("got object is empty")
 					}
@@ -180,7 +180,7 @@ func Test_getLogger(t *testing.T) {
 					glg.WithLevel(level.Unknown.String()),
 				),
 			},
-			checkFunc: func(w want, got logger.Logger) error {
+			checkFunc: func(w want, got logger.Interface) error {
 				if got == nil {
 					return errors.New("got object is empty")
 				}
@@ -198,7 +198,7 @@ func Test_getLogger(t *testing.T) {
 					glg.WithLevel(level.Unknown.String()),
 				),
 			},
-			checkFunc: func(w want, got logger.Logger) error {
+			checkFunc: func(w want, got logger.Interface) error {
 				if got == nil {
 					return errors.New("got object is empty")
 				}

--- a/internal/log/logger/iface.go
+++ b/internal/log/logger/iface.go
@@ -16,7 +16,7 @@
 
 package logger
 
-type Logger interface {
+type Interface interface {
 	// Debug logs the vals at Debug level.
 	Debug(vals ...any)
 

--- a/internal/log/nop/nop.go
+++ b/internal/log/nop/nop.go
@@ -18,7 +18,7 @@ import "github.com/vdaas/vald/internal/log/logger"
 type nopLogger struct{}
 
 // New returns a new logger instance.
-func New() logger.Logger {
+func New() logger.Interface {
 	return new(nopLogger)
 }
 

--- a/internal/log/nop/nop_test.go
+++ b/internal/log/nop/nop_test.go
@@ -25,16 +25,16 @@ import (
 func TestNew(t *testing.T) {
 	t.Parallel()
 	type want struct {
-		want logger.Logger
+		want logger.Interface
 	}
 	type test struct {
 		want       want
-		checkFunc  func(want, logger.Logger) error
+		checkFunc  func(want, logger.Interface) error
 		beforeFunc func()
 		afterFunc  func()
 		name       string
 	}
-	defaultCheckFunc := func(w want, got logger.Logger) error {
+	defaultCheckFunc := func(w want, got logger.Interface) error {
 		if !reflect.DeepEqual(got, w.want) {
 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
 		}
@@ -42,7 +42,7 @@ func TestNew(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "return logger.Logger",
+			name: "return logger.Interface",
 			want: want{
 				want: new(nopLogger),
 			},

--- a/internal/log/option.go
+++ b/internal/log/option.go
@@ -38,13 +38,13 @@ var defaultOptions = []Option{
 }
 
 type option struct {
-	logger  logger.Logger
+	logger  logger.Interface
 	logType logger.Type
 	level   level.Level
 	format  format.Format
 }
 
-func WithLogger(l logger.Logger) Option {
+func WithLogger(l logger.Interface) Option {
 	return func(o *option) {
 		if l == nil {
 			return

--- a/internal/log/option_test.go
+++ b/internal/log/option_test.go
@@ -28,7 +28,7 @@ import (
 func TestWithLogger(t *testing.T) {
 	type T = option
 	type args struct {
-		logger logger.Logger
+		logger logger.Interface
 	}
 	type want struct {
 		obj *T

--- a/internal/log/zap/zap.go
+++ b/internal/log/zap/zap.go
@@ -42,7 +42,7 @@ type logger struct {
 }
 
 // New returns a new logger instance.
-func New(opts ...Option) (log.Logger, error) {
+func New(opts ...Option) (log.Interface, error) {
 	l := new(logger)
 	for _, opt := range append(defaultOpts, opts...) {
 		opt(l)

--- a/internal/log/zap/zap_test.go
+++ b/internal/log/zap/zap_test.go
@@ -36,13 +36,13 @@ func TestNew(t *testing.T) {
 	}
 	type test struct {
 		want       want
-		checkFunc  func(want, log.Logger, error) error
+		checkFunc  func(want, log.Interface, error) error
 		beforeFunc func(args)
 		afterFunc  func(args)
 		name       string
 		args       args
 	}
-	defaultCheckFunc := func(w want, got log.Logger, err error) error {
+	defaultCheckFunc := func(w want, got log.Interface, err error) error {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 		}
@@ -68,7 +68,7 @@ func TestNew(t *testing.T) {
 					want: &logger{},
 					err:  nil,
 				},
-				checkFunc: func(w want, got log.Logger, err error) error {
+				checkFunc: func(w want, got log.Interface, err error) error {
 					if !called {
 						return errors.New("Option function is not applied")
 					}

--- a/internal/net/grpc/interceptor/client/metric/metric.go
+++ b/internal/net/grpc/interceptor/client/metric/metric.go
@@ -36,7 +36,7 @@ const (
 	gRPCStatus        = "grpc_client_status"
 )
 
-func ClientMetricInterceptors() (grpc.UnaryClientInterceptor, grpc.StreamClientInterceptor, error) {
+func ClientInterceptors() (grpc.UnaryClientInterceptor, grpc.StreamClientInterceptor, error) {
 	meter := metrics.GetMeter()
 
 	latencyHistogram, err := meter.Float64Histogram(

--- a/internal/net/grpc/interceptor/client/metric/metric_test.go
+++ b/internal/net/grpc/interceptor/client/metric/metric_test.go
@@ -15,7 +15,7 @@ package metric
 
 // NOT IMPLEMENTED BELOW
 //
-// func TestClientMetricInterceptors(t *testing.T) {
+// func TestClientInterceptors(t *testing.T) {
 // 	type want struct {
 // 		want  grpc.UnaryClientInterceptor
 // 		want1 grpc.StreamClientInterceptor
@@ -90,7 +90,7 @@ package metric
 // 				checkFunc = defaultCheckFunc
 // 			}
 //
-// 			got, got1, err := ClientMetricInterceptors()
+// 			got, got1, err := ClientInterceptors()
 // 			if err := checkFunc(test.want, got, got1, err); err != nil {
 // 				tt.Errorf("error = %v", err)
 // 			}

--- a/internal/net/grpc/interceptor/server/recover/recover.go
+++ b/internal/net/grpc/interceptor/server/recover/recover.go
@@ -23,7 +23,7 @@ import (
 	"github.com/vdaas/vald/internal/safety"
 )
 
-func RecoverInterceptor() grpc.UnaryServerInterceptor {
+func Interceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
 		req any,
@@ -38,7 +38,7 @@ func RecoverInterceptor() grpc.UnaryServerInterceptor {
 	}
 }
 
-func RecoverStreamInterceptor() grpc.StreamServerInterceptor {
+func StreamInterceptor() grpc.StreamServerInterceptor {
 	return func(
 		srv any,
 		ss grpc.ServerStream,

--- a/internal/net/grpc/interceptor/server/recover/recover_test.go
+++ b/internal/net/grpc/interceptor/server/recover/recover_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 
 // NOT IMPLEMENTED BELOW
 //
-// func TestRecoverInterceptor(t *testing.T) {
+// func TestInterceptor(t *testing.T) {
 // 	type want struct {
 // 		want grpc.UnaryServerInterceptor
 // 	}
@@ -95,7 +95,7 @@ func TestMain(m *testing.M) {
 // 				checkFunc = defaultCheckFunc
 // 			}
 //
-// 			got := RecoverInterceptor()
+// 			got := Interceptor()
 // 			if err := checkFunc(test.want, got); err != nil {
 // 				tt.Errorf("error = %v", err)
 // 			}
@@ -103,7 +103,7 @@ func TestMain(m *testing.M) {
 // 	}
 // }
 //
-// func TestRecoverStreamInterceptor(t *testing.T) {
+// func TestStreamInterceptor(t *testing.T) {
 // 	type want struct {
 // 		want grpc.StreamServerInterceptor
 // 	}
@@ -170,7 +170,7 @@ func TestMain(m *testing.M) {
 // 				checkFunc = defaultCheckFunc
 // 			}
 //
-// 			got := RecoverStreamInterceptor()
+// 			got := StreamInterceptor()
 // 			if err := checkFunc(test.want, got); err != nil {
 // 				tt.Errorf("error = %v", err)
 // 			}

--- a/internal/net/grpc/option.go
+++ b/internal/net/grpc/option.go
@@ -643,7 +643,7 @@ func WithClientInterceptors(names ...string) Option {
 					WithStatsHandler(trace.NewStatsHandler()),
 				)
 			case "metricinterceptor", "metric":
-				uci, sci, err := metric.ClientMetricInterceptors()
+				uci, sci, err := metric.ClientInterceptors()
 				if err != nil {
 					lerr := errors.NewErrCriticalOption("gRPCInterceptors", "metric", errors.Wrap(err, "failed to create interceptor"))
 					log.Warn(lerr.Error())

--- a/internal/runner/option.go
+++ b/internal/runner/option.go
@@ -50,7 +50,7 @@ func WithConfigLoader[T any](f func(string) (T, *config.GlobalConfig, error)) Op
 	}
 }
 
-func WithDaemonInitializer[T any](f func(T) (Runner, error)) Option[T] {
+func WithDaemonInitializer[T any](f func(T) (Interface, error)) Option[T] {
 	return func(r *runner[T]) {
 		if f != nil {
 			r.initializeDaemon = f

--- a/internal/runner/option_test.go
+++ b/internal/runner/option_test.go
@@ -296,7 +296,7 @@ func TestWithConfigLoader(t *testing.T) {
 func TestWithDaemonInitializer(t *testing.T) {
 	type T = runner[any]
 	type args struct {
-		f func(any) (Runner, error)
+		f func(any) (Interface, error)
 	}
 	type want struct {
 		obj *T
@@ -319,7 +319,7 @@ func TestWithDaemonInitializer(t *testing.T) {
 
 	tests := []test{
 		func() test {
-			f := func(any) (Runner, error) {
+			f := func(any) (Interface, error) {
 				return nil, nil
 			}
 			return test{

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -39,7 +39,7 @@ import (
 	"go.uber.org/automaxprocs/maxprocs"
 )
 
-type Runner interface {
+type Interface interface {
 	PreStart(ctx context.Context) error
 	Start(ctx context.Context) (<-chan error, error)
 	PreStop(ctx context.Context) error
@@ -49,7 +49,7 @@ type Runner interface {
 
 type runner[T any] struct {
 	loadConfig       func(string) (T, *config.GlobalConfig, error)
-	initializeDaemon func(T) (Runner, error)
+	initializeDaemon func(T) (Interface, error)
 	version          string
 	maxVersion       string
 	minVersion       string
@@ -138,7 +138,7 @@ func Do[T any](ctx context.Context, opts ...Option[T]) error {
 	return Run(ctx, daemon, r.name)
 }
 
-func Run(ctx context.Context, run Runner, name string) (err error) {
+func Run(ctx context.Context, run Interface, name string) (err error) {
 	sctx, cancel := signal.NotifyContext(ctx,
 		syscall.SIGINT,
 		syscall.SIGQUIT,

--- a/internal/runner/runner_race_test.go
+++ b/internal/runner/runner_race_test.go
@@ -153,7 +153,7 @@ func TestDo_for_race(t *testing.T) {
 							Version: "v1.1.2",
 						}, nil
 					}),
-					WithDaemonInitializer(func(any) (Runner, error) {
+					WithDaemonInitializer(func(any) (Interface, error) {
 						return nil, errors.New("err")
 					}),
 				},
@@ -185,7 +185,7 @@ func TestDo_for_race(t *testing.T) {
 							Version: "v1.1.2",
 						}, nil
 					}),
-					WithDaemonInitializer(func(any) (Runner, error) {
+					WithDaemonInitializer(func(any) (Interface, error) {
 						return &runnerMock{
 							PreStartFunc: func(ctx context.Context) error {
 								return nil

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 func TestRun(t *testing.T) {
 	type args struct {
 		ctx  context.Context
-		run  Runner
+		run  Interface
 		name string
 	}
 	type want struct {
@@ -64,7 +64,7 @@ func TestRun(t *testing.T) {
 				name: "returns nil when internal functionally occurs no error",
 				args: args{
 					ctx: ctx,
-					run: func() Runner {
+					run: func() Interface {
 						return &runnerMock{
 							PreStartFunc: func(ctx context.Context) error {
 								return nil
@@ -101,7 +101,7 @@ func TestRun(t *testing.T) {
 				args: args{
 					ctx:  ctx,
 					name: "vald",
-					run: func() Runner {
+					run: func() Interface {
 						return &runnerMock{
 							PreStartFunc: func(ctx context.Context) error {
 								return nil
@@ -165,7 +165,7 @@ func TestRun(t *testing.T) {
 				args: args{
 					ctx:  ctx,
 					name: "vald",
-					run: func() Runner {
+					run: func() Interface {
 						return &runnerMock{
 							PreStartFunc: func(ctx context.Context) error {
 								return nil
@@ -226,7 +226,7 @@ func TestRun(t *testing.T) {
 			name: "returns error when run.PreStart returns error",
 			args: args{
 				ctx: t.Context(),
-				run: func() Runner {
+				run: func() Interface {
 					return &runnerMock{
 						PreStartFunc: func(context.Context) error {
 							return errors.New("err")
@@ -244,7 +244,7 @@ func TestRun(t *testing.T) {
 			name: "returns error when run.Start returns error",
 			args: args{
 				ctx: t.Context(),
-				run: func() Runner {
+				run: func() Interface {
 					return &runnerMock{
 						PreStartFunc: func(context.Context) error {
 							return nil

--- a/internal/servers/server/option.go
+++ b/internal/servers/server/option.go
@@ -681,8 +681,8 @@ func WithGRPCInterceptors(names ...string) Option {
 			case "recoverinterceptor", "recover":
 				s.grpc.opts = append(
 					s.grpc.opts,
-					grpc.ChainUnaryInterceptor(recover.RecoverInterceptor()),
-					grpc.ChainStreamInterceptor(recover.RecoverStreamInterceptor()),
+					grpc.ChainUnaryInterceptor(recover.Interceptor()),
+					grpc.ChainStreamInterceptor(recover.StreamInterceptor()),
 				)
 			case "accessloginterceptor", "accesslog":
 				s.grpc.opts = append(

--- a/internal/test/data/hdf5/hdf5.go
+++ b/internal/test/data/hdf5/hdf5.go
@@ -30,7 +30,7 @@ import (
 
 type Data interface {
 	Download(url string) error
-	Read(key Hdf5Key) error
+	Read(key Key) error
 	GetName() DatasetName
 	GetPath() string
 	GetByGroupName(name string) [][]float32
@@ -72,15 +72,15 @@ func (d DatasetUrl) String() string {
 	}
 }
 
-type Hdf5Key int
+type Key int
 
 const (
-	Train Hdf5Key = iota + 1
+	Train Key = iota + 1
 	Test
 	Neighors
 )
 
-func (key Hdf5Key) String() string {
+func (key Key) String() string {
 	switch key {
 	case Train:
 		return "train"
@@ -124,7 +124,7 @@ func (d *data) Download(url string) error {
 	}
 }
 
-func (d *data) Read(key Hdf5Key) error {
+func (d *data) Read(key Key) error {
 	f, err := hdf5.OpenFile(d.path, hdf5.F_ACC_RDONLY)
 	if err != nil {
 		return err
@@ -242,7 +242,7 @@ func downloadFile(url, path string) error {
 	return nil
 }
 
-func ReadDatasetF32(file *hdf5.File, key Hdf5Key) ([][]float32, error) {
+func ReadDatasetF32(file *hdf5.File, key Key) ([][]float32, error) {
 	data, err := file.OpenDataset(key.String())
 	if err != nil {
 		return nil, err
@@ -271,7 +271,7 @@ func ReadDatasetF32(file *hdf5.File, key Hdf5Key) ([][]float32, error) {
 	return vecs, nil
 }
 
-func ReadDatasetI32(file *hdf5.File, key Hdf5Key) ([][]int32, error) {
+func ReadDatasetI32(file *hdf5.File, key Key) ([][]int32, error) {
 	data, err := file.OpenDataset(key.String())
 	if err != nil {
 		return nil, err

--- a/internal/test/data/hdf5/hdf5_test.go
+++ b/internal/test/data/hdf5/hdf5_test.go
@@ -161,7 +161,7 @@ func TestDatasetUrl_String(t *testing.T) {
 	}
 }
 
-func Test_Hdf5Key_String(t *testing.T) {
+func Test_Key_String(t *testing.T) {
 	type want struct {
 		want string
 	}
@@ -171,7 +171,7 @@ func Test_Hdf5Key_String(t *testing.T) {
 		afterFunc  func(*testing.T)
 		name       string
 		want       want
-		h          Hdf5Key
+		h          Key
 	}
 	defaultCheckFunc := func(w want, got string) error {
 		if !reflect.DeepEqual(got, w.want) {
@@ -442,7 +442,7 @@ func Test_data_Read(t *testing.T) {
 		name      DatasetName
 	}
 	type args struct {
-		key Hdf5Key
+		key Key
 	}
 	type want struct {
 		err error
@@ -1246,7 +1246,7 @@ func Test_downloadFile(t *testing.T) {
 func TestReadDatasetF32(t *testing.T) {
 	type args struct {
 		file *hdf5.File
-		key  Hdf5Key
+		key  Key
 	}
 	type want struct {
 		err  error
@@ -1338,7 +1338,7 @@ func TestReadDatasetF32(t *testing.T) {
 func TestReadDatasetI32(t *testing.T) {
 	type args struct {
 		file *hdf5.File
-		key  Hdf5Key
+		key  Key
 	}
 	type want struct {
 		err  error

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -56,7 +56,7 @@ type worker struct {
 }
 
 // New initializes and return the worker, or return initialization error if occurred.
-func New(opts ...WorkerOption) (Worker, error) {
+func New(opts ...Option) (Worker, error) {
 	w := new(worker)
 	for _, opt := range append(defaultWorkerOpts, opts...) {
 		if err := opt(w); err != nil {

--- a/internal/worker/worker_option.go
+++ b/internal/worker/worker_option.go
@@ -18,15 +18,15 @@ package worker
 
 import "github.com/vdaas/vald/internal/sync/errgroup"
 
-type WorkerOption func(w *worker) error
+type Option func(w *worker) error
 
-var defaultWorkerOpts = []WorkerOption{
+var defaultWorkerOpts = []Option{
 	WithName("worker"),
 	WithLimitation(10),
 	WithErrGroup(errgroup.Get()),
 }
 
-func WithName(name string) WorkerOption {
+func WithName(name string) Option {
 	return func(w *worker) error {
 		if name != "" {
 			w.name = name
@@ -35,7 +35,7 @@ func WithName(name string) WorkerOption {
 	}
 }
 
-func WithLimitation(limit int) WorkerOption {
+func WithLimitation(limit int) Option {
 	return func(w *worker) error {
 		if limit > 0 {
 			w.limitation = limit
@@ -44,7 +44,7 @@ func WithLimitation(limit int) WorkerOption {
 	}
 }
 
-func WithErrGroup(eg errgroup.Group) WorkerOption {
+func WithErrGroup(eg errgroup.Group) Option {
 	return func(w *worker) error {
 		if eg != nil {
 			w.eg = eg
@@ -53,7 +53,7 @@ func WithErrGroup(eg errgroup.Group) WorkerOption {
 	}
 }
 
-func WithQueueOption(opts ...QueueOption) WorkerOption {
+func WithQueueOption(opts ...QueueOption) Option {
 	return func(w *worker) error {
 		if opts == nil {
 			return nil

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestNew(t *testing.T) {
 	type args struct {
-		opts []WorkerOption
+		opts []Option
 	}
 	type want struct {
 		want Worker
@@ -114,7 +114,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "return worker with option",
 			args: args{
-				opts: []WorkerOption{
+				opts: []Option{
 					WithName("test1"),
 				},
 			},

--- a/pkg/agent/core/faiss/config/config.go
+++ b/pkg/agent/core/faiss/config/config.go
@@ -41,8 +41,8 @@ type Data struct {
 	GlobalConfig `json:",inline" yaml:",inline"`
 }
 
-// NewConfig returns the Data struct or error from the given file path.
-func NewConfig(path string) (cfg *Data, err error) {
+// New returns the Data struct or error from the given file path.
+func New(path string) (cfg *Data, err error) {
 	cfg = new(Data)
 
 	err = config.Read(path, &cfg)

--- a/pkg/agent/core/faiss/usecase/agentd.go
+++ b/pkg/agent/core/faiss/usecase/agentd.go
@@ -46,7 +46,7 @@ type run struct {
 	observability observability.Observability
 }
 
-func New(cfg *config.Data) (r runner.Runner, err error) {
+func New(cfg *config.Data) (r runner.Interface, err error) {
 	faiss, err := service.New(
 		cfg.Faiss,
 		service.WithErrGroup(errgroup.Get()),

--- a/pkg/agent/core/faiss/usecase/agentd_test.go
+++ b/pkg/agent/core/faiss/usecase/agentd_test.go
@@ -20,18 +20,18 @@ package usecase
 // 		cfg *config.Data
 // 	}
 // 	type want struct {
-// 		wantR runner.Runner
+// 		wantR runner.Interface
 // 		err   error
 // 	}
 // 	type test struct {
 // 		name       string
 // 		args       args
 // 		want       want
-// 		checkFunc  func(want, runner.Runner, error) error
+// 		checkFunc  func(want, runner.Interface, error) error
 // 		beforeFunc func(*testing.T, args)
 // 		afterFunc  func(*testing.T, args)
 // 	}
-// 	defaultCheckFunc := func(w want, gotR runner.Runner, err error) error {
+// 	defaultCheckFunc := func(w want, gotR runner.Interface, err error) error {
 // 		if !errors.Is(err, w.err) {
 // 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 // 		}

--- a/pkg/agent/core/ngt/service/ngt_test.go
+++ b/pkg/agent/core/ngt/service/ngt_test.go
@@ -1613,7 +1613,7 @@ func Test_ngt_E2E(t *testing.T) {
 				for _, req := range test.args.requests {
 					_, err := test.args.client.Do(ctx, test.args.addr,
 						func(ctx context.Context, conn *grpc.ClientConn, opts ...grpc.CallOption) (any, error) {
-							return vald.NewValdClient(conn).MultiUpsert(ctx, req)
+							return vald.NewFromConn(conn).MultiUpsert(ctx, req)
 						})
 					if err != nil {
 						t.Error(err)

--- a/pkg/agent/core/ngt/usecase/agentd.go
+++ b/pkg/agent/core/ngt/usecase/agentd.go
@@ -53,7 +53,7 @@ const (
 	fieldManager = "vald-agent-index-controller"
 )
 
-func New(cfg *config.Data) (r runner.Runner, err error) {
+func New(cfg *config.Data) (r runner.Interface, err error) {
 	serviceOpts := []service.Option{
 		service.WithErrGroup(errgroup.Get()),
 		service.WithEnableInMemoryMode(cfg.NGT.EnableInMemoryMode),

--- a/pkg/agent/core/ngt/usecase/agentd_test.go
+++ b/pkg/agent/core/ngt/usecase/agentd_test.go
@@ -23,18 +23,18 @@ package usecase
 // 		cfg *config.Data
 // 	}
 // 	type want struct {
-// 		wantR runner.Runner
+// 		wantR runner.Interface
 // 		err   error
 // 	}
 // 	type test struct {
 // 		name       string
 // 		args       args
 // 		want       want
-// 		checkFunc  func(want, runner.Runner, error) error
+// 		checkFunc  func(want, runner.Interface, error) error
 // 		beforeFunc func(*testing.T, args)
 // 		afterFunc  func(*testing.T, args)
 // 	}
-// 	defaultCheckFunc := func(w want, gotR runner.Runner, err error) error {
+// 	defaultCheckFunc := func(w want, gotR runner.Interface, err error) error {
 // 		if !errors.Is(err, w.err) {
 // 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 // 		}

--- a/pkg/agent/sidecar/config/config.go
+++ b/pkg/agent/sidecar/config/config.go
@@ -68,7 +68,7 @@ type Data struct {
 	config.GlobalConfig `json:",inline" yaml:",inline"`
 }
 
-func NewConfig(path string) (cfg *Data, err error) {
+func New(path string) (cfg *Data, err error) {
 	cfg = new(Data)
 
 	err = config.Read(path, &cfg)

--- a/pkg/agent/sidecar/usecase/initcontainer/initcontainer.go
+++ b/pkg/agent/sidecar/usecase/initcontainer/initcontainer.go
@@ -53,7 +53,7 @@ type run struct {
 	rs            restorer.Restorer
 }
 
-func New(cfg *config.Data) (r runner.Runner, err error) {
+func New(cfg *config.Data) (r runner.Interface, err error) {
 	log.Info("Initialized in initcontainer mode")
 
 	eg := errgroup.Get()

--- a/pkg/agent/sidecar/usecase/initcontainer/initcontainer_test.go
+++ b/pkg/agent/sidecar/usecase/initcontainer/initcontainer_test.go
@@ -23,18 +23,18 @@ package initcontainer
 // 		cfg *config.Data
 // 	}
 // 	type want struct {
-// 		wantR runner.Runner
+// 		wantR runner.Interface
 // 		err   error
 // 	}
 // 	type test struct {
 // 		name       string
 // 		args       args
 // 		want       want
-// 		checkFunc  func(want, runner.Runner, error) error
+// 		checkFunc  func(want, runner.Interface, error) error
 // 		beforeFunc func(*testing.T, args)
 // 		afterFunc  func(*testing.T, args)
 // 	}
-// 	defaultCheckFunc := func(w want, gotR runner.Runner, err error) error {
+// 	defaultCheckFunc := func(w want, gotR runner.Interface, err error) error {
 // 		if !errors.Is(err, w.err) {
 // 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 // 		}

--- a/pkg/agent/sidecar/usecase/sidecar/sidecar.go
+++ b/pkg/agent/sidecar/usecase/sidecar/sidecar.go
@@ -52,7 +52,7 @@ type run struct {
 	so            observer.StorageObserver
 }
 
-func New(cfg *config.Data) (r runner.Runner, err error) {
+func New(cfg *config.Data) (r runner.Interface, err error) {
 	log.Info("Initialized in sidecar mode")
 
 	eg := errgroup.Get()

--- a/pkg/agent/sidecar/usecase/sidecar/sidecar_test.go
+++ b/pkg/agent/sidecar/usecase/sidecar/sidecar_test.go
@@ -23,18 +23,18 @@ package sidecar
 // 		cfg *config.Data
 // 	}
 // 	type want struct {
-// 		wantR runner.Runner
+// 		wantR runner.Interface
 // 		err   error
 // 	}
 // 	type test struct {
 // 		name       string
 // 		args       args
 // 		want       want
-// 		checkFunc  func(want, runner.Runner, error) error
+// 		checkFunc  func(want, runner.Interface, error) error
 // 		beforeFunc func(*testing.T, args)
 // 		afterFunc  func(*testing.T, args)
 // 	}
-// 	defaultCheckFunc := func(w want, gotR runner.Runner, err error) error {
+// 	defaultCheckFunc := func(w want, gotR runner.Interface, err error) error {
 // 		if !errors.Is(err, w.err) {
 // 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 // 		}

--- a/pkg/agent/sidecar/usecase/sidecard.go
+++ b/pkg/agent/sidecar/usecase/sidecard.go
@@ -23,7 +23,7 @@ import (
 	"github.com/vdaas/vald/pkg/agent/sidecar/usecase/sidecar"
 )
 
-func New(cfg *config.Data) (r runner.Runner, err error) {
+func New(cfg *config.Data) (r runner.Interface, err error) {
 	switch config.SidecarMode(cfg.AgentSidecar.Mode) {
 	case config.INITCONTAINER:
 		return initcontainer.New(cfg)

--- a/pkg/agent/sidecar/usecase/sidecard_test.go
+++ b/pkg/agent/sidecar/usecase/sidecard_test.go
@@ -23,18 +23,18 @@ package usecase
 // 		cfg *config.Data
 // 	}
 // 	type want struct {
-// 		wantR runner.Runner
+// 		wantR runner.Interface
 // 		err   error
 // 	}
 // 	type test struct {
 // 		name       string
 // 		args       args
 // 		want       want
-// 		checkFunc  func(want, runner.Runner, error) error
+// 		checkFunc  func(want, runner.Interface, error) error
 // 		beforeFunc func(*testing.T, args)
 // 		afterFunc  func(*testing.T, args)
 // 	}
-// 	defaultCheckFunc := func(w want, gotR runner.Runner, err error) error {
+// 	defaultCheckFunc := func(w want, gotR runner.Interface, err error) error {
 // 		if !errors.Is(err, w.err) {
 // 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 // 		}

--- a/pkg/discoverer/k8s/usecase/discovered.go
+++ b/pkg/discoverer/k8s/usecase/discovered.go
@@ -49,7 +49,7 @@ type run struct {
 	der           net.Dialer
 }
 
-func New(cfg *config.Data) (r runner.Runner, err error) {
+func New(cfg *config.Data) (r runner.Interface, err error) {
 	eg := errgroup.Get()
 	netOpts, err := cfg.Discoverer.Net.Opts()
 	if err != nil {

--- a/pkg/gateway/filter/config/config.go
+++ b/pkg/gateway/filter/config/config.go
@@ -49,7 +49,7 @@ type Data struct {
 	config.GlobalConfig `json:",inline" yaml:",inline"`
 }
 
-func NewConfig(path string) (cfg *Data, err error) {
+func New(path string) (cfg *Data, err error) {
 	cfg = new(Data)
 
 	err = config.Read(path, &cfg)

--- a/pkg/gateway/filter/usecase/vald.go
+++ b/pkg/gateway/filter/usecase/vald.go
@@ -50,7 +50,7 @@ type run struct {
 	egress        egress.Client
 }
 
-func New(cfg *config.Data) (r runner.Runner, err error) {
+func New(cfg *config.Data) (r runner.Interface, err error) {
 	if addrs := cfg.Client.Addrs; len(addrs) == 0 {
 		return nil, errors.ErrGRPCTargetAddrNotFound
 	}

--- a/pkg/gateway/filter/usecase/vald_test.go
+++ b/pkg/gateway/filter/usecase/vald_test.go
@@ -23,18 +23,18 @@ package usecase
 // 		cfg *config.Data
 // 	}
 // 	type want struct {
-// 		wantR runner.Runner
+// 		wantR runner.Interface
 // 		err   error
 // 	}
 // 	type test struct {
 // 		name       string
 // 		args       args
 // 		want       want
-// 		checkFunc  func(want, runner.Runner, error) error
+// 		checkFunc  func(want, runner.Interface, error) error
 // 		beforeFunc func(*testing.T, args)
 // 		afterFunc  func(*testing.T, args)
 // 	}
-// 	defaultCheckFunc := func(w want, gotR runner.Runner, err error) error {
+// 	defaultCheckFunc := func(w want, gotR runner.Interface, err error) error {
 // 		if !errors.Is(err, w.err) {
 // 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 // 		}

--- a/pkg/gateway/lb/config/config.go
+++ b/pkg/gateway/lb/config/config.go
@@ -43,7 +43,7 @@ type Data struct {
 	config.GlobalConfig `json:",inline" yaml:",inline"`
 }
 
-func NewConfig(path string) (cfg *Data, err error) {
+func New(path string) (cfg *Data, err error) {
 	cfg = new(Data)
 
 	err = config.Read(path, &cfg)

--- a/pkg/gateway/lb/service/gateway.go
+++ b/pkg/gateway/lb/service/gateway.go
@@ -95,7 +95,7 @@ func (g *gateway) BroadCast(
 		case <-ictx.Done():
 			return nil
 		default:
-			err = f(ictx, addr, vc.NewValdClient(conn), copts...)
+			err = f(ictx, addr, vc.NewFromConn(conn), copts...)
 			if err != nil {
 				return err
 			}
@@ -130,7 +130,7 @@ func (g *gateway) DoMulti(
 		copts ...grpc.CallOption,
 	) (err error) {
 		if atomic.LoadUint32(&cur) < limit {
-			err = f(ictx, addr, vc.NewValdClient(conn), copts...)
+			err = f(ictx, addr, vc.NewFromConn(conn), copts...)
 			if err != nil {
 				return err
 			}
@@ -148,7 +148,7 @@ func (g *gateway) DoMulti(
 			if atomic.LoadUint32(&cur) < limit {
 				_, ok := visited.Load(addr)
 				if !ok {
-					err = f(ictx, addr, vc.NewValdClient(conn), copts...)
+					err = f(ictx, addr, vc.NewFromConn(conn), copts...)
 					if err != nil {
 						return err
 					}

--- a/pkg/gateway/lb/usecase/vald.go
+++ b/pkg/gateway/lb/usecase/vald.go
@@ -78,7 +78,7 @@ func discovererClient(
 	return discoverer.New(discovererOpts...)
 }
 
-func New(cfg *config.Data) (r runner.Runner, err error) {
+func New(cfg *config.Data) (r runner.Interface, err error) {
 	eg := errgroup.Get()
 
 	var gateway service.Gateway

--- a/pkg/gateway/lb/usecase/vald_test.go
+++ b/pkg/gateway/lb/usecase/vald_test.go
@@ -114,18 +114,18 @@ func Test_discovererClient(t *testing.T) {
 // 		cfg *config.Data
 // 	}
 // 	type want struct {
-// 		wantR runner.Runner
+// 		wantR runner.Interface
 // 		err   error
 // 	}
 // 	type test struct {
 // 		name       string
 // 		args       args
 // 		want       want
-// 		checkFunc  func(want, runner.Runner, error) error
+// 		checkFunc  func(want, runner.Interface, error) error
 // 		beforeFunc func(*testing.T, args)
 // 		afterFunc  func(*testing.T, args)
 // 	}
-// 	defaultCheckFunc := func(w want, gotR runner.Runner, err error) error {
+// 	defaultCheckFunc := func(w want, gotR runner.Interface, err error) error {
 // 		if !errors.Is(err, w.err) {
 // 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 // 		}

--- a/pkg/gateway/mirror/service/discovery.go
+++ b/pkg/gateway/mirror/service/discovery.go
@@ -56,7 +56,7 @@ type discovery struct {
 	mirr            Mirror
 	eg              errgroup.Group
 	labels          map[string]string
-	targetsByName   atomic.Pointer[map[string]target.Target]
+	targetsByName   atomic.Pointer[map[string]target.Endpoint]
 	mirrorTargets   *resource.Client[*target.MirrorTarget, *mirrv1.ValdMirrorTargetList]
 	namespace       string
 	colocation      string
@@ -80,7 +80,7 @@ func NewDiscovery(opts ...DiscoveryOption) (Discovery, error) {
 			log.Warn(oerr)
 		}
 	}
-	d.targetsByName.Store(&map[string]target.Target{})
+	d.targetsByName.Store(&map[string]target.Endpoint{})
 	d.selfMirrAddrStr = strings.Join(d.selfMirrAddrs, ",")
 
 	watcher, err := target.New(
@@ -118,7 +118,7 @@ func NewDiscovery(opts ...DiscoveryOption) (Discovery, error) {
 	return d, nil
 }
 
-func (d *discovery) onReconcile(_ context.Context, list map[string]target.Target) {
+func (d *discovery) onReconcile(_ context.Context, list map[string]target.Endpoint) {
 	log.Debugf("mirror reconciled\t%#v", list)
 	d.targetsByName.Store(&list)
 }
@@ -164,22 +164,22 @@ func (d *discovery) Start(ctx context.Context) (<-chan error, error) {
 	return ech, nil
 }
 
-func (d *discovery) loadTargets() map[string]target.Target {
+func (d *discovery) loadTargets() map[string]target.Endpoint {
 	if v := d.targetsByName.Load(); v != nil {
 		return *v
 	}
-	return map[string]target.Target{}
+	return map[string]target.Endpoint{}
 }
 
 type createdTarget struct {
 	name string
-	tgt  target.Target
+	tgt  target.Endpoint
 }
 
 type updatedTarget struct {
 	name string
-	old  target.Target
-	new  target.Target
+	old  target.Endpoint
+	new  target.Endpoint
 }
 
 type deletedTarget struct {
@@ -199,12 +199,12 @@ func newMirrorTarget(host string, port int) *payload.Mirror_Target {
 }
 
 func (d *discovery) startSync(
-	ctx context.Context, prev map[string]target.Target,
-) (current map[string]target.Target, errs error) {
+	ctx context.Context, prev map[string]target.Endpoint,
+) (current map[string]target.Endpoint, errs error) {
 	current = d.loadTargets()
 	curAddrs := map[string]string{} // map[addr: metadata.name]
 
-	created := map[string]*createdTarget{} // map[addr: target.Target]
+	created := map[string]*createdTarget{} // map[addr: target.Endpoint]
 	updated := map[string]*updatedTarget{} // map[addr: *updatedTarget]
 	for name, ctgt := range current {
 		addr := net.JoinHostPort(ctgt.Host, uint16(ctgt.Port)) //nolint:gosec // port values come from the MirrorTarget CRD spec, not attacker-controlled input
@@ -252,7 +252,7 @@ func (d *discovery) startSync(
 }
 
 func (d *discovery) syncWithAddr(
-	ctx context.Context, current map[string]target.Target, curAddrs map[string]string,
+	ctx context.Context, current map[string]target.Endpoint, curAddrs map[string]string,
 ) (errs error) {
 	for addr, name := range curAddrs {
 		// When the status code of a regularly running Register RPC is Unimplemented, the connection to the target will be disconnected

--- a/pkg/gateway/mirror/service/discovery_test.go
+++ b/pkg/gateway/mirror/service/discovery_test.go
@@ -41,26 +41,26 @@ func Test_discovery_startSync(t *testing.T) {
 	t.Parallel()
 	type args struct {
 		ctx  context.Context //nolint:containedctx // table-driven test args struct, ctx passed through to the function under test
-		prev map[string]target.Target
+		prev map[string]target.Endpoint
 	}
 	type fields struct {
 		ctrl k8s.Controller
 		mirr Mirror
 	}
 	type want struct {
-		want map[string]target.Target
+		want map[string]target.Endpoint
 		err  error
 	}
 	type test struct {
 		fields     fields
 		args       args
 		want       want
-		checkFunc  func(want, map[string]target.Target, error) error
+		checkFunc  func(want, map[string]target.Endpoint, error) error
 		beforeFunc func(*testing.T, *discovery, args)
 		afterFunc  func(*testing.T, args)
 		name       string
 	}
-	defaultCheckFunc := func(w want, got map[string]target.Target, err error) error {
+	defaultCheckFunc := func(w want, got map[string]target.Endpoint, err error) error {
 		if !errors.Is(err, w.err) {
 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 		}
@@ -71,8 +71,8 @@ func Test_discovery_startSync(t *testing.T) {
 	}
 	tests := []test{
 		func() test {
-			prev := make(map[string]target.Target)
-			current := map[string]target.Target{
+			prev := make(map[string]target.Endpoint)
+			current := map[string]target.Endpoint{
 				testMirrorName1: {
 					Host: testMirrorHost1,
 					Port: 8081,
@@ -104,8 +104,8 @@ func Test_discovery_startSync(t *testing.T) {
 			}
 		}(),
 		func() test {
-			prev := make(map[string]target.Target)
-			current := map[string]target.Target{
+			prev := make(map[string]target.Endpoint)
+			current := map[string]target.Endpoint{
 				testMirrorName1: {
 					Host: testMirrorHost1,
 					Port: 8081,
@@ -138,13 +138,13 @@ func Test_discovery_startSync(t *testing.T) {
 			}
 		}(),
 		func() test {
-			prev := map[string]target.Target{
+			prev := map[string]target.Endpoint{
 				testMirrorName1: {
 					Host: testMirrorHost1,
 					Port: 8081,
 				},
 			}
-			current := make(map[string]target.Target)
+			current := make(map[string]target.Endpoint)
 			return test{
 				name: "Succeeded detecting the deleted resource and disconnecting the target",
 				args: args{
@@ -171,13 +171,13 @@ func Test_discovery_startSync(t *testing.T) {
 			}
 		}(),
 		func() test {
-			prev := map[string]target.Target{
+			prev := map[string]target.Endpoint{
 				testMirrorName1: {
 					Host: testMirrorHost1,
 					Port: 8081,
 				},
 			}
-			current := make(map[string]target.Target)
+			current := make(map[string]target.Endpoint)
 			return test{
 				name: "Succeeded detecting the deleted resource but failed to disconnect the target",
 				args: args{
@@ -205,13 +205,13 @@ func Test_discovery_startSync(t *testing.T) {
 			}
 		}(),
 		func() test {
-			prev := map[string]target.Target{
+			prev := map[string]target.Endpoint{
 				testMirrorName1: {
 					Host: testMirrorHost1,
 					Port: 8081,
 				},
 			}
-			current := map[string]target.Target{
+			current := map[string]target.Endpoint{
 				testMirrorName1: {
 					Host: testMirrorHost2,
 					Port: 8081,
@@ -246,13 +246,13 @@ func Test_discovery_startSync(t *testing.T) {
 			}
 		}(),
 		func() test {
-			prev := map[string]target.Target{
+			prev := map[string]target.Endpoint{
 				testMirrorName1: {
 					Host: testMirrorHost1,
 					Port: 8081,
 				},
 			}
-			current := map[string]target.Target{
+			current := map[string]target.Endpoint{
 				testMirrorName1: {
 					Host: testMirrorHost2,
 					Port: 8081,
@@ -328,7 +328,7 @@ func Test_discovery_syncWithAddr(t *testing.T) {
 	t.Parallel()
 	type args struct {
 		ctx      context.Context //nolint:containedctx // table-driven test args struct, ctx passed through to the function under test
-		current  map[string]target.Target
+		current  map[string]target.Endpoint
 		curAddrs map[string]string
 	}
 	type fields struct {
@@ -355,7 +355,7 @@ func Test_discovery_syncWithAddr(t *testing.T) {
 	}
 	tests := []test{
 		func() test {
-			current := map[string]target.Target{
+			current := map[string]target.Endpoint{
 				testMirrorName1: {
 					Host:  testMirrorHost1,
 					Port:  8081,
@@ -393,7 +393,7 @@ func Test_discovery_syncWithAddr(t *testing.T) {
 			}
 		}(),
 		func() test {
-			current := map[string]target.Target{
+			current := map[string]target.Endpoint{
 				testMirrorName1: {
 					Host:  testMirrorHost1,
 					Port:  8081,
@@ -429,7 +429,7 @@ func Test_discovery_syncWithAddr(t *testing.T) {
 			}
 		}(),
 		func() test {
-			current := map[string]target.Target{}
+			current := map[string]target.Endpoint{}
 			curAddrs := map[string]string{}
 			newAddrs := []string{
 				testMirrorAddr1,
@@ -590,7 +590,7 @@ func Test_discovery_syncWithAddr(t *testing.T) {
 // func Test_discovery_onReconcile(t *testing.T) {
 // 	type args struct {
 // 		in0  context.Context
-// 		list map[string]target.Target
+// 		list map[string]target.Endpoint
 // 	}
 // 	type fields struct {
 // 		der             net.Dialer
@@ -598,7 +598,7 @@ func Test_discovery_syncWithAddr(t *testing.T) {
 // 		mirr            Mirror
 // 		eg              errgroup.Group
 // 		labels          map[string]string
-// 		targetsByName   atomic.Pointer[map[string]target.Target]
+// 		targetsByName   atomic.Pointer[map[string]target.Endpoint]
 // 		mirrorTargets   *resource.Client[*target.MirrorTarget, *mirrv1.ValdMirrorTargetList]
 // 		namespace       string
 // 		colocation      string
@@ -737,7 +737,7 @@ func Test_discovery_syncWithAddr(t *testing.T) {
 // 		mirr            Mirror
 // 		eg              errgroup.Group
 // 		labels          map[string]string
-// 		targetsByName   atomic.Pointer[map[string]target.Target]
+// 		targetsByName   atomic.Pointer[map[string]target.Endpoint]
 // 		mirrorTargets   *resource.Client[*target.MirrorTarget, *mirrv1.ValdMirrorTargetList]
 // 		namespace       string
 // 		colocation      string
@@ -880,7 +880,7 @@ func Test_discovery_syncWithAddr(t *testing.T) {
 // 		mirr            Mirror
 // 		eg              errgroup.Group
 // 		labels          map[string]string
-// 		targetsByName   atomic.Pointer[map[string]target.Target]
+// 		targetsByName   atomic.Pointer[map[string]target.Endpoint]
 // 		mirrorTargets   *resource.Client[*target.MirrorTarget, *mirrv1.ValdMirrorTargetList]
 // 		namespace       string
 // 		colocation      string
@@ -889,17 +889,17 @@ func Test_discovery_syncWithAddr(t *testing.T) {
 // 		dur             time.Duration
 // 	}
 // 	type want struct {
-// 		want map[string]target.Target
+// 		want map[string]target.Endpoint
 // 	}
 // 	type test struct {
 // 		name       string
 // 		fields     fields
 // 		want       want
-// 		checkFunc  func(want, map[string]target.Target) error
+// 		checkFunc  func(want, map[string]target.Endpoint) error
 // 		beforeFunc func(*testing.T)
 // 		afterFunc  func(*testing.T)
 // 	}
-// 	defaultCheckFunc := func(w want, got map[string]target.Target) error {
+// 	defaultCheckFunc := func(w want, got map[string]target.Endpoint) error {
 // 		if !reflect.DeepEqual(got, w.want) {
 // 			return errors.Errorf("got: \"%#v\",\n\t\t\t\twant: \"%#v\"", got, w.want)
 // 		}
@@ -1104,7 +1104,7 @@ func Test_discovery_syncWithAddr(t *testing.T) {
 // 		mirr            Mirror
 // 		eg              errgroup.Group
 // 		labels          map[string]string
-// 		targetsByName   atomic.Pointer[map[string]target.Target]
+// 		targetsByName   atomic.Pointer[map[string]target.Endpoint]
 // 		mirrorTargets   *resource.Client[*target.MirrorTarget, *mirrv1.ValdMirrorTargetList]
 // 		namespace       string
 // 		colocation      string
@@ -1251,7 +1251,7 @@ func Test_discovery_syncWithAddr(t *testing.T) {
 // 		mirr            Mirror
 // 		eg              errgroup.Group
 // 		labels          map[string]string
-// 		targetsByName   atomic.Pointer[map[string]target.Target]
+// 		targetsByName   atomic.Pointer[map[string]target.Endpoint]
 // 		mirrorTargets   *resource.Client[*target.MirrorTarget, *mirrv1.ValdMirrorTargetList]
 // 		namespace       string
 // 		colocation      string
@@ -1400,7 +1400,7 @@ func Test_discovery_syncWithAddr(t *testing.T) {
 // 		mirr            Mirror
 // 		eg              errgroup.Group
 // 		labels          map[string]string
-// 		targetsByName   atomic.Pointer[map[string]target.Target]
+// 		targetsByName   atomic.Pointer[map[string]target.Endpoint]
 // 		mirrorTargets   *resource.Client[*target.MirrorTarget, *mirrv1.ValdMirrorTargetList]
 // 		namespace       string
 // 		colocation      string
@@ -1546,7 +1546,7 @@ func Test_discovery_syncWithAddr(t *testing.T) {
 // 		mirr            Mirror
 // 		eg              errgroup.Group
 // 		labels          map[string]string
-// 		targetsByName   atomic.Pointer[map[string]target.Target]
+// 		targetsByName   atomic.Pointer[map[string]target.Endpoint]
 // 		mirrorTargets   *resource.Client[*target.MirrorTarget, *mirrv1.ValdMirrorTargetList]
 // 		namespace       string
 // 		colocation      string
@@ -1693,7 +1693,7 @@ func Test_discovery_syncWithAddr(t *testing.T) {
 // 		mirr            Mirror
 // 		eg              errgroup.Group
 // 		labels          map[string]string
-// 		targetsByName   atomic.Pointer[map[string]target.Target]
+// 		targetsByName   atomic.Pointer[map[string]target.Endpoint]
 // 		mirrorTargets   *resource.Client[*target.MirrorTarget, *mirrv1.ValdMirrorTargetList]
 // 		namespace       string
 // 		colocation      string

--- a/pkg/gateway/mirror/usecase/vald.go
+++ b/pkg/gateway/mirror/usecase/vald.go
@@ -51,7 +51,7 @@ type run struct {
 }
 
 // New returns Runner instance.
-func New(cfg *config.Data) (r runner.Runner, err error) {
+func New(cfg *config.Data) (r runner.Interface, err error) {
 	eg := errgroup.Get()
 
 	netOpts, err := cfg.Mirror.Net.Opts()

--- a/pkg/gateway/mirror/usecase/vald_test.go
+++ b/pkg/gateway/mirror/usecase/vald_test.go
@@ -20,18 +20,18 @@ package usecase
 // 		cfg *config.Data
 // 	}
 // 	type want struct {
-// 		wantR runner.Runner
+// 		wantR runner.Interface
 // 		err   error
 // 	}
 // 	type test struct {
 // 		name       string
 // 		args       args
 // 		want       want
-// 		checkFunc  func(want, runner.Runner, error) error
+// 		checkFunc  func(want, runner.Interface, error) error
 // 		beforeFunc func(*testing.T, args)
 // 		afterFunc  func(*testing.T, args)
 // 	}
-// 	defaultCheckFunc := func(w want, gotR runner.Runner, err error) error {
+// 	defaultCheckFunc := func(w want, gotR runner.Interface, err error) error {
 // 		if !errors.Is(err, w.err) {
 // 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 // 		}

--- a/pkg/index/job/correction/config/config.go
+++ b/pkg/index/job/correction/config/config.go
@@ -40,7 +40,7 @@ type Data struct {
 	config.GlobalConfig `json:",inline" yaml:",inline"`
 }
 
-func NewConfig(path string) (cfg *Data, err error) {
+func New(path string) (cfg *Data, err error) {
 	cfg = new(Data)
 
 	err = config.Read(path, &cfg)

--- a/pkg/index/job/correction/service/corrector.go
+++ b/pkg/index/job/correction/service/corrector.go
@@ -222,7 +222,7 @@ func (c *correct) Start(ctx context.Context) (err error) {
 		// cancel with nil cause is a no-op when the context has already been
 		// canceled with a specific cause (e.g. io.EOF on stream completion).
 		defer cancel(nil)
-		stream, err := vc.NewValdClient(conn).StreamListObject(ctx, emptyReq, copts...)
+		stream, err := vc.NewFromConn(conn).StreamListObject(ctx, emptyReq, copts...)
 		if err != nil || stream == nil {
 			return err
 		}
@@ -376,7 +376,7 @@ func (c *correct) loadReplicaInfo(
 				return nil
 			}
 
-			ots, gerr := vc.NewValdClient(conn).GetTimestamp(ctx, &payload.Object_TimestampRequest{
+			ots, gerr := vc.NewFromConn(conn).GetTimestamp(ctx, &payload.Object_TimestampRequest{
 				Id: &payload.Object_ID{
 					Id: id,
 				},
@@ -434,7 +434,7 @@ func (c *correct) getLatestObject(
 		conn *grpc.ClientConn,
 		copts ...grpc.CallOption,
 	) (any, error) {
-		obj, err := vc.NewValdClient(conn).GetObject(ctx, &payload.Object_VectorRequest{
+		obj, err := vc.NewFromConn(conn).GetObject(ctx, &payload.Object_VectorRequest{
 			Id: &payload.Object_ID{
 				Id: id,
 			},
@@ -489,7 +489,7 @@ func (c *correct) correctTimestamp(
 				conn *grpc.ClientConn,
 				copts ...grpc.CallOption,
 			) (any, error) {
-				client := vc.NewValdClient(conn)
+				client := vc.NewFromConn(conn)
 				_, err := client.UpdateTimestamp(ctx, &payload.Update_TimestampRequest{
 					Id:        latestObject.GetId(),
 					Timestamp: latestObject.GetTimestamp(),
@@ -542,7 +542,7 @@ func (c *correct) correctOversupply(
 					conn *grpc.ClientConn,
 					copts ...grpc.CallOption,
 				) (any, error) {
-					_, err := vc.NewValdClient(conn).Remove(ctx, req, copts...)
+					_, err := vc.NewFromConn(conn).Remove(ctx, req, copts...)
 					if err != nil {
 						if st, ok := status.FromError(err); !ok || st == nil {
 							log.Errorf("gRPC call returned not a gRPC status error: %v", err)
@@ -597,7 +597,7 @@ func (c *correct) correctShortage(
 					conn *grpc.ClientConn,
 					copts ...grpc.CallOption,
 				) (any, error) {
-					client := vc.NewValdClient(conn)
+					client := vc.NewFromConn(conn)
 					_, err := client.Insert(ctx, req, copts...)
 					if err != nil {
 						if st, ok := status.FromError(err); !ok || st == nil {

--- a/pkg/index/job/correction/usecase/corrector.go
+++ b/pkg/index/job/correction/usecase/corrector.go
@@ -45,7 +45,7 @@ type run struct {
 	corrector     service.Corrector
 }
 
-func New(cfg *config.Data) (r runner.Runner, err error) {
+func New(cfg *config.Data) (r runner.Interface, err error) {
 	eg := errgroup.Get()
 
 	gOpts, err := cfg.Corrector.Gateway.Opts()
@@ -92,8 +92,8 @@ func New(cfg *config.Data) (r runner.Runner, err error) {
 
 	grpcServerOptions := []server.Option{
 		server.WithGRPCOption(
-			grpc.ChainUnaryInterceptor(recover.RecoverInterceptor()),
-			grpc.ChainStreamInterceptor(recover.RecoverStreamInterceptor()),
+			grpc.ChainUnaryInterceptor(recover.Interceptor()),
+			grpc.ChainStreamInterceptor(recover.StreamInterceptor()),
 		),
 	}
 

--- a/pkg/index/job/creation/config/config.go
+++ b/pkg/index/job/creation/config/config.go
@@ -36,8 +36,8 @@ type Data struct {
 	config.GlobalConfig `json:",inline" yaml:",inline"`
 }
 
-// NewConfig load configurations from file path.
-func NewConfig(path string) (cfg *Data, err error) {
+// New load configurations from file path.
+func New(path string) (cfg *Data, err error) {
 	cfg = new(Data)
 
 	if err = config.Read(path, &cfg); err != nil {

--- a/pkg/index/job/creation/usecase/creation.go
+++ b/pkg/index/job/creation/usecase/creation.go
@@ -43,7 +43,7 @@ type run struct {
 }
 
 // New returns Runner instance.
-func New(cfg *config.Data) (_ runner.Runner, err error) {
+func New(cfg *config.Data) (_ runner.Interface, err error) {
 	eg := errgroup.Get()
 
 	dOpts, err := cfg.Creation.Discoverer.Client.Opts()
@@ -97,8 +97,8 @@ func New(cfg *config.Data) (_ runner.Runner, err error) {
 		starter.WithGRPC(func(cfg *iconfig.Server) []server.Option {
 			return []server.Option{
 				server.WithGRPCOption(
-					grpc.ChainUnaryInterceptor(recover.RecoverInterceptor()),
-					grpc.ChainStreamInterceptor(recover.RecoverStreamInterceptor()),
+					grpc.ChainUnaryInterceptor(recover.Interceptor()),
+					grpc.ChainStreamInterceptor(recover.StreamInterceptor()),
 				),
 			}
 		}),

--- a/pkg/index/job/deletion/usecase/deletion.go
+++ b/pkg/index/job/deletion/usecase/deletion.go
@@ -43,7 +43,7 @@ type run struct {
 }
 
 // New returns Runner instance.
-func New(cfg *config.Data) (_ runner.Runner, err error) {
+func New(cfg *config.Data) (_ runner.Interface, err error) {
 	eg := errgroup.Get()
 
 	dOpts, err := cfg.Deletion.Discoverer.Client.Opts()
@@ -97,8 +97,8 @@ func New(cfg *config.Data) (_ runner.Runner, err error) {
 		starter.WithGRPC(func(cfg *iconfig.Server) []server.Option {
 			return []server.Option{
 				server.WithGRPCOption(
-					grpc.ChainUnaryInterceptor(recover.RecoverInterceptor()),
-					grpc.ChainStreamInterceptor(recover.RecoverStreamInterceptor()),
+					grpc.ChainUnaryInterceptor(recover.Interceptor()),
+					grpc.ChainStreamInterceptor(recover.StreamInterceptor()),
 				),
 			}
 		}),

--- a/pkg/index/job/exportation/config/config.go
+++ b/pkg/index/job/exportation/config/config.go
@@ -36,8 +36,8 @@ type Data struct {
 	config.GlobalConfig `json:",inline" yaml:",inline"`
 }
 
-// NewConfig load configurations from file path.
-func NewConfig(path string) (cfg *Data, err error) {
+// New load configurations from file path.
+func New(path string) (cfg *Data, err error) {
 	cfg = new(Data)
 
 	if err = config.Read(path, &cfg); err != nil {

--- a/pkg/index/job/exportation/config/config_test.go
+++ b/pkg/index/job/exportation/config/config_test.go
@@ -45,7 +45,7 @@ func removeTestConfigFile(t *testing.T, path string) {
 	}
 }
 
-func TestNewConfig(t *testing.T) {
+func TestNew(t *testing.T) {
 	t.Parallel()
 	type args struct {
 		path string
@@ -234,7 +234,7 @@ observability:
 				checkFunc = defaultCheckFunc
 			}
 
-			gotCfg, err := NewConfig(test.args.path)
+			gotCfg, err := New(test.args.path)
 			if cerr := checkFunc(test.want, gotCfg, err); cerr != nil {
 				tt.Errorf("error = %v, got = %#v", cerr, gotCfg)
 			}

--- a/pkg/index/job/exportation/service/options_test.go
+++ b/pkg/index/job/exportation/service/options_test.go
@@ -166,7 +166,7 @@ func TestWithGateway(t *testing.T) {
 	t.Run("sets gateway when client is not nil", func(tt *testing.T) {
 		tt.Parallel()
 		e := new(export)
-		client := vald.NewValdClient(nil)
+		client := vald.NewFromConn(nil)
 		if err := WithGateway(client)(e); err != nil {
 			tt.Errorf("err: %v", err)
 		}

--- a/pkg/index/job/exportation/usecase/exportation.go
+++ b/pkg/index/job/exportation/usecase/exportation.go
@@ -40,7 +40,7 @@ type run struct {
 }
 
 // New returns Runner instance.
-func New(cfg *config.Data) (_ runner.Runner, err error) {
+func New(cfg *config.Data) (_ runner.Interface, err error) {
 	eg := errgroup.Get()
 
 	gOpts, err := cfg.Exporter.Gateway.Opts()

--- a/pkg/index/job/readreplica/rotate/config/config.go
+++ b/pkg/index/job/readreplica/rotate/config/config.go
@@ -36,8 +36,8 @@ type Data struct {
 	config.GlobalConfig `json:",inline" yaml:",inline"`
 }
 
-// NewConfig loads configurations from the file path.
-func NewConfig(path string) (cfg *Data, err error) {
+// New loads configurations from the file path.
+func New(path string) (cfg *Data, err error) {
 	cfg = new(Data)
 
 	if err = config.Read(path, &cfg); err != nil {

--- a/pkg/index/job/readreplica/rotate/usecase/rotate.go
+++ b/pkg/index/job/readreplica/rotate/usecase/rotate.go
@@ -42,7 +42,7 @@ type run struct {
 }
 
 // New returns Runner instance.
-func New(cfg *config.Data) (_ runner.Runner, err error) {
+func New(cfg *config.Data) (_ runner.Interface, err error) {
 	eg := errgroup.Get()
 
 	rotator, err := service.New(
@@ -60,8 +60,8 @@ func New(cfg *config.Data) (_ runner.Runner, err error) {
 		starter.WithGRPC(func(cfg *iconfig.Server) []server.Option {
 			return []server.Option{
 				server.WithGRPCOption(
-					grpc.ChainUnaryInterceptor(recover.RecoverInterceptor()),
-					grpc.ChainStreamInterceptor(recover.RecoverStreamInterceptor()),
+					grpc.ChainUnaryInterceptor(recover.Interceptor()),
+					grpc.ChainStreamInterceptor(recover.StreamInterceptor()),
 				),
 			}
 		}),

--- a/pkg/index/job/save/config/config.go
+++ b/pkg/index/job/save/config/config.go
@@ -36,8 +36,8 @@ type Data struct {
 	config.GlobalConfig `json:",inline" yaml:",inline"`
 }
 
-// NewConfig loads configurations from the file path.
-func NewConfig(path string) (cfg *Data, err error) {
+// New loads configurations from the file path.
+func New(path string) (cfg *Data, err error) {
 	cfg = new(Data)
 
 	if err = config.Read(path, &cfg); err != nil {

--- a/pkg/index/job/save/usecase/save.go
+++ b/pkg/index/job/save/usecase/save.go
@@ -43,7 +43,7 @@ type run struct {
 }
 
 // New returns Runner instance.
-func New(cfg *config.Data) (_ runner.Runner, err error) {
+func New(cfg *config.Data) (_ runner.Interface, err error) {
 	eg := errgroup.Get()
 
 	dOpts, err := cfg.Save.Discoverer.Client.Opts()
@@ -96,8 +96,8 @@ func New(cfg *config.Data) (_ runner.Runner, err error) {
 		starter.WithGRPC(func(cfg *iconfig.Server) []server.Option {
 			return []server.Option{
 				server.WithGRPCOption(
-					grpc.ChainUnaryInterceptor(recover.RecoverInterceptor()),
-					grpc.ChainStreamInterceptor(recover.RecoverStreamInterceptor()),
+					grpc.ChainUnaryInterceptor(recover.Interceptor()),
+					grpc.ChainStreamInterceptor(recover.StreamInterceptor()),
 				),
 			}
 		}),

--- a/pkg/index/operator/usecase/operator.go
+++ b/pkg/index/operator/usecase/operator.go
@@ -39,7 +39,7 @@ type run struct {
 }
 
 // New returns Runner instance.
-func New(cfg *config.Data) (_ runner.Runner, err error) {
+func New(cfg *config.Data) (_ runner.Interface, err error) {
 	eg := errgroup.Get()
 	operator, err := service.New(
 		cfg.Operator.Namespace,
@@ -60,8 +60,8 @@ func New(cfg *config.Data) (_ runner.Runner, err error) {
 		starter.WithGRPC(func(cfg *iconfig.Server) []server.Option {
 			return []server.Option{
 				server.WithGRPCOption(
-					grpc.ChainUnaryInterceptor(recover.RecoverInterceptor()),
-					grpc.ChainStreamInterceptor(recover.RecoverStreamInterceptor()),
+					grpc.ChainUnaryInterceptor(recover.Interceptor()),
+					grpc.ChainStreamInterceptor(recover.StreamInterceptor()),
 				),
 			}
 		}),

--- a/pkg/manager/index/config/config.go
+++ b/pkg/manager/index/config/config.go
@@ -40,7 +40,7 @@ type Data struct {
 	config.GlobalConfig `json:",inline" yaml:",inline"`
 }
 
-func NewConfig(path string) (cfg *Data, err error) {
+func New(path string) (cfg *Data, err error) {
 	cfg = new(Data)
 
 	err = config.Read(path, &cfg)

--- a/pkg/manager/index/service/indexer.go
+++ b/pkg/manager/index/service/indexer.go
@@ -292,7 +292,7 @@ func (idx *index) loadInfos(ctx context.Context) (err error) {
 			case <-ctx.Done():
 				return nil
 			default:
-				info, err := vald.NewValdClient(conn).IndexInfo(ctx, new(payload.Empty), copts...)
+				info, err := vald.NewFromConn(conn).IndexInfo(ctx, new(payload.Empty), copts...)
 				if err != nil {
 					log.Warnf("an error occurred while calling IndexInfo of %s: %s", addr, err)
 					return nil

--- a/pkg/manager/index/usecase/indexer.go
+++ b/pkg/manager/index/usecase/indexer.go
@@ -47,7 +47,7 @@ type run struct {
 	indexer       service.Indexer
 }
 
-func New(cfg *config.Data) (r runner.Runner, err error) {
+func New(cfg *config.Data) (r runner.Interface, err error) {
 	eg := errgroup.Get()
 
 	var indexer service.Indexer

--- a/pkg/manager/index/usecase/indexer_test.go
+++ b/pkg/manager/index/usecase/indexer_test.go
@@ -23,18 +23,18 @@ package usecase
 // 		cfg *config.Data
 // 	}
 // 	type want struct {
-// 		wantR runner.Runner
+// 		wantR runner.Interface
 // 		err   error
 // 	}
 // 	type test struct {
 // 		name       string
 // 		args       args
 // 		want       want
-// 		checkFunc  func(want, runner.Runner, error) error
+// 		checkFunc  func(want, runner.Interface, error) error
 // 		beforeFunc func(*testing.T, args)
 // 		afterFunc  func(*testing.T, args)
 // 	}
-// 	defaultCheckFunc := func(w want, gotR runner.Runner, err error) error {
+// 	defaultCheckFunc := func(w want, gotR runner.Interface, err error) error {
 // 		if !errors.Is(err, w.err) {
 // 			return errors.Errorf("got_error: \"%#v\",\n\t\t\t\twant: \"%#v\"", err, w.err)
 // 		}

--- a/pkg/operator/benchmark/config/config.go
+++ b/pkg/operator/benchmark/config/config.go
@@ -38,8 +38,8 @@ type Config struct {
 	config.GlobalConfig `json:",inline" yaml:",inline"`
 }
 
-// NewConfig represents the set config from the given setting file path.
-func NewConfig(path string) (cfg *Config, err error) {
+// NewData represents the set config from the given setting file path.
+func NewData(path string) (cfg *Config, err error) {
 	err = config.Read(path, &cfg)
 	if err != nil {
 		return nil, err

--- a/pkg/operator/benchmark/usecase/benchmarkd.go
+++ b/pkg/operator/benchmark/usecase/benchmarkd.go
@@ -52,7 +52,7 @@ type run struct {
 
 var JOB_NAMESPACE = os.Getenv("JOB_NAMESPACE")
 
-func New(cfg *config.Config) (r runner.Runner, err error) {
+func New(cfg *config.Config) (r runner.Interface, err error) {
 	log.Info("pkg/operator/benchmark/cmd start")
 
 	eg := errgroup.Get()
@@ -80,8 +80,8 @@ func New(cfg *config.Config) (r runner.Runner, err error) {
 			// TODO register grpc server handler here
 		}),
 		server.WithGRPCOption(
-			grpc.ChainUnaryInterceptor(recover.RecoverInterceptor()),
-			grpc.ChainStreamInterceptor(recover.RecoverStreamInterceptor()),
+			grpc.ChainUnaryInterceptor(recover.Interceptor()),
+			grpc.ChainStreamInterceptor(recover.StreamInterceptor()),
 		),
 		server.WithPreStartFunc(func() error {
 			// TODO check unbackupped upstream

--- a/pkg/operator/vald/config/config.go
+++ b/pkg/operator/vald/config/config.go
@@ -451,7 +451,7 @@ func (o *Operator) Load() (*Config, error) {
 	return c, nil
 }
 
-func NewConfig(path string) (cfg *Data, err error) {
+func New(path string) (cfg *Data, err error) {
 	cfg = new(Data)
 
 	if err = config.Read(path, &cfg); err != nil {

--- a/pkg/operator/vald/config/config_test.go
+++ b/pkg/operator/vald/config/config_test.go
@@ -42,7 +42,7 @@ const minimalServerYAML = `server_config:
 `
 
 //nolint:maintidx
-func TestNewConfig(t *testing.T) {
+func TestNew(t *testing.T) {
 	t.Parallel()
 
 	type test struct {
@@ -208,15 +208,15 @@ operator:
 			t.Parallel()
 
 			path := writeTempFile(t, "config.yaml", tc.yaml)
-			cfg, err := NewConfig(path)
+			cfg, err := New(path)
 			if tc.wantErr {
 				if err == nil {
-					t.Error("NewConfig() error = nil, want error")
+					t.Error("New() error = nil, want error")
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("NewConfig() error = %v, want nil", err)
+				t.Fatalf("New() error = %v, want nil", err)
 			}
 			if tc.check != nil {
 				tc.check(t, cfg)

--- a/pkg/operator/vald/usecase/operator.go
+++ b/pkg/operator/vald/usecase/operator.go
@@ -42,7 +42,7 @@ type run struct {
 	operator      service.Operator
 }
 
-func New(cfg *config.Data) (_ runner.Runner, err error) {
+func New(cfg *config.Data) (_ runner.Interface, err error) {
 	eg := errgroup.Get()
 	operator, err := service.New(cfg.Operator)
 	if err != nil {
@@ -54,8 +54,8 @@ func New(cfg *config.Data) (_ runner.Runner, err error) {
 		starter.WithGRPC(func(cfg *iconfig.Server) []server.Option {
 			return []server.Option{
 				server.WithGRPCOption(
-					grpc.ChainUnaryInterceptor(recover.RecoverInterceptor()),
-					grpc.ChainStreamInterceptor(recover.RecoverStreamInterceptor()),
+					grpc.ChainUnaryInterceptor(recover.Interceptor()),
+					grpc.ChainStreamInterceptor(recover.StreamInterceptor()),
 				),
 			}
 		}),

--- a/pkg/tools/benchmark/job/service/job.go
+++ b/pkg/tools/benchmark/job/service/job.go
@@ -205,7 +205,7 @@ func (j *job) PreStart(ctx context.Context) error {
 		}
 		log.Infof("[benchmark job] success download dataset of %s", j.hdf5.GetName().String())
 		log.Infof("[benchmark job] start load dataset of %s", j.hdf5.GetName().String())
-		var key hdf5.Hdf5Key
+		var key hdf5.Key
 		switch j.dataset.Group {
 		case "train":
 			key = hdf5.Train

--- a/pkg/tools/benchmark/job/usecase/benchmarkd.go
+++ b/pkg/tools/benchmark/job/usecase/benchmarkd.go
@@ -50,7 +50,7 @@ type run struct {
 	observability observability.Observability
 }
 
-func New(cfg *config.Config) (r runner.Runner, err error) {
+func New(cfg *config.Config) (r runner.Interface, err error) {
 	log.Info("pkg/tools/benchmark/job/cmd start")
 	eg := errgroup.Get()
 
@@ -141,8 +141,8 @@ func New(cfg *config.Config) (r runner.Runner, err error) {
 			// TODO register grpc server handler here
 		}),
 		server.WithGRPCOption(
-			grpc.ChainUnaryInterceptor(recover.RecoverInterceptor()),
-			grpc.ChainStreamInterceptor(recover.RecoverStreamInterceptor()),
+			grpc.ChainUnaryInterceptor(recover.Interceptor()),
+			grpc.ChainStreamInterceptor(recover.StreamInterceptor()),
 		),
 		server.WithPreStartFunc(func() error {
 			// TODO check unbackupped upstream

--- a/tests/e2e/crud/crud_faiss_test.go
+++ b/tests/e2e/crud/crud_faiss_test.go
@@ -109,7 +109,7 @@ func init() {
 	}
 
 	fmt.Printf("loading dataset: %s ", *datasetName)
-	ds, err = hdf5.HDF5ToDataset(*datasetName)
+	ds, err = hdf5.ToDataset(*datasetName)
 	if err != nil {
 		panic(err)
 	}

--- a/tests/e2e/crud/crud_test.go
+++ b/tests/e2e/crud/crud_test.go
@@ -120,7 +120,7 @@ func init() {
 	}
 
 	fmt.Printf("loading dataset: %s ", *datasetName)
-	ds, err = hdf5.HDF5ToDataset(*datasetName)
+	ds, err = hdf5.ToDataset(*datasetName)
 	if err != nil {
 		panic(err)
 	}
@@ -907,7 +907,7 @@ func TestE2EReadReplica(t *testing.T) {
 	t.Log("waiting for read replica rotator jobs to complete...")
 	if err := kubectl.WaitResources(ctx, t, "job", "app=vald-readreplica-rotate", "complete", "60s", kubeConfig); err != nil {
 		t.Log("wait failed. printing yaml of vald-readreplica-rotate")
-		kubectl.KubectlCmd(ctx, t, kubeConfig, "get", "pod", "-l", "app=vald-readreplica-rotate", "-o", "yaml")
+		kubectl.Cmd(ctx, t, kubeConfig, "get", "pod", "-l", "app=vald-readreplica-rotate", "-o", "yaml")
 		t.Log("wait failed. printing log of vald-index-operator")
 		kubectl.DebugLog(ctx, t, "app=vald-index-operator", kubeConfig)
 		t.Log("wait failed. printing log of vald-readreplica-rotate")

--- a/tests/e2e/hdf5/hdf5.go
+++ b/tests/e2e/hdf5/hdf5.go
@@ -27,7 +27,7 @@ type Dataset struct {
 	Neighbors [][]int
 }
 
-func HDF5ToDataset(name string) (*Dataset, error) {
+func ToDataset(name string) (*Dataset, error) {
 	file, err := hdf5.OpenFile(name, hdf5.F_ACC_RDONLY)
 	if err != nil {
 		return nil, err

--- a/tests/e2e/kubernetes/kubectl/kubectl.go
+++ b/tests/e2e/kubernetes/kubectl/kubectl.go
@@ -56,7 +56,7 @@ func DebugLog(ctx context.Context, t *testing.T, label, kubeconfig string) error
 	return runCmd(t, cmd)
 }
 
-func KubectlCmd(ctx context.Context, t *testing.T, kubeconfig string, subcmds ...string) error {
+func Cmd(ctx context.Context, t *testing.T, kubeconfig string, subcmds ...string) error {
 	t.Helper()
 	cmd := exec.CommandContext(ctx, "kubectl", append([]string{"--kubeconfig", kubeconfig}, subcmds...)...)
 	return runCmd(t, cmd)

--- a/tests/e2e/multiapis/multiapis_test.go
+++ b/tests/e2e/multiapis/multiapis_test.go
@@ -112,7 +112,7 @@ func init() {
 	}
 
 	fmt.Printf("loading dataset: %s ", *datasetName)
-	ds, err = hdf5.HDF5ToDataset(*datasetName)
+	ds, err = hdf5.ToDataset(*datasetName)
 	if err != nil {
 		panic(err)
 	}

--- a/tests/e2e/sidecar/sidecar_test.go
+++ b/tests/e2e/sidecar/sidecar_test.go
@@ -91,7 +91,7 @@ func init() {
 	}
 
 	fmt.Printf("loading dataset: %s ", *datasetName)
-	ds, err = hdf5.HDF5ToDataset(*datasetName)
+	ds, err = hdf5.ToDataset(*datasetName)
 	if err != nil {
 		panic(err)
 	}

--- a/tests/v2/e2e/crud/crud_test.go
+++ b/tests/v2/e2e/crud/crud_test.go
@@ -70,7 +70,7 @@ func TestMain(m *testing.M) {
 	}
 	log.Init(log.WithLevel(cfg.Logging.Level), log.WithFormat(cfg.Logging.Format))
 	if cfg.Dataset != nil && cfg.Dataset.Name != "" {
-		ds, err = hdf5.HDF5ToDataset(cfg.Dataset.Name)
+		ds, err = hdf5.ToDataset(cfg.Dataset.Name)
 		if err != nil {
 			log.Fatalf("failed to load dataset: %v", err)
 		}

--- a/tests/v2/e2e/hdf5/hdf5.go
+++ b/tests/v2/e2e/hdf5/hdf5.go
@@ -66,7 +66,7 @@ func (d *Dataset) InitNoiseFunc(num uint64, opts ...noise.Option) noise.Func {
 	return d.noiseFunc
 }
 
-func HDF5ToDataset(name string) (*Dataset, error) {
+func ToDataset(name string) (*Dataset, error) {
 	file, err := hdf5.OpenFile(name, hdf5.F_ACC_RDONLY)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

codegraph/graphify を使った全リポジトリ監査(Haiku 60体並列探索 + Sonnet秘書集約)で、コンストラクタ関数・Option関連の型/関数がパッケージ名と重複("stutter")している箇所を検出し、[Go公式の命名規約](https://go.dev/wiki/CodeReviewComments#package-names)(例: `bytes.Buffer` であって `bytes.BytesBuffer` ではない)に沿ってリネームしました。

- 検出34件 → grep裏取りで33件確定(1件は誤検出として除外: `internal/k8s/portforward`)
- ロジック変更は無し(純粋な識別子リネーム。`git diff --numstat` で全132ファイルの追加/削除行数が完全一致(377/377)していることで裏付け)

### 主なリネーム

| 種別 | Before | After |
|---|---|---|
| config系12パッケージ | `NewConfig` | `New`(`pkg/operator/benchmark/config`のみ`NewData`) |
| internal/circuitbreaker | `NewCircuitBreaker` | `New` |
| internal/client/v1/client/vald | `NewValdClient` | `NewFromConn` |
| internal/runner (interface, 38箇所) | `Runner` | `Interface` |
| internal/log/logger (interface) | `Logger` | `Interface` |
| internal/compress/zstd (interface) | `Zstd` | `Compressor` |
| internal/db/kvs/redis (interface) | `Redis` | `Client` |
| internal/k8s/vald/mirror/target (struct) | `Target` | `Endpoint` |
| internal/worker, hack/.../strategy (Option型) | `WorkerOption`, `StrategyOption` | `Option` |
| その他8件 | (詳細はコミットメッセージ参照) | |

## Verification

- `go vet ./...`: 新規エラー0件(既存のcopylock警告29件のみ、いずれも未変更ファイル/未変更行)
- 変更した全パッケージで `go test` pass
- `gofmt -l`: クリーン
- `vald-reviewer` によるレビュー: Vald Law 1(生成コード非改変)/3-5(panic・エラー握りつぶし・stdlib import混入なし)違反なし、ロジック変更混入なし、リネーム漏れなし

## Test plan

- [ ] CI(golangci-lint / unit test / build)がグリーンであることを確認
- [ ] レビュアーによる命名選択(特に `runner.Interface`, `logger.Interface` など)の妥当性確認
- [ ] `/swarm-release-gate` 相当の最終人間承認後にマージ

Generated with [Claude Code](https://claude.ai/claude-code)