### PR TITLE
build: support native macOS (Darwin) build (NGT, Faiss, cgo, make test)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,7 @@ rust/target/
 
 !rust/libs
 /gen
+
+# local native-build prefixes (macOS dev)
+.local/
+.local-ngt/

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,6 @@ VERSION ?= $(eval VERSION := $(shell cat versions/VALD_VERSION))$(VERSION)
 
 NGT_REPO = github.com/NGT-labs/NGT
 
-NGT_EXTRA_CMAKE_FLAGS ?=
-
 TEST_NOT_IMPL_PLACEHOLDER = NOT IMPLEMENTED BELOW
 
 TEMP_DIR := $(eval TEMP_DIR := $(shell mktemp -d))$(TEMP_DIR)
@@ -206,6 +204,22 @@ EXTLDFLAGS ?=
 else
 EXTLDFLAGS ?= -Wl,--no-keep-memory
 endif
+endif
+
+# NGT build flags: OS-aware and overridable. NGT requires an OpenMP runtime.
+# On Linux/container the compiler bundles libgomp/libomp. On macOS, OpenMP
+# (libomp), HDF5, and the other native-build deps are provided by Homebrew --
+# see docs/contributing/development.md (`brew install libomp hdf5 ...`). LTO uses
+# Apple thin-LTO on Darwin (-ffat-lto-objects is unsupported for Mach-O).
+ifeq ($(GOOS),darwin)
+NGT_LTO_FLAGS ?= -flto=thin
+NGT_OPENMP_PREFIX := $(shell brew --prefix libomp 2>/dev/null)
+NGT_OPENMP_CFLAGS := -I$(NGT_OPENMP_PREFIX)/include
+NGT_EXTRA_CMAKE_FLAGS ?= -DOpenMP_ROOT=$(NGT_OPENMP_PREFIX) -DCMAKE_SHARED_LINKER_FLAGS=-L$(NGT_OPENMP_PREFIX)/lib -DCMAKE_EXE_LINKER_FLAGS=-L$(NGT_OPENMP_PREFIX)/lib -DCMAKE_INSTALL_RPATH=@loader_path/../lib
+else
+NGT_LTO_FLAGS ?= -flto=auto -ffat-lto-objects
+NGT_OPENMP_CFLAGS :=
+NGT_EXTRA_CMAKE_FLAGS ?=
 endif
 
 BENCH_DATASET_MD5S := $(eval BENCH_DATASET_MD5S := $(shell find $(BENCH_DATASET_MD5_DIR) -type f -regex ".*\.md5"))$(BENCH_DATASET_MD5S)
@@ -850,8 +864,8 @@ $(USR_LOCAL)/include/NGT/Capi.h:
 	-DCMAKE_AR=$$(command -v llvm-ar 2>/dev/null || ls /usr/bin/llvm-ar-* 2>/dev/null | sort -V | tail -1 | grep . || command -v gcc-ar 2>/dev/null || ls /usr/bin/gcc-ar-* 2>/dev/null | sort -V | tail -1 | grep . || command -v ar) \
 	-DCMAKE_CXX_COMPILER_AR=$$(command -v llvm-ar 2>/dev/null || ls /usr/bin/llvm-ar-* 2>/dev/null | sort -V | tail -1 | grep . || command -v gcc-ar 2>/dev/null || ls /usr/bin/gcc-ar-* 2>/dev/null | sort -V | tail -1 | grep . || command -v ar) \
 	-DCMAKE_RANLIB=$$(command -v llvm-ranlib 2>/dev/null || ls /usr/bin/llvm-ranlib-* 2>/dev/null | sort -V | tail -1 | grep . || command -v gcc-ranlib 2>/dev/null || ls /usr/bin/gcc-ranlib-* 2>/dev/null | sort -V | tail -1 | grep . || command -v ranlib) \
