### PR TITLE
fix: skip NGT AVX2 on arm64

### DIFF
--- a/Makefile.d/tools.mk
+++ b/Makefile.d/tools.mk
@@ -413,7 +413,7 @@ ngt/install: $(USR_LOCAL)/include/NGT/Capi.h
 $(USR_LOCAL)/include/NGT/Capi.h: | ninja/install $(if $(findstring clang,$(notdir $(CC))),$(LIB_PATH)/libomp.a)
 	$(call cmake-install,https://github.com/NGT-labs/NGT.git,ngt, \
 		-DNGT_LARGE_DATASET=ON \
-		-DNGT_AVX2=ON \
+		$(if $(filter amd64,$(GOARCH)),-DNGT_AVX2=ON) \
 		-DBUILD_STATIC_EXECS=OFF \
 		-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
 		-DCMAKE_AR=$$(command -v llvm-ar 2>/dev/null || ls /usr/bin/llvm-ar-* 2>/dev/null | sort -V | tail -1 | grep . || command -v gcc-ar 2>/dev/null || ls /usr/bin/gcc-ar-* 2>/dev/null | sort -V | tail -1 | grep . || command -v ar) \

--- a/Makefile.d/tools.mk
+++ b/Makefile.d/tools.mk
@@ -413,7 +413,7 @@ ngt/install: $(USR_LOCAL)/include/NGT/Capi.h
 $(USR_LOCAL)/include/NGT/Capi.h: | ninja/install $(if $(findstring clang,$(notdir $(CC))),$(LIB_PATH)/libomp.a)
 	$(call cmake-install,https://github.com/NGT-labs/NGT.git,ngt, \
 		-DNGT_LARGE_DATASET=ON \
-		$(if $(filter amd64,$(GOARCH)),-DNGT_AVX2=ON) \
+		$(if $(filter arm64,$(subst aarch64,arm64,$(ARCH))),,-DNGT_AVX2=ON) \
 		-DBUILD_STATIC_EXECS=OFF \
 		-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
 		-DCMAKE_AR=$$(command -v llvm-ar 2>/dev/null || ls /usr/bin/llvm-ar-* 2>/dev/null | sort -V | tail -1 | grep . || command -v gcc-ar 2>/dev/null || ls /usr/bin/gcc-ar-* 2>/dev/null | sort -V | tail -1 | grep . || command -v ar) \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->
<!-- It would be better to describe the details, especially What changed and Why you changed -->

SSIA

### Related Issue

<!-- This project mainly accepts pull requests related to open issues -->
<!-- NOTE: If suggesting a new feature or change, please discuss it in an issue first -->
<!-- NOTE: If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

### Versions

<!--- Please change the versions below along with your environment -->

- Vald Version: v1.7.17
- Go Version: v1.26.5
- Rust Version: v1.97.1
- Docker Version: v29.6.2
- Kubernetes Version: v1.36.3
- Helm Version: v4.2.3
- NGT Version: v2.7.4
- Faiss Version: v1.14.3

### Checklist

<!-- For completed items, change [ ] to [x]. -->
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

- [x] I have read the [CONTRIBUTING](https://github.com/vdaas/vald/blob/main/CONTRIBUTING.md) document and completed [our CLA agreement](https://cla-assistant.io/vdaas/vald).
- [x] I have checked open [Pull Requests](https://github.com/vdaas/vald/pulls) for the similar feature or fixes?

### Special notes for your reviewer

<!-- Please tell us anything you would like to share with reviewers related to this PR. Your thoughts and feedback are highly valued -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build compatibility on `aarch64` systems by preventing unsupported AVX2 features from being enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->