-	-DCMAKE_C_FLAGS="$(CFLAGS) -flto=auto -ffat-lto-objects" \
-	-DCMAKE_CXX_FLAGS="$(CXXFLAGS) -flto=auto -ffat-lto-objects" \
+	-DCMAKE_C_FLAGS="$(CFLAGS) $(NGT_LTO_FLAGS) $(NGT_OPENMP_CFLAGS)" \
+	-DCMAKE_CXX_FLAGS="$(CXXFLAGS) $(NGT_LTO_FLAGS) $(NGT_OPENMP_CFLAGS)" \
 	-DCMAKE_INSTALL_PREFIX=$(USR_LOCAL) \
 	$(NGT_EXTRA_CMAKE_FLAGS) \
 	-B $(TEMP_DIR)/NGT-$(NGT_VERSION)/build $(TEMP_DIR)/NGT-$(NGT_VERSION)
@@ -859,7 +873,7 @@ $(USR_LOCAL)/include/NGT/Capi.h:
 	make -C $(TEMP_DIR)/NGT-$(NGT_VERSION)/build install
 	cd $(ROOTDIR)
 	rm -rf $(TEMP_DIR)/NGT-$(NGT_VERSION)
-	ldconfig
+	command -v ldconfig >/dev/null 2>&1 && ldconfig || true
 
 .PHONY: faiss/install
 ## install Faiss

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,11 @@ FAISS_LDFLAGS = $(NGT_LDFLAGS)
 HDF5_LDFLAGS = -lhdf5 -lhdf5_hl -lsz -laec -lz -ldl -lm
 CGO_LDFLAGS = $(FAISS_LDFLAGS) $(HDF5_LDFLAGS)
 # TEST_LDFLAGS without -static to avoid conflicts with CGO and glibc dynamic linking requirements
+ifeq ($(GOOS),darwin)
+TEST_LDFLAGS_BASE = -fPIC -pthread -lc++ -lm -L$(OPENMP_PREFIX)/lib -Wl,-rpath,$(USR_LOCAL)/lib -lomp -framework Accelerate -lpthread
+else
 TEST_LDFLAGS_BASE = -fPIC -pthread -std=gnu++23 -lstdc++ -lm -z relro -z now -flto=auto -ffat-lto-objects -march=native -mtune=native -fno-plt -O3 -ffast-math -fvisibility=hidden -ffp-contract=fast -fomit-frame-pointer -fmerge-all-constants -funroll-loops -falign-functions=32 -ffunction-sections -fdata-sections
+endif
 TEST_LDFLAGS = $(TEST_LDFLAGS_BASE) $(CGO_LDFLAGS)
 
 ifeq ($(GOARCH),amd64)
@@ -216,6 +220,11 @@ ifeq ($(GOOS),darwin)
 # Homebrew, consistent with the existing darwin HDF5/ZLIB handling.
 OPENMP_PREFIX := $(shell brew --prefix libomp 2>/dev/null)
 OPENMP_CFLAGS := -I$(OPENMP_PREFIX)/include
+# cgo (go test/go build) must see libomp headers on Darwin; export so all go
+# invocations inherit them (test targets only set CGO_LDFLAGS inline).
+CGO_CFLAGS += $(OPENMP_CFLAGS)
+CGO_CXXFLAGS += $(OPENMP_CFLAGS)
+export CGO_CFLAGS CGO_CXXFLAGS
 NATIVE_LTO_FLAGS ?= -flto=thin
 # NGT: let cmake find_package(OpenMP) via OpenMP_ROOT; install rpath so bin/ngt
 # resolves libngt without ldconfig (absent on Darwin).
@@ -227,6 +236,8 @@ FAISS_CMAKE_C_FLAGS := $(CFLAGS) $(NATIVE_LTO_FLAGS) $(OPENMP_CFLAGS)
 FAISS_CMAKE_EXE_LINKER_FLAGS :=
 FAISS_EXTRA_CMAKE_FLAGS := -DOpenMP_ROOT=$(OPENMP_PREFIX)
 FAISS_BLA_VENDOR :=
+# HDF5: skip the static example binaries on Darwin (no crt0.o for -static).
+HDF5_BUILD_EXAMPLES := -DHDF5_BUILD_EXAMPLES=OFF
 else
 NATIVE_LTO_FLAGS ?= -flto=auto -ffat-lto-objects
 OPENMP_CFLAGS :=
@@ -235,6 +246,7 @@ FAISS_CMAKE_C_FLAGS := $(LDFLAGS)
 FAISS_CMAKE_EXE_LINKER_FLAGS := $(FAISS_LDFLAGS)
 FAISS_EXTRA_CMAKE_FLAGS :=
 FAISS_BLA_VENDOR := -DBLA_VENDOR=OpenBLAS
+HDF5_BUILD_EXAMPLES :=
 endif
 
 BENCH_DATASET_MD5S := $(eval BENCH_DATASET_MD5S := $(shell find $(BENCH_DATASET_MD5_DIR) -type f -regex ".*\.md5"))$(BENCH_DATASET_MD5S)

--- a/Makefile
+++ b/Makefile
@@ -212,14 +212,29 @@ endif
 # see docs/contributing/development.md (`brew install libomp hdf5 ...`). LTO uses
 # Apple thin-LTO on Darwin (-ffat-lto-objects is unsupported for Mach-O).
 ifeq ($(GOOS),darwin)
-NGT_LTO_FLAGS ?= -flto=thin
-NGT_OPENMP_PREFIX := $(shell brew --prefix libomp 2>/dev/null)
-NGT_OPENMP_CFLAGS := -I$(NGT_OPENMP_PREFIX)/include
-NGT_EXTRA_CMAKE_FLAGS ?= -DOpenMP_ROOT=$(NGT_OPENMP_PREFIX) -DCMAKE_SHARED_LINKER_FLAGS=-L$(NGT_OPENMP_PREFIX)/lib -DCMAKE_EXE_LINKER_FLAGS=-L$(NGT_OPENMP_PREFIX)/lib -DCMAKE_INSTALL_RPATH=@loader_path/../lib
+# Shared darwin native-build helpers. OpenMP runtime (libomp) is provided by
+# Homebrew, consistent with the existing darwin HDF5/ZLIB handling.
+OPENMP_PREFIX := $(shell brew --prefix libomp 2>/dev/null)
+OPENMP_CFLAGS := -I$(OPENMP_PREFIX)/include
+NATIVE_LTO_FLAGS ?= -flto=thin
+# NGT: let cmake find_package(OpenMP) via OpenMP_ROOT; install rpath so bin/ngt
+# resolves libngt without ldconfig (absent on Darwin).
+NGT_EXTRA_CMAKE_FLAGS ?= -DOpenMP_ROOT=$(OPENMP_PREFIX) -DCMAKE_SHARED_LINKER_FLAGS=-L$(OPENMP_PREFIX)/lib -DCMAKE_EXE_LINKER_FLAGS=-L$(OPENMP_PREFIX)/lib -DCMAKE_INSTALL_RPATH=@loader_path/../lib
+# Faiss: drop the GNU LDFLAGS-as-CFLAGS and the -fopenmp/-lopenblas/-llapack/
+# -lgfortran linker flags; let cmake find OpenMP (OpenMP_ROOT) and BLAS/LAPACK
+# (Accelerate.framework) natively. BLA_VENDOR unset -> Accelerate on Darwin.
+FAISS_CMAKE_C_FLAGS := $(CFLAGS) $(NATIVE_LTO_FLAGS) $(OPENMP_CFLAGS)
+FAISS_CMAKE_EXE_LINKER_FLAGS :=
+FAISS_EXTRA_CMAKE_FLAGS := -DOpenMP_ROOT=$(OPENMP_PREFIX)
+FAISS_BLA_VENDOR :=
 else
-NGT_LTO_FLAGS ?= -flto=auto -ffat-lto-objects
-NGT_OPENMP_CFLAGS :=
+NATIVE_LTO_FLAGS ?= -flto=auto -ffat-lto-objects
+OPENMP_CFLAGS :=
 NGT_EXTRA_CMAKE_FLAGS ?=
+FAISS_CMAKE_C_FLAGS := $(LDFLAGS)
+FAISS_CMAKE_EXE_LINKER_FLAGS := $(FAISS_LDFLAGS)
+FAISS_EXTRA_CMAKE_FLAGS :=
+FAISS_BLA_VENDOR := -DBLA_VENDOR=OpenBLAS
 endif
 
 BENCH_DATASET_MD5S := $(eval BENCH_DATASET_MD5S := $(shell find $(BENCH_DATASET_MD5_DIR) -type f -regex ".*\.md5"))$(BENCH_DATASET_MD5S)
@@ -864,8 +879,8 @@ $(USR_LOCAL)/include/NGT/Capi.h:
 	-DCMAKE_AR=$$(command -v llvm-ar 2>/dev/null || ls /usr/bin/llvm-ar-* 2>/dev/null | sort -V | tail -1 | grep . || command -v gcc-ar 2>/dev/null || ls /usr/bin/gcc-ar-* 2>/dev/null | sort -V | tail -1 | grep . || command -v ar) \
 	-DCMAKE_CXX_COMPILER_AR=$$(command -v llvm-ar 2>/dev/null || ls /usr/bin/llvm-ar-* 2>/dev/null | sort -V | tail -1 | grep . || command -v gcc-ar 2>/dev/null || ls /usr/bin/gcc-ar-* 2>/dev/null | sort -V | tail -1 | grep . || command -v ar) \
 	-DCMAKE_RANLIB=$$(command -v llvm-ranlib 2>/dev/null || ls /usr/bin/llvm-ranlib-* 2>/dev/null | sort -V | tail -1 | grep . || command -v gcc-ranlib 2>/dev/null || ls /usr/bin/gcc-ranlib-* 2>/dev/null | sort -V | tail -1 | grep . || command -v ranlib) \
-	-DCMAKE_C_FLAGS="$(CFLAGS) $(NGT_LTO_FLAGS) $(NGT_OPENMP_CFLAGS)" \
-	-DCMAKE_CXX_FLAGS="$(CXXFLAGS) $(NGT_LTO_FLAGS) $(NGT_OPENMP_CFLAGS)" \
+	-DCMAKE_C_FLAGS="$(CFLAGS) $(NATIVE_LTO_FLAGS) $(OPENMP_CFLAGS)" \
+	-DCMAKE_CXX_FLAGS="$(CXXFLAGS) $(NATIVE_LTO_FLAGS) $(OPENMP_CFLAGS)" \
 	-DCMAKE_INSTALL_PREFIX=$(USR_LOCAL) \
 	$(NGT_EXTRA_CMAKE_FLAGS) \
 	-B $(TEMP_DIR)/NGT-$(NGT_VERSION)/build $(TEMP_DIR)/NGT-$(NGT_VERSION)
@@ -889,16 +904,17 @@ $(LIB_PATH)/libfaiss.a:
 	-DBUILD_TESTING=OFF \
 	-DFAISS_ENABLE_PYTHON=OFF \
 	-DFAISS_ENABLE_GPU=OFF \
-	-DBLA_VENDOR=OpenBLAS \
-	-DCMAKE_C_FLAGS="$(LDFLAGS)" \
-	-DCMAKE_EXE_LINKER_FLAGS="$(FAISS_LDFLAGS)" \
+	$(FAISS_BLA_VENDOR) \
+	-DCMAKE_C_FLAGS="$(FAISS_CMAKE_C_FLAGS)" \
+	-DCMAKE_EXE_LINKER_FLAGS="$(FAISS_CMAKE_EXE_LINKER_FLAGS)" \
+	$(FAISS_EXTRA_CMAKE_FLAGS) \
 	-DCMAKE_INSTALL_PREFIX=$(USR_LOCAL) \
 	-B $(TEMP_DIR)/faiss-$(FAISS_VERSION)/build $(TEMP_DIR)/faiss-$(FAISS_VERSION)
 	make -C $(TEMP_DIR)/faiss-$(FAISS_VERSION)/build -j$(CORES) faiss
 	make -C $(TEMP_DIR)/faiss-$(FAISS_VERSION)/build install
 	cd $(ROOTDIR)
 	rm -rf $(TEMP_DIR)/v$(FAISS_VERSION).tar.gz $(TEMP_DIR)/faiss-$(FAISS_VERSION)
-	ldconfig
+	command -v ldconfig >/dev/null 2>&1 && ldconfig || true
 
 .PHONY: usearch/install
 ## install usearch

--- a/Makefile.d/tools.mk
+++ b/Makefile.d/tools.mk
@@ -377,6 +377,7 @@ $(LIB_PATH)/libhdf5.a: $(LIB_PATH) \
 	-DHDF5_BUILD_HL_LIB=ON \
 	-DHDF5_BUILD_STATIC_EXECS=ON \
 	-DHDF5_BUILD_TOOLS=OFF \
+	$(HDF5_BUILD_EXAMPLES) \
 	-DHDF5_ENABLE_Z_LIB_SUPPORT=ON \
 	-DH5_ZLIB_INCLUDE_DIR=$(USR_LOCAL)/include \
 	-DH5_ZLIB_LIBRARY=$(LIB_PATH)/libz.a \
@@ -389,7 +390,7 @@ $(LIB_PATH)/libhdf5.a: $(LIB_PATH) \
 	&& make install \
 	&& cd $(ROOTDIR) \
 	&& rm -rf $(TEMP_DIR)/hdf5.tar.gz $(TEMP_DIR)/hdf5 \
-	&& ldconfig
+	&& (command -v ldconfig >/dev/null 2>&1 && ldconfig || true)
 
 .PHONY: yq/install
 ## install yq

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -9,7 +9,7 @@ This document describes how to set up the development environment and how to dev
 #### OS
 
 - When using Docker related environment, you can use any OS that supports Docker.
-- When using native environment, `Linux` is required.
+- When using native environment, `Linux` or `macOS` (Darwin; `arm64`/Apple Silicon and `amd64`) are supported.
 
 #### Architecture
 
@@ -19,6 +19,40 @@ But you can also build and test `Vald` on `arm64` with the same way as described
 ### Devcontainer
 
 This is the easiest way to start developing `Vald`. You can just open our [devcontainer.json](https://github.com/vdaas/vald/blob/main/.devcontainer/devcontainer.json) with `VS Code` and go.
+
+### macOS (Darwin) native build
+
+Vald can be built and tested natively on macOS (Apple Silicon and Intel). It uses
+**Apple clang** (from the Xcode Command Line Tools) as the C/C++ compiler,
+[Homebrew](https://brew.sh) for the remaining native dependencies, and Apple's
+`Accelerate.framework` for BLAS/LAPACK. The C/C++ libraries (NGT, Faiss, HDF5,
+zlib) are built from source into `/usr/local` by the Makefile (`make ngt/install`,
+`make faiss/install`, `make hdf5/install`), which requires `sudo`.
+
+```bash
+# 1. Xcode Command Line Tools — REQUIRED: provides the Apple clang compiler
+#    and the macOS SDK. This is the compiler the build uses.
+xcode-select --install
+clang --version    # verify: should print "Apple clang version ..."
+
+# 2. Homebrew dependencies
+brew install go protobuf buf cmake hdf5 zlib libomp
+
+# 3. Build and install the C/C++ libraries into /usr/local (requires sudo)
+sudo make ngt/install hdf5/install faiss/install
+
+# 4. Run the unit tests
+make test
+```
+
+> **Compiler:** the build uses Apple clang from step 1 — `brew install llvm` is
+> **not** required. (Homebrew `llvm` is only needed if you explicitly want LLVM's
+> `clang`/`llvm-ar`; in that case `brew install llvm` and add
+> `/opt/homebrew/opt/llvm/bin` to your `PATH` first.) On Darwin the Makefile
+> resolves OpenMP and HDF5/ZLIB headers through Homebrew
+> (`brew --prefix libomp|hdf5|zlib`), uses Apple thin-LTO (`-flto=thin`), and
+> `Accelerate.framework` for BLAS/LAPACK — so `OpenBLAS`/`lapack`/`gcc` (gfortran)
+> are **not** required. On Linux the original GNU toolchain flags are unchanged.
 
 ### Other
 

--- a/internal/core/algorithm/faiss/Capi.cpp
+++ b/internal/core/algorithm/faiss/Capi.cpp
@@ -347,7 +347,7 @@ int faiss_add_ivfpq(
   try {
     //printf("is_trained: %d\n", (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->is_trained);
     //printf("ntotal: %ld\n", (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->ntotal);
-    (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->add_with_ids(nb, xb, xids);
+    (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->add_with_ids(nb, xb, reinterpret_cast<const faiss::idx_t*>(xids));
     //printf("is_trained: %d\n", (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->is_trained);
     //printf("ntotal: %ld\n", (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->ntotal);
   } catch(std::exception &err) {
@@ -371,7 +371,7 @@ int faiss_add_binaryivf(
   //fflush(stdout);
 
   try {
-    (static_cast<faiss::IndexBinaryIVF*>(st->faiss_index))->add_with_ids(nb, xb, xids);
+    (static_cast<faiss::IndexBinaryIVF*>(st->faiss_index))->add_with_ids(nb, xb, reinterpret_cast<const faiss::idx_t*>(xids));
   } catch(std::exception &err) {
     std::stringstream ss;
     ss << "Capi : " << __FUNCTION__ << "() : Error: " << err.what();
@@ -425,7 +425,7 @@ bool faiss_search_ivfpq(
     //printf("is_trained: %d\n", (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->is_trained);
     //printf("ntotal: %ld\n", (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->ntotal);
     (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->nprobe = nprobe;
-    (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->search(nq, xq, k, D, I);
+    (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->search(nq, xq, k, D, reinterpret_cast<faiss::idx_t*>(I));
     //printf("I=\n");
     //for(int i = 0; i < nq; i++) {
     //    for(int j = 0; j < k; j++) {
@@ -465,7 +465,7 @@ bool faiss_search_binaryivf(
   int32_t* tmpD = new int32_t[nq*k];
   try {
     (static_cast<faiss::IndexBinaryIVF*>(st->faiss_index))->nprobe = nprobe;
-    (static_cast<faiss::IndexBinaryIVF*>(st->faiss_index))->search(nq, xq, k, tmpD, I);
+    (static_cast<faiss::IndexBinaryIVF*>(st->faiss_index))->search(nq, xq, k, tmpD, reinterpret_cast<faiss::idx_t*>(I));
   } catch(std::exception &err) {
     delete[] tmpD;
     std::stringstream ss;
@@ -514,7 +514,7 @@ int faiss_remove_ivfpq(
   try {
     //printf("is_trained: %d\n", (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->is_trained);
     //printf("ntotal: %ld\n", (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->ntotal);
-    faiss::IDSelectorArray sel(size, ids);
+    faiss::IDSelectorArray sel(size, reinterpret_cast<const faiss::idx_t*>(ids));
     (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->remove_ids(sel);
     //printf("is_trained: %d\n", (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->is_trained);
     //printf("ntotal: %ld\n", (static_cast<faiss::IndexIVFPQ*>(st->faiss_index))->ntotal);
@@ -537,7 +537,7 @@ int faiss_remove_binaryivf(
   //fflush(stdout);
 
   try {
-    faiss::IDSelectorArray sel(size, ids);
+    faiss::IDSelectorArray sel(size, reinterpret_cast<const faiss::idx_t*>(ids));
     (static_cast<faiss::IndexBinaryIVF*>(st->faiss_index))->remove_ids(sel);
   } catch(std::exception &err) {
     std::stringstream ss;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Enables building and testing Vald **natively on macOS (Darwin, arm64/Apple Silicon and amd64)**, without Docker/devcontainer. Today `make ngt/install`, `make faiss/install`, and `make test` all fail at configure/compile time on macOS because the build recipes assume a GNU/Linux toolchain. This makes the flags OS-aware (Linux is byte-for-byte unchanged) and fixes one cross-platform source bug. See #3570 for the full design.

**What changed (5 files, +98/−17):**

1. **NGT** (`Makefile`, `ngt/install`): `-flto=auto -ffat-lto-objects` → `NATIVE_LTO_FLAGS` (`-flto=thin` on Darwin; `-ffat-lto-objects` is an unsupported LLVM target feature for Mach-O). OpenMP resolved via `brew --prefix libomp` (`-DOpenMP_ROOT`) so `find_package(OpenMP)` succeeds for Apple clang. `-DCMAKE_INSTALL_RPATH=@loader_path/../lib` so `bin/ngt` resolves `libngt.2.dylib` without `ldconfig`. `ldconfig` guarded (absent on Darwin).
2. **Faiss** (`Makefile`, `faiss/install`): dropped the GNU `LDFLAGS`-as-`CFLAGS` and the `-fopenmp -lopenblas -llapack -lgfortran` linker flags on Darwin; cmake now finds OpenMP (`OpenMP_ROOT`) and BLAS/LAPACK (Apple **Accelerate.framework**) natively. `BLA_VENDOR=OpenBLAS` kept on Linux, unset on Darwin.
3. **HDF5** (`Makefile`, `Makefile.d/tools.mk`): skip the static example binaries on Darwin (`-DHDF5_BUILD_EXAMPLES=OFF`) — `-static` linking fails (no `crt0.o` on macOS). `ldconfig` guarded.
4. **Go cgo + `make test`** (`Makefile`): `TEST_LDFLAGS_BASE` (the GNU `-z relro -z now -flto=auto -ffat-lto-objects -std=gnu++23 -march=native…` block, passed as `CGO_LDFLAGS`) is fatal on Mach-O — made OS-aware (Darwin: `-lc++`, drop ELF flags, `-Wl,-rpath` so cgo test binaries resolve the shared `libngt.2.dylib`, `-lomp -framework Accelerate`). `CGO_CFLAGS`/`CGO_CXXFLAGS` now exported with the libomp include (test targets only set `CGO_LDFLAGS` inline).
5. **`internal/core/algorithm/faiss/Capi.cpp`** (source portability bug): `faiss::idx_t` is `int64_t` = `long` on Linux but `long long` on Darwin. The C wrapper passed `long*` (matching Go's `*C.long`), which type-mismatches on Darwin. Cast to `faiss::idx_t*` at the 6 faiss call sites (`add_with_ids`, `search`, `IDSelectorArray`) — safe `reinterpret_cast` (both 64-bit, identical layout on LP64).

Helper vars generalized and shared: `OPENMP_PREFIX`, `OPENMP_CFLAGS`, `NATIVE_LTO_FLAGS`. macOS setup is documented in `docs/contributing/development.md`.

### Related Issue

#3570 (extends #2694 / `VALD-359`).

### Versions

- Vald Version: v1.7.17
- Go Version: v1.26.5 (darwin/arm64)
- Rust Version: n/a (this PR does not touch the Rust data plane)
- Docker Version: n/a
- Kubernetes Version: n/a
- Helm Version: n/a
- NGT Version: v2.7.2
- Faiss Version: v1.14.1

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

- Verified end-to-end on Apple M4 (darwin27/arm64): `make ngt/install`, `make faiss/install`, `make hdf5/install` all green; `libngt.a`/`libfaiss.a` link against libomp + Accelerate and return correct ANN search results (functional C/C++ tests); `go build ./...` compiles the entire codebase; NGT + faiss cgo unit tests run green; **246/254** unit-test packages pass via `make test`.
- **The build uses Apple clang from Xcode Command Line Tools** — `brew install llvm` is NOT required (verified by building with brew `llvm` removed from PATH).
- **Linux/container is unchanged** — every GNU flag is preserved verbatim on `GOOS=linux`; the Dockerfile's `NGT_EXTRA_CMAKE_FLAGS` override still applies.
- The remaining 8 non-passing test packages are not macOS *build* issues: 3 are environment-dependent (need Cassandra / `make dockerfile` codegen / ruleguard — fail on Linux too); `internal/file/watch` is a fsnotify kqueue/goleak behavior; and 3 NGT-agent property tests surface a pre-existing, platform-independent vqueue correctness bug filed separately as #3571 (timestamp collision in `newer()`).
- Commits are atomic per layer: `build(ngt)`, `build(faiss)`, `build(cgo,test)`, `docs(development)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for native macOS builds across NGT, FAISS, OpenMP, and HDF5 components.
  * Improved platform-specific build configuration and installation behavior on macOS.

* **Bug Fixes**
  * Improved compatibility and reliability when adding, searching, and removing FAISS-indexed records.

* **Documentation**
  * Added macOS setup instructions, prerequisites, supported architectures, compiler guidance, and example installation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->